### PR TITLE
Multiple code improvements - squid:RedundantThrowsDeclarationCheck, squid:S1226, squid:S1213, squid:S1488, squid:S1125, squid:S1126

### DIFF
--- a/src/main/java/io/minio/BucketRegionCache.java
+++ b/src/main/java/io/minio/BucketRegionCache.java
@@ -66,10 +66,6 @@ enum BucketRegionCache {
    * Returns true if given bucket name is in the map else false.
    */
   public boolean exists(String bucketName) {
-    if (this.regionMap.get(bucketName) == null) {
-      return false;
-    } else {
-      return true;
-    }
+    return this.regionMap.get(bucketName) != null;
   }
 }

--- a/src/main/java/io/minio/Digest.java
+++ b/src/main/java/io/minio/Digest.java
@@ -33,6 +33,12 @@ import io.minio.errors.InsufficientDataException;
  */
 class Digest {
   /**
+   * Private constructor
+   */
+  private Digest() {}
+
+
+  /**
    * Returns SHA-256 hash of given string.
    */
   public static String sha256Hash(String string) throws NoSuchAlgorithmException {
@@ -95,7 +101,7 @@ class Digest {
    * @param len          Length of Input stream.
    */
   public static String md5Hash(Object inputStream, int len)
-    throws IllegalArgumentException, NoSuchAlgorithmException, IOException, InsufficientDataException {
+    throws NoSuchAlgorithmException, IOException, InsufficientDataException {
     RandomAccessFile file = null;
     BufferedInputStream stream = null;
     if (inputStream instanceof RandomAccessFile) {
@@ -139,9 +145,7 @@ class Digest {
    * Returns SHA-256 and MD5 hashes for given byte array and it's length.
    */
   public static String[] sha256md5Hashes(byte[] data, int length) throws NoSuchAlgorithmException {
-    String[] hashes = { sha256Hash(data, length), md5Hash(data, length) };
-
-    return hashes;
+    return new String[] { sha256Hash(data, length), md5Hash(data, length) };
   }
 
 
@@ -152,7 +156,7 @@ class Digest {
    * @param len          Length of Input stream.
    */
   public static String[] sha256md5Hashes(Object inputStream, int len)
-    throws IllegalArgumentException, NoSuchAlgorithmException, IOException, InsufficientDataException {
+    throws NoSuchAlgorithmException, IOException, InsufficientDataException {
     RandomAccessFile file = null;
     BufferedInputStream stream = null;
     if (inputStream instanceof RandomAccessFile) {
@@ -174,10 +178,8 @@ class Digest {
       stream.reset();
     }
 
-    String[] hashes = { BaseEncoding.base16().encode(sha256Digest.digest()).toLowerCase(),
+    return new String[] { BaseEncoding.base16().encode(sha256Digest.digest()).toLowerCase(),
                         BaseEncoding.base64().encode(md5Digest.digest()) };
-
-    return hashes;
   }
 
 
@@ -242,9 +244,4 @@ class Digest {
     } while (totalBytesRead < length);
     return pos;
   }
-
-  /**
-   * Private constructor
-   */
-  private Digest() {}
 }

--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -177,7 +177,7 @@ public final class MinioClient {
    * @see #MinioClient(String endpoint, String accessKey, String secretKey, boolean secure)
    * @see #MinioClient(String endpoint, int port, String accessKey, String secretKey, boolean secure)
    */
-  public MinioClient(URL url) throws NullPointerException, InvalidEndpointException, InvalidPortException {
+  public MinioClient(URL url) throws InvalidEndpointException, InvalidPortException {
     this(url.toString(), 0, null, null);
   }
 
@@ -197,7 +197,7 @@ public final class MinioClient {
    * @see #MinioClient(String endpoint, String accessKey, String secretKey, boolean secure)
    * @see #MinioClient(String endpoint, int port, String accessKey, String secretKey, boolean secure)
    */
-  public MinioClient(HttpUrl url) throws NullPointerException, InvalidEndpointException, InvalidPortException {
+  public MinioClient(HttpUrl url) throws InvalidEndpointException, InvalidPortException {
     this(url.toString(), 0, null, null);
   }
 
@@ -253,7 +253,7 @@ public final class MinioClient {
    * @see #MinioClient(String endpoint, int port, String accessKey, String secretKey, boolean secure)
    */
   public MinioClient(URL url, String accessKey, String secretKey)
-    throws NullPointerException, InvalidEndpointException, InvalidPortException {
+    throws InvalidEndpointException, InvalidPortException {
     this(url.toString(), 0, accessKey, secretKey);
   }
 
@@ -276,7 +276,7 @@ public final class MinioClient {
    * @see #MinioClient(String endpoint, int port, String accessKey, String secretKey, boolean secure)
    */
   public MinioClient(HttpUrl url, String accessKey, String secretKey)
-      throws NullPointerException, InvalidEndpointException, InvalidPortException {
+      throws InvalidEndpointException, InvalidPortException {
     this(url.toString(), 0, accessKey, secretKey);
   }
 
@@ -848,7 +848,7 @@ public final class MinioClient {
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
            InternalException {
     if (bucketName != null && S3_AMAZONAWS_COM.equals(this.baseUrl.host()) && this.accessKey != null
-          && this.secretKey != null && BucketRegionCache.INSTANCE.exists(bucketName) == false) {
+          && this.secretKey != null && !BucketRegionCache.INSTANCE.exists(bucketName)) {
       Map<String,String> queryParamMap = new HashMap<>();
       queryParamMap.put("location", null);
 
@@ -895,7 +895,7 @@ public final class MinioClient {
    */
   private String getText(XmlPullParser xpp, String location) throws XmlPullParserException {
     if (xpp.getEventType() == xpp.TEXT) {
-      location = xpp.getText();
+      return xpp.getText();
     }
     return location;
   }
@@ -2541,7 +2541,7 @@ public final class MinioClient {
    * @param n            Length of bytes to skip.
    */
   private void skipStream(Object inputStream, long n)
-    throws IllegalArgumentException, IOException, InsufficientDataException {
+    throws IOException, InsufficientDataException {
     RandomAccessFile file = null;
     BufferedInputStream stream = null;
     if (inputStream instanceof RandomAccessFile) {
@@ -2591,9 +2591,7 @@ public final class MinioClient {
       lastPartSize = partSize;
     }
 
-    int[] rv = { (int) partSize, (int) partCount, (int) lastPartSize };
-
-    return rv;
+    return new int[] { (int) partSize, (int) partCount, (int) lastPartSize };
   }
 
 
@@ -2604,7 +2602,7 @@ public final class MinioClient {
    *
    * @see #traceOff
    */
-  public void traceOn(OutputStream traceStream) throws NullPointerException {
+  public void traceOn(OutputStream traceStream) {
     if (traceStream == null) {
       throw new NullPointerException();
     } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1125 - Literal boolean values should not be used in condition expressions.
squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement.
This pull request removes 63 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1226
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1125
https://dev.eclipse.org/sonar/rules/show/squid:S1126
Please let me know if you have any questions.
George Kankava