### PR TITLE
createRequest: Create request now handles buckets with '.'.

### DIFF
--- a/src/main/java/io/minio/AwsS3Endpoints.java
+++ b/src/main/java/io/minio/AwsS3Endpoints.java
@@ -1,0 +1,58 @@
+/*
+ * Minio Java Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+
+public enum AwsS3Endpoints {
+  INSTANCE;
+  private final Map<String, String> endpoints = new Hashtable<String, String>();
+
+  AwsS3Endpoints() {
+    // ap-northeast-1
+    endpoints.put("ap-northeast-1", "s3-ap-northeast-1.amazonaws.com");
+    // ap-southeast-1
+    endpoints.put("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com");
+    // ap-southeast-2
+    endpoints.put("ap-southeast-2", "s3-ap-southeast-2.amazonaws.com");
+    // eu-central-1
+    endpoints.put("eu-central-1", "s3-eu-central-1.amazonaws.com");
+    // eu-west-1
+    endpoints.put("eu-west-1", "s3-eu-west-1.amazonaws.com");
+    // sa-east-1
+    endpoints.put("sa-east-1", "s3-sa-east-1.amazonaws.com");
+    // us-west-1
+    endpoints.put("us-west-1", "s3-us-west-1.amazonaws.com");
+    // us-west-2
+    endpoints.put("us-west-2", "s3-us-west-2.amazonaws.com");
+    // us-east-1
+    endpoints.put("us-east-1", "s3.amazonaws.com");
+  }
+
+  /**
+   * get Amazon S3 endpoint for the relevant region.
+   */
+  public String endpoint(String region) {
+    String s = AwsS3Endpoints.INSTANCE.endpoints.get(region);
+    if (s == null) {
+      s = "s3.amazonaws.com";
+    }
+    return s;
+  }
+}

--- a/src/main/java/io/minio/BucketRegionCache.java
+++ b/src/main/java/io/minio/BucketRegionCache.java
@@ -20,7 +20,7 @@ import java.util.Hashtable;
 import java.util.Map;
 
 
-public enum Regions {
+public enum BucketRegionCache {
   INSTANCE;
   private final Map<String, String> regionMap = new Hashtable<String, String>();
 

--- a/src/main/java/io/minio/PostPolicy.java
+++ b/src/main/java/io/minio/PostPolicy.java
@@ -180,7 +180,7 @@ public class PostPolicy {
     formData.put("x-amz-algorithm", ALGORITHM);
 
     DateTime date = new DateTime();
-    String region = Regions.INSTANCE.region(this.bucketName);
+    String region = BucketRegionCache.INSTANCE.region(this.bucketName);
     String credential = Signer.credential(accessKey, date, region);
     conditions.add(new String[]{"eq", "$x-amz-credential", credential});
     formData.put("x-amz-credential", credential);

--- a/test/FunctionalTest.java
+++ b/test/FunctionalTest.java
@@ -21,7 +21,6 @@ import java.io.*;
 import java.lang.*;
 import static java.nio.file.StandardOpenOption.*;
 import java.nio.file.*;
-import java.io.*;
 
 import org.xmlpull.v1.XmlPullParserException;
 import org.joda.time.DateTime;
@@ -120,6 +119,14 @@ public class FunctionalTest {
     client.removeBucket(name);
   }
 
+  // Test: makeBucket(String bucketName, String region) where bucketName has
+  // periods in its name.
+  public static void makeBucket_test5() throws Exception {
+    println("Test: makeBucket(String bucketName, String region)");
+    String name = getRandomName() + ".withperiod";
+    client.makeBucket(name, "eu-central-1");
+    client.removeBucket(name);
+  }
 
   // Test: listBuckets()
   public static void listBuckets_test() throws Exception {
@@ -676,10 +683,14 @@ public class FunctionalTest {
     try {
       client = new MinioClient(endpoint, accessKey, secretKey);
 
+      // Enable trace for debugging.
+      // client.traceOn(System.out);
+
       makeBucket_test1();
-      // makeBucket_test2(); - throws exception due to Amazon S3 region issue
+      makeBucket_test2();
       makeBucket_test3();
-      // makeBucket_test4(); - throws exception due to Amazon S3 region issue
+      makeBucket_test4();
+      makeBucket_test5();
 
       listBuckets_test();
 


### PR DESCRIPTION
- accessing bucket names right after they were created. In current style
  if we try to access the buckets we would get 'Access Denied'.
  This can be solved by sending the requests directly to the endpoint
  where the bucket was created. For this we have to automatically use
  the relevant endpoint based on bucket location, similar to how it is
  achieved in 'aws-sdks'.

- bucket names with '.' cannot be used with virtual host style for
  HTTPS requests due to SSL certificate issue, so in this case we fallback
  to using path style instead for such requests, similar to how it is achieved
  in 'aws-sdks'.