### PR TITLE
fix: add encoded query string for presigning.

### DIFF
--- a/src/main/java/io/minio/MinioClient.java
+++ b/src/main/java/io/minio/MinioClient.java
@@ -16,8 +16,6 @@
 
 package io.minio;
 
-import com.google.common.net.UrlEscapers;
-import com.google.common.escape.Escaper;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import com.squareup.okhttp.HttpUrl;
@@ -128,7 +126,6 @@ import java.util.logging.Logger;
  */
 @SuppressWarnings({"SameParameterValue", "WeakerAccess"})
 public final class MinioClient {
-  private static final Escaper QUERY_ESCAPER = UrlEscapers.urlPathSegmentEscaper();
   private static final Logger LOGGER = Logger.getLogger(MinioClient.class.getName());
   // maximum allowed object size is 5TiB
   private static final long MAX_OBJECT_SIZE = 5L * 1024 * 1024 * 1024 * 1024;
@@ -594,29 +591,6 @@ public final class MinioClient {
   }
 
   /**
-   * Returns encoded query string for URL.
-   */
-  private static String encodeQueryString(String str) {
-    return QUERY_ESCAPER.escape(str)
-      .replaceAll("\\!", "%21")
-      .replaceAll("\\$", "%24")
-      .replaceAll("\\&", "%26")
-      .replaceAll("\\'", "%27")
-      .replaceAll("\\(", "%28")
-      .replaceAll("\\)", "%29")
-      .replaceAll("\\*", "%2A")
-      .replaceAll("\\+", "%2B")
-      .replaceAll("\\,", "%2C")
-      .replaceAll("\\\\", "%2F")
-      .replaceAll("\\:", "%3A")
-      .replaceAll("\\;", "%3B")
-      .replaceAll("\\=", "%3D")
-      .replaceAll("\\@", "%40")
-      .replaceAll("\\[", "%5B")
-      .replaceAll("\\]", "%5D");
-  }
-
-  /**
    * Creates Request object for given request parameters.
    *
    * @param method         HTTP method.
@@ -684,8 +658,8 @@ public final class MinioClient {
 
     if (queryParamMap != null) {
       for (Map.Entry<String,String> entry : queryParamMap.entrySet()) {
-        urlBuilder.addEncodedQueryParameter(encodeQueryString(entry.getKey()),
-                                            encodeQueryString(entry.getValue()));
+        urlBuilder.addEncodedQueryParameter(Signer.encodeQueryString(entry.getKey()),
+                                            Signer.encodeQueryString(entry.getValue()));
       }
     }
 

--- a/test/FunctionalTest.java
+++ b/test/FunctionalTest.java
@@ -480,7 +480,15 @@ public class FunctionalTest {
         response.body().close();
         os.close();
       } else {
-        println("FAILED");
+        String errorXml = "";
+
+        // read entire body stream to string.
+        Scanner scanner = new java.util.Scanner(response.body().charStream()).useDelimiter("\\A");
+        if (scanner.hasNext()) {
+          errorXml = scanner.next();
+        }
+
+        println("FAILED", response, errorXml);
       }
     } else {
       println("NO RESPONSE");
@@ -518,7 +526,15 @@ public class FunctionalTest {
         response.body().close();
         os.close();
       } else {
-        println("FAILED");
+        String errorXml = "";
+
+        // read entire body stream to string.
+        Scanner scanner = new java.util.Scanner(response.body().charStream()).useDelimiter("\\A");
+        if (scanner.hasNext()) {
+          errorXml = scanner.next();
+        }
+
+        println("FAILED", response, errorXml);
       }
     } else {
       println("NO RESPONSE");
@@ -551,7 +567,15 @@ public class FunctionalTest {
 
     if (response != null) {
       if (!response.isSuccessful()) {
-        println("FAILED");
+        String errorXml = "";
+
+        // read entire body stream to string.
+        Scanner scanner = new java.util.Scanner(response.body().charStream()).useDelimiter("\\A");
+        if (scanner.hasNext()) {
+          errorXml = scanner.next();
+        }
+
+        println("FAILED", response, errorXml);
       }
     } else {
       println("NO RESPONSE");
@@ -578,7 +602,15 @@ public class FunctionalTest {
 
     if (response != null) {
       if (!response.isSuccessful()) {
-        println("FAILED");
+        String errorXml = "";
+
+        // read entire body stream to string.
+        Scanner scanner = new java.util.Scanner(response.body().charStream()).useDelimiter("\\A");
+        if (scanner.hasNext()) {
+          errorXml = scanner.next();
+        }
+
+        println("FAILED", response, errorXml);
       }
     } else {
       println("NO RESPONSE");
@@ -611,7 +643,15 @@ public class FunctionalTest {
 
     if (response != null) {
       if (!response.isSuccessful()) {
-        println("FAILED");
+        String errorXml = "";
+
+        // read entire body stream to string.
+        Scanner scanner = new java.util.Scanner(response.body().charStream()).useDelimiter("\\A");
+        if (scanner.hasNext()) {
+          errorXml = scanner.next();
+        }
+
+        println("FAILED", response, errorXml);
       }
     } else {
       println("NO RESPONSE");


### PR DESCRIPTION
This patch fixes presignv4() by using encodeQueryString().

Fixes #456