### PR TITLE
build: use endpoint, access/secret keys from command line.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
     apply plugin: 'findbugs'
 
     group = 'io.minio'
-    version = '2.0.5'
+    version = '3.0'
     if (!project.hasProperty('release')) {
         version += '-DEV'
     }
@@ -253,7 +253,23 @@ project(':functional') {
     task runFunctionalTest(type:JavaExec) {
         main = 'FunctionalTest'
         classpath = sourceSets.main.runtimeClasspath
-        args = ["https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"]
+
+        ext.endPoint = 'https://play.minio.io:9000'
+        if (rootProject.hasProperty('endPoint')) {
+            ext.endPoint = rootProject.properties['endPoint']
+        }
+
+        ext.accessKey = 'Q3AM3UQ867SPQQA43P2F'
+        if (project.properties.containsKey('accessKey')) {
+            ext.accessKey = rootProject.properties['accessKey']
+        }
+
+        ext.secretKey = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'
+        if (project.properties.containsKey('secretKey')) {
+            ext.secretKey = rootProject.properties['secretKey']
+        }
+
+        args = [ext.endPoint, ext.accessKey, ext.secretKey]
     }
 
 }


### PR DESCRIPTION
runFunctionalTest task uses play.minio.io and its credentials by
default.  This patch adds support to override this by passing
endpoint, access key and secret key in command line.

Below is an example.

```bash
./gradlew -PendPoint=http://192.168.1.107:9000 \
          -PaccessKey=minio \
          -PsecretKey=minio123 \
	  runFunctionalTest
```