### PR TITLE
fix: use XML pull parser for every instance of XmlEntity

### DIFF
--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -1163,7 +1163,15 @@ public final class MinioClient {
 
             if (this.prefixIterator.hasNext()) {
               Prefix prefix = this.prefixIterator.next();
-              return new Result<Item>(new Item(prefix.prefix(), true), null);
+              Item item;
+              try {
+                item = new Item(prefix.prefix(), true);
+              } catch (XmlPullParserException e) {
+                // special case: ignore the error as we can't propagate the exception in next()
+                item = null;
+              }
+
+              return new Result<Item>(item, null);
             }
 
             this.completed = true;

--- a/src/main/java/io/minio/messages/AccessControlList.java
+++ b/src/main/java/io/minio/messages/AccessControlList.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.List;
 
@@ -28,7 +29,7 @@ public class AccessControlList extends XmlEntity {
 
 
   @SuppressWarnings("unused")
-  public AccessControlList() {
+  public AccessControlList() throws XmlPullParserException {
     super();
     super.name = "AccessControlList";
   }

--- a/src/main/java/io/minio/messages/AccessControlPolicy.java
+++ b/src/main/java/io/minio/messages/AccessControlPolicy.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -30,7 +31,7 @@ public class AccessControlPolicy extends XmlEntity {
   private AccessControlList accessControlList;
 
 
-  public AccessControlPolicy() {
+  public AccessControlPolicy() throws XmlPullParserException {
     super();
     this.name = "AccessControlPolicy";
   }

--- a/src/main/java/io/minio/messages/Bucket.java
+++ b/src/main/java/io/minio/messages/Bucket.java
@@ -18,6 +18,7 @@ package io.minio.messages;
 
 import java.util.Date;
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 import io.minio.DateFormat;
 
 
@@ -29,7 +30,7 @@ public class Bucket extends XmlEntity {
   private String creationDate;
 
 
-  public Bucket() {
+  public Bucket() throws XmlPullParserException {
     super();
     super.name = "Bucket";
   }

--- a/src/main/java/io/minio/messages/Buckets.java
+++ b/src/main/java/io/minio/messages/Buckets.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -28,7 +29,7 @@ public class Buckets extends XmlEntity {
   private List<Bucket> bucketList = new LinkedList<Bucket>();
 
 
-  public Buckets() {
+  public Buckets() throws XmlPullParserException {
     super();
     super.name = "Buckets";
   }

--- a/src/main/java/io/minio/messages/CompleteMultipartUpload.java
+++ b/src/main/java/io/minio/messages/CompleteMultipartUpload.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.List;
 import java.util.Arrays;
@@ -28,7 +29,7 @@ public class CompleteMultipartUpload extends XmlEntity {
   private List<Part> partList;
 
 
-  public CompleteMultipartUpload() {
+  public CompleteMultipartUpload() throws XmlPullParserException {
     this(null);
   }
 
@@ -36,7 +37,7 @@ public class CompleteMultipartUpload extends XmlEntity {
   /**
    * constructor to init partList.
    */
-  public CompleteMultipartUpload(Part[] parts) {
+  public CompleteMultipartUpload(Part[] parts) throws XmlPullParserException {
     super();
     super.name = "CompleteMultipartUpload";
 

--- a/src/main/java/io/minio/messages/CreateBucketConfiguration.java
+++ b/src/main/java/io/minio/messages/CreateBucketConfiguration.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 
 public class CreateBucketConfiguration extends XmlEntity {
@@ -27,7 +28,7 @@ public class CreateBucketConfiguration extends XmlEntity {
   /**
    * constructor.
    */
-  public CreateBucketConfiguration(String locationConstraint) {
+  public CreateBucketConfiguration(String locationConstraint) throws XmlPullParserException {
     super();
     super.name = "CreateBucketConfiguration";
 

--- a/src/main/java/io/minio/messages/ErrorResponse.java
+++ b/src/main/java/io/minio/messages/ErrorResponse.java
@@ -46,7 +46,7 @@ public class ErrorResponse extends XmlEntity {
   private ErrorCode errorCode;
 
 
-  public ErrorResponse() {
+  public ErrorResponse() throws XmlPullParserException {
     super();
     super.name = "ErrorResponse";
   }
@@ -65,7 +65,7 @@ public class ErrorResponse extends XmlEntity {
    * constructor.
    */
   public ErrorResponse(ErrorCode errorCode, String bucketName, String objectName, String resource, String requestId,
-                       String hostId) {
+                       String hostId) throws XmlPullParserException {
     this();
     this.errorCode  = errorCode;
     this.code       = errorCode.code();

--- a/src/main/java/io/minio/messages/Grant.java
+++ b/src/main/java/io/minio/messages/Grant.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 
 @SuppressWarnings({"SameParameterValue", "unused"})
@@ -27,7 +28,7 @@ public class Grant extends XmlEntity {
   private String permission;
 
 
-  public Grant() {
+  public Grant() throws XmlPullParserException {
     super();
     this.name = "Grant";
   }

--- a/src/main/java/io/minio/messages/Grantee.java
+++ b/src/main/java/io/minio/messages/Grantee.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 @SuppressWarnings({"SameParameterValue", "unused"})
 public class Grantee extends XmlEntity {
@@ -32,7 +33,7 @@ public class Grantee extends XmlEntity {
   private String uri;
 
 
-  public Grantee() {
+  public Grantee() throws XmlPullParserException {
     super();
     this.name = "Grantee";
   }

--- a/src/main/java/io/minio/messages/InitiateMultipartUploadResult.java
+++ b/src/main/java/io/minio/messages/InitiateMultipartUploadResult.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 
 @SuppressWarnings({"SameParameterValue", "unused"})
@@ -29,7 +30,7 @@ public class InitiateMultipartUploadResult extends XmlEntity {
   private String uploadId;
 
 
-  public InitiateMultipartUploadResult() {
+  public InitiateMultipartUploadResult() throws XmlPullParserException {
     super();
     this.name = "InitiateMultipartUploadResult";
   }

--- a/src/main/java/io/minio/messages/Initiator.java
+++ b/src/main/java/io/minio/messages/Initiator.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 
 @SuppressWarnings("unused")
@@ -27,7 +28,7 @@ public class Initiator extends XmlEntity {
   private String displayName;
 
 
-  public Initiator() {
+  public Initiator() throws XmlPullParserException {
     super();
     this.name = "Initiator";
   }

--- a/src/main/java/io/minio/messages/Item.java
+++ b/src/main/java/io/minio/messages/Item.java
@@ -18,6 +18,7 @@ package io.minio.messages;
 
 import java.util.Date;
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 import io.minio.DateFormat;
 
 
@@ -38,7 +39,7 @@ public class Item extends XmlEntity {
   private boolean isDir = false;
 
 
-  public Item() {
+  public Item() throws XmlPullParserException {
     this(null, false);
   }
 
@@ -46,7 +47,7 @@ public class Item extends XmlEntity {
   /**
    * constructor to set object name and isDir flag.
    */
-  public Item(String objectName, boolean isDir) {
+  public Item(String objectName, boolean isDir) throws XmlPullParserException {
     super();
     this.name = "Item";
 

--- a/src/main/java/io/minio/messages/ListAllMyBucketsResult.java
+++ b/src/main/java/io/minio/messages/ListAllMyBucketsResult.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -29,7 +30,7 @@ public class ListAllMyBucketsResult extends XmlEntity {
   private Buckets buckets;
 
 
-  public ListAllMyBucketsResult() {
+  public ListAllMyBucketsResult() throws XmlPullParserException {
     super();
     this.name = "ListAllMyBucketsResult";
   }

--- a/src/main/java/io/minio/messages/ListBucketResult.java
+++ b/src/main/java/io/minio/messages/ListBucketResult.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -44,7 +45,8 @@ public class ListBucketResult extends XmlEntity {
   private List<Prefix> commonPrefixes;
 
 
-  public ListBucketResult() {
+  public ListBucketResult() throws XmlPullParserException {
+    super();
     super.name = "ListBucketResult";
   }
 

--- a/src/main/java/io/minio/messages/ListMultipartUploadsResult.java
+++ b/src/main/java/io/minio/messages/ListMultipartUploadsResult.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +43,7 @@ public class ListMultipartUploadsResult extends XmlEntity {
   private boolean isTruncated;
 
 
-  public ListMultipartUploadsResult() {
+  public ListMultipartUploadsResult() throws XmlPullParserException {
     super();
     super.name = "ListMultipartUploadsResult";
   }

--- a/src/main/java/io/minio/messages/ListPartsResult.java
+++ b/src/main/java/io/minio/messages/ListPartsResult.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -46,7 +47,7 @@ public class ListPartsResult extends XmlEntity {
   private List<Part> partList;
 
 
-  public ListPartsResult() {
+  public ListPartsResult() throws XmlPullParserException {
     super();
     this.name = "ListPartsResult";
   }

--- a/src/main/java/io/minio/messages/Owner.java
+++ b/src/main/java/io/minio/messages/Owner.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 
 @SuppressWarnings("SameParameterValue")
@@ -27,7 +28,7 @@ public class Owner extends XmlEntity {
   private String displayName;
 
 
-  public Owner() {
+  public Owner() throws XmlPullParserException {
     super();
     this.name = "Owner";
   }

--- a/src/main/java/io/minio/messages/Part.java
+++ b/src/main/java/io/minio/messages/Part.java
@@ -18,6 +18,7 @@ package io.minio.messages;
 
 import java.util.Date;
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 import io.minio.DateFormat;
 
 
@@ -33,7 +34,7 @@ public class Part extends XmlEntity {
   private Long size;
 
 
-  public Part() {
+  public Part() throws XmlPullParserException {
     this(0, null);
   }
 
@@ -41,7 +42,7 @@ public class Part extends XmlEntity {
   /**
    * constructor.
    */
-  public Part(int partNumber, String etag) {
+  public Part(int partNumber, String etag) throws XmlPullParserException {
     super();
     super.name = "Part";
 

--- a/src/main/java/io/minio/messages/Prefix.java
+++ b/src/main/java/io/minio/messages/Prefix.java
@@ -17,6 +17,7 @@
 package io.minio.messages;
 
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 
 
 @SuppressWarnings({"WeakerAccess", "unused"})
@@ -25,7 +26,8 @@ public class Prefix extends XmlEntity {
   private String prefix;
 
 
-  public Prefix() {
+  public Prefix() throws XmlPullParserException {
+    super();
     super.name = "Prefix";
   }
 

--- a/src/main/java/io/minio/messages/Upload.java
+++ b/src/main/java/io/minio/messages/Upload.java
@@ -18,6 +18,7 @@ package io.minio.messages;
 
 import java.util.Date;
 import com.google.api.client.util.Key;
+import org.xmlpull.v1.XmlPullParserException;
 import io.minio.DateFormat;
 
 @SuppressWarnings("unused")
@@ -37,7 +38,7 @@ public class Upload extends XmlEntity {
   private long aggregatedPartSize;
 
 
-  public Upload() {
+  public Upload() throws XmlPullParserException {
     super();
     super.name = "Upload";
   }

--- a/src/main/java/io/minio/messages/XmlEntity.java
+++ b/src/main/java/io/minio/messages/XmlEntity.java
@@ -27,26 +27,20 @@ import java.io.IOException;
 
 
 public abstract class XmlEntity extends GenericXml {
-  private static final XmlPullParser XML_PULL_PARSER;
-
-  static {
-    try {
-      XML_PULL_PARSER = Xml.createParser();
-    } catch (XmlPullParserException e) {
-      throw new ExceptionInInitializerError(e);
-    }
-  }
-
-  private XmlNamespaceDictionary defaultNamespaceDictionary = new XmlNamespaceDictionary();
+  private XmlPullParser xmlPullParser;
+  private XmlNamespaceDictionary defaultNamespaceDictionary;
 
 
   /**
    * constructor.
    */
-  public XmlEntity() {
+  public XmlEntity() throws XmlPullParserException {
     super.namespaceDictionary = new XmlNamespaceDictionary();
     super.namespaceDictionary.set("s3", "http://s3.amazonaws.com/doc/2006-03-01");
     super.namespaceDictionary.set("", "");
+
+    this.xmlPullParser = Xml.createParser();
+    this.defaultNamespaceDictionary = new XmlNamespaceDictionary();
   }
 
 
@@ -57,14 +51,14 @@ public abstract class XmlEntity extends GenericXml {
 
 
   public void parseXml(Reader reader) throws IOException, XmlPullParserException {
-    XML_PULL_PARSER.setInput(reader);
-    Xml.parseElement(XML_PULL_PARSER, this, this.defaultNamespaceDictionary, null);
+    this.xmlPullParser.setInput(reader);
+    Xml.parseElement(this.xmlPullParser, this, this.defaultNamespaceDictionary, null);
   }
 
 
   protected void parseXml(Reader reader, XmlNamespaceDictionary namespaceDictionary)
     throws IOException, XmlPullParserException {
-    XML_PULL_PARSER.setInput(reader);
-    Xml.parseElement(XML_PULL_PARSER, this, namespaceDictionary, null);
+    this.xmlPullParser.setInput(reader);
+    Xml.parseElement(this.xmlPullParser, this, namespaceDictionary, null);
   }
 }


### PR DESCRIPTION
Previously there single XML pull parser which is used by XmlEntity and
their children classes.  This causes parsing error when doing threaded
execution.  This patch fixes this.

Closes #339