### PR TITLE
fix: use content length as is for InputStream/RandomAccessFile/byte a…

### DIFF
--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -581,6 +581,10 @@ public final class MinioClient {
 
         @Override
         public long contentLength() {
+          if (body instanceof InputStream || body instanceof RandomAccessFile || body instanceof byte[]) {
+            return length;
+          }
+
           if (length == 0) {
             return -1;
           } else {


### PR DESCRIPTION
…rray.