### PR TITLE
fix: date parsing throws IllegalArgumentException.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,16 @@ task javadocJar (type: Jar, dependsOn: javadoc) {
   from javadoc.destinationDir
 }
 
+task localeTest (type: Test) {
+  description = "Runs tests with locale"
+  System.setProperty('user.language', 'de')
+  System.setProperty('user.country', 'DE')
+  systemProperties = System.properties
+  dependsOn test
+}
+
+check.dependsOn localeTest
+
 javadoc.options {
   encoding = 'UTF-8'
   links 'https://docs.oracle.com/javase/8/docs/api/'

--- a/src/main/java/io/minio/DateFormat.java
+++ b/src/main/java/io/minio/DateFormat.java
@@ -16,6 +16,8 @@
 
 package io.minio;
 
+import java.util.Locale;
+
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -25,17 +27,18 @@ import org.joda.time.format.DateTimeFormatter;
  */
 public class DateFormat {
   public static final DateTimeFormatter AMZ_DATE_FORMAT =
-      DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss'Z'").withZoneUTC();
+      DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss'Z'").withZoneUTC().withLocale(Locale.US);
 
   public static final DateTimeFormatter EXPIRATION_DATE_FORMAT =
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH':'mm':'ss'.'SSS'Z'").withZoneUTC();
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH':'mm':'ss'.'SSS'Z'").withZoneUTC().withLocale(Locale.US);
 
   public static final DateTimeFormatter RESPONSE_DATE_FORMAT = EXPIRATION_DATE_FORMAT;
 
-  public static final DateTimeFormatter SIGNER_DATE_FORMAT = DateTimeFormat.forPattern("yyyyMMdd").withZoneUTC();
+  public static final DateTimeFormatter SIGNER_DATE_FORMAT =
+      DateTimeFormat.forPattern("yyyyMMdd").withZoneUTC().withLocale(Locale.US);
 
   public static final DateTimeFormatter HTTP_HEADER_DATE_FORMAT =
-      DateTimeFormat.forPattern("EEE',' dd MMM yyyy HH':'mm':'ss zzz").withZoneUTC();
+      DateTimeFormat.forPattern("EEE',' dd MMM yyyy HH':'mm':'ss zzz").withZoneUTC().withLocale(Locale.US);
 
   private DateFormat() {}
 }


### PR DESCRIPTION
When minio-java is used in system running with different locale than
"US", date parsing fails with IllegalArgumentException.  This patch
fixes the issue by setting the locale to "US" for all date formats.

Thanks to @RBoelter for reporting/debugging/providing the solution.

Fixes #411