### PR TITLE
messages: add default namespace

### DIFF
--- a/src/main/java/io/minio/messages/CompleteMultipartUpload.java
+++ b/src/main/java/io/minio/messages/CompleteMultipartUpload.java
@@ -43,6 +43,7 @@ public class CompleteMultipartUpload extends XmlEntity {
   public CompleteMultipartUpload(Part[] parts) throws XmlPullParserException {
     super();
     super.name = "CompleteMultipartUpload";
+    super.namespaceDictionary.set("", "http://s3.amazonaws.com/doc/2006-03-01");
 
     if (parts == null) {
       this.partList = null;

--- a/src/main/java/io/minio/messages/CreateBucketConfiguration.java
+++ b/src/main/java/io/minio/messages/CreateBucketConfiguration.java
@@ -34,6 +34,7 @@ public class CreateBucketConfiguration extends XmlEntity {
   public CreateBucketConfiguration(String locationConstraint) throws XmlPullParserException {
     super();
     super.name = "CreateBucketConfiguration";
+    super.namespaceDictionary.set("", "http://s3.amazonaws.com/doc/2006-03-01");
 
     this.locationConstraint = locationConstraint;
   }


### PR DESCRIPTION
Previously default namespace was set to empty string causes minio
server returning MalformedXML.  This patch fixes the issue by adding
default namespace to create bucket and complete multipart upload
message.

Fixes #371