### PR TITLE
fix: split and add path as segments to HttpUrl.Builder

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -646,7 +646,9 @@ public final class MinioClient {
 
     if (objectName != null) {
       // Limitation: OkHttp does not allow to add '.' and '..' as path segment.
-      urlBuilder.addEncodedPathSegment(S3Escaper.encodePath(objectName));
+      for (String pathSegment : objectName.split("/")) {
+        urlBuilder.addEncodedPathSegment(S3Escaper.encode(pathSegment));
+      }
     }
 
     if (queryParamMap != null) {

--- a/api/src/main/java/io/minio/S3Escaper.java
+++ b/api/src/main/java/io/minio/S3Escaper.java
@@ -49,25 +49,4 @@ class S3Escaper {
       .replaceAll("\\[", "%5B")
       .replaceAll("\\]", "%5D");
   }
-
-
-  /**
-   * Returns S3 encoded path.
-   */
-  public static String encodePath(String path) {
-    StringBuffer encodedPath = new StringBuffer();
-
-    // Limitation: Its not allowed to add path segment as '/', '//', '/usr' or 'usr/'.
-    if (path != null) {
-      for (String pathSegment : path.split("/")) {
-        if (encodedPath.length() > 0) {
-          encodedPath.append("/");
-        }
-
-        encodedPath.append(encode(pathSegment));
-      }
-    }
-
-    return encodedPath.toString();
-  }
 }

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -279,6 +279,22 @@ public class FunctionalTest {
   }
 
   /**
+   * Test: getObject(String bucketName, String objectName, String fileName).
+   * where objectName has multiple path segments.
+   */
+  public static void getObject_test5() throws Exception {
+    System.out.println("Test: objectName with multiple path segments: "
+                       + "getObject(String bucketName, String objectName, String fileName)");
+    String fileName = createFile(3 * MB);
+    String objectName = "path/to/" + fileName;
+    client.putObject(bucketName, objectName, fileName);
+    Files.delete(Paths.get(fileName));
+    client.getObject(bucketName, objectName, fileName + ".downloaded");
+    Files.delete(Paths.get(fileName + ".downloaded"));
+    client.removeObject(bucketName, objectName);
+  }
+
+  /**
    * Test: listObjects(final String bucketName).
    */
   public static void listObject_test1() throws Exception {
@@ -849,6 +865,7 @@ public class FunctionalTest {
       getObject_test2();
       getObject_test3();
       getObject_test4();
+      getObject_test5();
 
       listObject_test1();
       listObject_test2();


### PR DESCRIPTION
okhttp.HttpUrl.Builder.addEncodedPathSegment() does encoding '/' even
for encoded path.  This patch fixes this by splitting path by '/' and
encodes each segment and add them individually.

Fixes #504