### PR TITLE
Signed headers list in canonical header must be in lower case. Was ca…

### DIFF
--- a/src/main/java/io/minio/RequestSigner.java
+++ b/src/main/java/io/minio/RequestSigner.java
@@ -271,7 +271,7 @@ class RequestSigner implements Interceptor {
         } else {
           printSeparator = true;
         }
-        builder.append(header);
+        builder.append(header.toLowerCase().trim());
       }
     }
     return builder.toString();


### PR DESCRIPTION
…using auth failure with s3.