### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/io/minio/DateFormat.java
+++ b/src/main/java/io/minio/DateFormat.java
@@ -33,4 +33,6 @@ public class DateFormat {
 
   public static final DateTimeFormatter HTTP_HEADER_DATE_FORMAT =
       DateTimeFormat.forPattern("EEE',' dd MMM yyyy HH':'mm':'ss zzz").withZoneUTC();
+
+  private DateFormat() {}
 }

--- a/src/main/java/io/minio/Digest.java
+++ b/src/main/java/io/minio/Digest.java
@@ -228,4 +228,6 @@ public class Digest {
 
     return hashes;
   }
+
+  private Digest() {}
 }

--- a/src/main/java/io/minio/http/HeaderParser.java
+++ b/src/main/java/io/minio/http/HeaderParser.java
@@ -72,4 +72,6 @@ public class HeaderParser {
       }
     }
   }
+
+  private HeaderParser() {}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava