### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/io/minio/AwsS3Endpoints.java
+++ b/src/main/java/io/minio/AwsS3Endpoints.java
@@ -16,13 +16,13 @@
 
 package io.minio;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 
 
 public enum AwsS3Endpoints {
   INSTANCE;
-  private final Map<String, String> endpoints = new Hashtable<>();
+  private final Map<String, String> endpoints = new HashMap<>();
 
   AwsS3Endpoints() {
     // ap-northeast-1

--- a/src/main/java/io/minio/BucketRegionCache.java
+++ b/src/main/java/io/minio/BucketRegionCache.java
@@ -16,14 +16,13 @@
 
 package io.minio;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 
 
 public enum BucketRegionCache {
   INSTANCE;
-  private final Map<String, String> regionMap = new Hashtable<>();
-
+  private final Map<String, String> regionMap = new HashMap<>();
 
   /**
    * returns AWS region for given bucket name.

--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -825,7 +825,7 @@ public final class MinioClient {
       throw new InvalidArgumentException("length should be greater than zero");
     }
 
-    Map<String,String> headerMap = new Hashtable<>();
+    Map<String,String> headerMap = new HashMap<>();
     if (length != null) {
       headerMap.put("Range", "bytes=" + offset + "-" + (offset + length - 1));
     } else {
@@ -1939,7 +1939,7 @@ public final class MinioClient {
     throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
            InternalException {
-    Map<String,String> headerMap = new Hashtable<>();
+    Map<String,String> headerMap = new HashMap<>();
     if (contentType != null) {
       headerMap.put("Content-Type", contentType);
     } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava