### PR TITLE
tests: Do not expect 'UTC' in Last-Modified header

### DIFF
--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -72,7 +72,6 @@ public class MinioClientTest {
   private static final String ACCEPT_RANGES = "Accept-Ranges";
   private static final String CONTENT_RANGE = "Content-Range";
   private static final String SUN_29_JUN_2015_22_01_10_GMT = "Sun, 29 Jun 2015 22:01:10 GMT";
-  private static final String MON_04_MAY_2015_07_58_51_UTC = "Mon, 04 May 2015 07:58:51 UTC";
   private static final String BUCKET_KEY = "/bucket/key";
   private static final String MD5_HASH_STRING = "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"";
   private static final ObjectMapper objectMapper =
@@ -509,7 +508,7 @@ public class MinioClientTest {
     MockResponse response = new MockResponse();
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
-    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
+    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
@@ -607,7 +606,7 @@ public class MinioClientTest {
     MockResponse response = new MockResponse();
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
-    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
+    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
@@ -633,7 +632,7 @@ public class MinioClientTest {
     MockResponse response = new MockResponse();
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
-    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
+    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
@@ -655,7 +654,7 @@ public class MinioClientTest {
     MockResponse response = new MockResponse();
 
     response.addHeader("Date", SUN_29_JUN_2015_22_01_10_GMT);
-    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
+    response.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response.addHeader("ETag", MD5_HASH_STRING);
     response.setResponseCode(200);
 
@@ -686,7 +685,7 @@ public class MinioClientTest {
     response2.addHeader(CONTENT_LENGTH, "5080");
     response2.addHeader(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
     response2.addHeader("ETag", "\"a670520d9d36833b3e28d1e4b73cbe22\"");
-    response2.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_UTC);
+    response2.addHeader(LAST_MODIFIED, MON_04_MAY_2015_07_58_51_GMT);
     response2.setResponseCode(200);
     server.enqueue(response2);
 


### PR DESCRIPTION
According to HTTP RFC (https://tools.ietf.org/html/rfc7232#page-7),
Last-Modified header should always contain 'GMT' word since it is
a http-date, 'UTC' is not supported though it has the same meaning
of GMT.