### PR TITLE
Multiple code improvements - squid:S1192, squid:S1166, squid:S1172, squid:S1213, squid:S1155, squid:UselessImportCheck

### DIFF
--- a/src/main/java/io/minio/Digest.java
+++ b/src/main/java/io/minio/Digest.java
@@ -33,7 +33,7 @@ import io.minio.errors.InsufficientDataException;
  */
 class Digest {
   /**
-   * Private constructor
+   * Private constructor.
    */
   private Digest() {}
 
@@ -184,17 +184,7 @@ class Digest {
 
 
   /**
-   * Updated MessageDigest with bytes read from file and stream
-   *
-   * @param len
-   * @param file
-   * @param stream
-   * @param pos
-   * @param sha256Digest
-   * @param md5Digest
-   * @return
-   * @throws IOException
-   * @throws InsufficientDataException
+   * Updated MessageDigest with bytes read from file and stream.
    */
   private static long readBytes(int len,
                                 RandomAccessFile file,
@@ -233,10 +223,10 @@ class Digest {
         continue;
       }
 
-      if(sha256Digest != null) {
+      if (sha256Digest != null) {
         sha256Digest.update(buf, 0, bytesRead);
       }
-      if(md5Digest != null) {
+      if (md5Digest != null) {
         md5Digest.update(buf, 0, bytesRead);
       }
 

--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -1964,13 +1964,12 @@ public final class MinioClient {
    *
    * @param bucketName   Bucket name.
    * @param objectName   Object name in the bucket.
-   * @param contentType  Content type of object data.
    * @param length       Length of object data.
    * @param data         Object data.
    * @param uploadId     Upload ID of multipart put object.
    * @param partNumber   Part number of multipart put object.
    */
-  private String putObject(String bucketName, String objectName, String contentType, int length, Object data,
+  private String putObject(String bucketName, String objectName, int length, Object data,
                            String uploadId, int partNumber)
     throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
@@ -2004,7 +2003,7 @@ public final class MinioClient {
            InvalidArgumentException, InsufficientDataException {
     if (size <= MIN_MULTIPART_SIZE) {
       // single put object
-      putObject(bucketName, objectName, contentType, (int) size, data, null, 0);
+      putObject(bucketName, objectName, (int) size, data, null, 0);
       return;
     }
 
@@ -2051,7 +2050,7 @@ public final class MinioClient {
         }
       }
 
-      String etag = putObject(bucketName, objectName, contentType, expectedReadSize, data, uploadId, partNumber);
+      String etag = putObject(bucketName, objectName, expectedReadSize, data, uploadId, partNumber);
       totalParts[partNumber - 1] = new Part(partNumber, etag);
     }
 

--- a/src/main/java/io/minio/MinioProperties.java
+++ b/src/main/java/io/minio/MinioProperties.java
@@ -22,6 +22,8 @@ import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -29,6 +31,9 @@ import java.util.jar.Manifest;
  */
 enum MinioProperties {
   INSTANCE;
+
+  private static final Logger LOGGER = Logger.getLogger(MinioProperties.class.getName());
+
   private final AtomicReference<String> version = new AtomicReference<>(null);
 
   public String getVersion() {
@@ -41,6 +46,7 @@ enum MinioProperties {
             setMinioClientJavaVersion(classLoader);
             setDevelopmentVersion();
           } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "IOException occured", e);
             version.set("unknown");
           }
           result = version.get();

--- a/src/main/java/io/minio/PostPolicy.java
+++ b/src/main/java/io/minio/PostPolicy.java
@@ -134,7 +134,7 @@ public class PostPolicy {
       sb.append("\"expiration\":" + "\"" + expirationDate.toString(DateFormat.EXPIRATION_DATE_FORMAT) + "\"");
     }
 
-    if (conditions.size() > 0) {
+    if (!conditions.isEmpty()) {
       sb.append(",\"conditions\":[");
 
       ListIterator<String[]> iterator = conditions.listIterator();

--- a/src/main/java/io/minio/http/HeaderParser.java
+++ b/src/main/java/io/minio/http/HeaderParser.java
@@ -16,7 +16,6 @@
 
 package io.minio.http;
 
-import java.lang.Class;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
@@ -32,6 +31,9 @@ import com.squareup.okhttp.Headers;
  */
 public class HeaderParser {
   private static final Logger LOGGER = Logger.getLogger(HeaderParser.class.getName());
+
+  /* private constructor */
+  private HeaderParser() {}
 
   /**
    * Sets destination object from Headers object.
@@ -79,6 +81,4 @@ public class HeaderParser {
       }
     }
   }
-
-  private HeaderParser() {}
 }

--- a/src/test/java/io/minio/MinioClientTest.java
+++ b/src/test/java/io/minio/MinioClientTest.java
@@ -22,7 +22,6 @@ import com.squareup.okhttp.mockwebserver.MockResponse;
 
 import okio.Buffer;
 
-import io.minio.ErrorCode;
 import io.minio.errors.*;
 import io.minio.messages.Bucket;
 import io.minio.messages.ErrorResponse;
@@ -64,6 +63,7 @@ public class MinioClientTest {
   private static final String SUN_29_JUN_2015_22_01_10_GMT = "Sun, 29 Jun 2015 22:01:10 GMT";
   private static final String MON_04_MAY_2015_07_58_51_UTC = "Mon, 04 May 2015 07:58:51 UTC";
   private static final String BUCKET_KEY = "/bucket/key";
+  private static final String MD5_HASH_STRING = "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"";
 
   @Test()
   public void setUserAgentOnceSet() throws IOException, MinioException {
@@ -186,7 +186,7 @@ public class MinioClientTest {
     response.addHeader("Date", "Sun, 05 Jun 2015 22:01:10 GMT");
     response.addHeader(CONTENT_LENGTH, "5080");
     response.addHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.setResponseCode(200);
     response.setBody(new Buffer().writeUtf8(expectedObject));
@@ -212,7 +212,7 @@ public class MinioClientTest {
 
     response.addHeader(CONTENT_LENGTH, "5");
     response.addHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader(ACCEPT_RANGES, BYTES);
     response.addHeader(CONTENT_RANGE, "0-4/11");
@@ -239,7 +239,7 @@ public class MinioClientTest {
     MockResponse response = new MockResponse();
     response.addHeader(CONTENT_LENGTH, "5");
     response.addHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader(ACCEPT_RANGES, BYTES);
     response.addHeader(CONTENT_RANGE, "0-4/11");
@@ -264,7 +264,7 @@ public class MinioClientTest {
 
     response.addHeader(CONTENT_LENGTH, "5");
     response.addHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader(ACCEPT_RANGES, BYTES);
     response.addHeader(CONTENT_RANGE, "0-4/11");
@@ -291,7 +291,7 @@ public class MinioClientTest {
 
     response.addHeader(CONTENT_LENGTH, "6");
     response.addHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader(ACCEPT_RANGES, BYTES);
     response.addHeader(CONTENT_RANGE, "5-10/11");
@@ -473,7 +473,7 @@ public class MinioClientTest {
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
     server.enqueue(response);
@@ -571,7 +571,7 @@ public class MinioClientTest {
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
     server.enqueue(response);
@@ -597,7 +597,7 @@ public class MinioClientTest {
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
     response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
-    response.addHeader("ETag", "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"");
+    response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
     server.enqueue(response);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1166 - Exception handlers should preserve the original exception.
squid:S1172 - Unused method parameters should be removed.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:UselessImportCheck - Useless imports should be removed.
This pull request removes 42 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1166
https://dev.eclipse.org/sonar/rules/show/squid:S1172
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck
Please let me know if you have any questions.
George Kankava