### PR TITLE
Multiple code improvements - squid:S106, squid:S134

### DIFF
--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -596,9 +596,7 @@ public final class MinioClient {
       while (xpp.getEventType() != xpp.END_DOCUMENT) {
         if (xpp.getEventType() ==  xpp.START_TAG && xpp.getName() == "LocationConstraint") {
           xpp.next();
-          if (xpp.getEventType() == xpp.TEXT) {
-            location = xpp.getText();
-          }
+          location = getText(xpp, location);
           break;
         }
         xpp.next();
@@ -622,6 +620,13 @@ public final class MinioClient {
       // Add the new location.
       BucketRegionCache.INSTANCE.add(bucketName, region);
     }
+  }
+
+  private String getText(XmlPullParser xpp, String location) throws XmlPullParserException {
+    if (xpp.getEventType() == xpp.TEXT) {
+      location = xpp.getText();
+    }
+    return location;
   }
 
 
@@ -1692,10 +1697,7 @@ public final class MinioClient {
           totalParts[partNumber - 1] = new Part(part.partNumber(), part.etag());
           skipStream(data, expectedReadSize);
 
-          part = null;
-          if (existingParts.hasNext()) {
-            part = existingParts.next().get();
-          }
+          part = getPart(existingParts);
 
           continue;
         }
@@ -1706,6 +1708,15 @@ public final class MinioClient {
     }
 
     completeMultipart(bucketName, objectName, uploadId, totalParts);
+  }
+
+  private Part getPart(Iterator<Result<Part>> existingParts) throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException, InternalException {
+    Part part;
+    part = null;
+    if (existingParts.hasNext()) {
+      part = existingParts.next().get();
+    }
+    return part;
   }
 
 

--- a/src/main/java/io/minio/MinioProperties.java
+++ b/src/main/java/io/minio/MinioProperties.java
@@ -34,21 +34,8 @@ enum MinioProperties {
         if (version.get() == null) {
           try {
             ClassLoader classLoader = getClass().getClassLoader();
-            if (classLoader != null) {
-              Enumeration<URL> resources = classLoader.getResources("META-INF/MANIFEST.MF");
-              while (resources.hasMoreElements()) {
-                Manifest manifest = new Manifest(resources.nextElement().openStream());
-                for (Object k : manifest.getMainAttributes().keySet()) {
-                  String versionString = "Minio-Client-Java-Version";
-                  if (k.toString().equals(versionString)) {
-                    version.set(manifest.getMainAttributes().getValue((Attributes.Name) k));
-                  }
-                }
-              }
-            }
-            if (version.get() == null) {
-              version.set("dev");
-            }
+            setMinioClientJavaVersion(classLoader);
+            setDevelopmentVersion();
           } catch (IOException e) {
             version.set("unknown");
           }
@@ -57,5 +44,26 @@ enum MinioProperties {
       }
     }
     return result;
+  }
+
+  private void setDevelopmentVersion() {
+    if (version.get() == null) {
+      version.set("dev");
+    }
+  }
+
+  private void setMinioClientJavaVersion(ClassLoader classLoader) throws IOException {
+    if (classLoader != null) {
+      Enumeration<URL> resources = classLoader.getResources("META-INF/MANIFEST.MF");
+      while (resources.hasMoreElements()) {
+        Manifest manifest = new Manifest(resources.nextElement().openStream());
+        for (Object k : manifest.getMainAttributes().keySet()) {
+          String versionString = "Minio-Client-Java-Version";
+          if (k.toString().equals(versionString)) {
+            version.set(manifest.getMainAttributes().getValue((Attributes.Name) k));
+          }
+        }
+      }
+    }
   }
 }

--- a/src/main/java/io/minio/http/HeaderParser.java
+++ b/src/main/java/io/minio/http/HeaderParser.java
@@ -21,15 +21,20 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.annotation.Annotation;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.squareup.okhttp.Headers;
 
 
 public class HeaderParser {
+  private static final Logger LOGGER = Logger.getLogger(HeaderParser.class.getName());
+
   /**
    * method to set destination from Headers object.
    */
   public static void set(Headers headers, Object destination) {
+
     Field[] publicFields;
     Field[] privateFields;
     Field[] fields;
@@ -64,11 +69,10 @@ public class HeaderParser {
         }
       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException
                | IllegalArgumentException e) {
-        // TODO: log the error than printing to stdout
-        System.out.println("exception occured: " + e);
-        System.out.println("setter: " + setter);
-        System.out.println("annotation: " + value);
-        System.out.println("value: " + headers.get(value));
+        LOGGER.log(Level.SEVERE, "exception occured: ", e);
+        LOGGER.log(Level.INFO, "setter: " + setter);
+        LOGGER.log(Level.INFO, "annotation: " + value);
+        LOGGER.log(Level.INFO, "value: " + headers.get(value));
       }
     }
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S106 - Standard outputs should not be used directly to log anything.
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S106
https://dev.eclipse.org/sonar/rules/show/squid:S134
Please let me know if you have any questions.
George Kankava