### PR TITLE
api: Set correct (un)modified condition header

### DIFF
--- a/api/src/main/java/io/minio/DateFormat.java
+++ b/api/src/main/java/io/minio/DateFormat.java
@@ -38,7 +38,7 @@ public class DateFormat {
       DateTimeFormat.forPattern("yyyyMMdd").withZoneUTC().withLocale(Locale.US);
 
   public static final DateTimeFormatter HTTP_HEADER_DATE_FORMAT =
-      DateTimeFormat.forPattern("EEE',' dd MMM yyyy HH':'mm':'ss zzz").withZoneUTC().withLocale(Locale.US);
+      DateTimeFormat.forPattern("EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'").withZoneUTC().withLocale(Locale.US);
 
   private DateFormat() {}
 }

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1055,11 +1055,13 @@ public class FunctionalTest {
       client.copyObject(bucketName, filename, destBucketName, copyConditions);
     } catch (ErrorResponseException e) {
       // File should not be copied as object was modified after date set in copyConditions.
-      ignore();
+      if (!e.errorResponse().code().equals("PreconditionFailed")) {
+        throw e;
+      }
     }
 
     client.removeObject(bucketName, filename);
-    client.removeObject(destBucketName, filename);
+    // Destination bucket is expected to be empty, otherwise it will trigger an exception.
     client.removeBucket(destBucketName);
   }
 


### PR DESCRIPTION
This PR sets the correct date time format for headers
x-amz-copy-if-modified-since and x-amz-copy-source-if-unmodified-since.
In consequence, modified/unmodified copy preconditions will just work.

Fixes #546 