### PR TITLE
fix: handle null content in list bucket result.

### DIFF
--- a/src/main/java/io/minio/messages/ListBucketResult.java
+++ b/src/main/java/io/minio/messages/ListBucketResult.java
@@ -114,6 +114,9 @@ public class ListBucketResult extends XmlEntity {
    * Returns List of Items.
    */
   public List<Item> contents() {
+    if (contents == null) {
+      return new LinkedList<>();
+    }
     return contents;
   }
 

--- a/test/FunctionalTest.java
+++ b/test/FunctionalTest.java
@@ -337,6 +337,21 @@ public class FunctionalTest {
   }
 
 
+  // Test: listObjects(final string bucketName)
+  public static void listObject_test4() throws Exception {
+    int i;
+    println("Test: empty bucket: listObjects(final String bucketName)");
+
+    i = 0;
+    for (Result r : client.listObjects(bucketName, "minio", true)) {
+      println(i++, r.get());
+      if (i == 10) {
+        break;
+      }
+    }
+  }
+
+
   // Test: removeObject(String bucketName, String objectName)
   public static void removeObject_test() throws Exception {
     println("Test: removeObject(String bucketName, String objectName)");
@@ -673,6 +688,7 @@ public class FunctionalTest {
       listObject_test1();
       listObject_test2();
       listObject_test3();
+      listObject_test4();
 
       removeObject_test();
 


### PR DESCRIPTION
When a bucket is empty, content field in ListBucketResult is
null. This patch handles null and returns empty LinkedList.

Fixes #364