### PR TITLE
fix: temp file existence checking is wrong getObject method

### DIFF
--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -1180,7 +1180,7 @@ public final class MinioClient {
 
     String tempFileName = fileName + "." + etag + ".part.minio";
     Path tempFilePath = Paths.get(tempFileName);
-    boolean tempFileExists = Files.exists(filePath);
+    boolean tempFileExists = Files.exists(tempFilePath);
 
     if (tempFileExists && !Files.isRegularFile(tempFilePath)) {
       throw new IOException(tempFileName + ": not a regular file");


### PR DESCRIPTION
Previously in getObject method, temp file existence check is wrongly
with actual file name. This causes exception when the destination file
exists.
This patch fixes the issue.