### PR TITLE
api: add list object version 2 support and set to default

### DIFF
--- a/api/src/main/java/io/minio/messages/ListBucketResultV1.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResultV1.java
@@ -25,22 +25,18 @@ import com.google.api.client.util.Key;
 
 
 /**
- * Helper class to parse Amazon AWS S3 response XML containing ListBucketResult Version 2 information.
+ * Helper class to parse Amazon AWS S3 response XML containing ListBucketResult Version 1 information.
  */
 @SuppressWarnings({"SameParameterValue", "unused"})
-public class ListBucketResult extends XmlEntity {
+public class ListBucketResultV1 extends XmlEntity {
   @Key("Name")
   private String name;
   @Key("Prefix")
   private String prefix;
-  @Key("ContinuationToken")
-  private String continuationToken;
-  @Key("NextContinuationToken")
-  private String nextContinuationToken;
-  @Key("StartAfter")
-  private String startAfter;
-  @Key("KeyCount")
-  private String keyCount;
+  @Key("Marker")
+  private String marker;
+  @Key("NextMarker")
+  private String nextMarker;
   @Key("MaxKeys")
   private int maxKeys;
   @Key("Delimiter")
@@ -53,9 +49,17 @@ public class ListBucketResult extends XmlEntity {
   private List<Prefix> commonPrefixes;
 
 
-  public ListBucketResult() throws XmlPullParserException {
+  public ListBucketResultV1() throws XmlPullParserException {
     super();
     super.name = "ListBucketResult";
+  }
+
+
+  /**
+   * Returns next marker.
+   */
+  public String nextMarker() {
+    return nextMarker;
   }
 
 
@@ -76,34 +80,10 @@ public class ListBucketResult extends XmlEntity {
 
 
   /**
-   * Returns continuation token.
+   * Returns marker.
    */
-  public String continuationToken() {
-    return continuationToken;
-  }
-
-
-  /**
-   * Returns next continuation token.
-   */
-  public String nextContinuationToken() {
-    return nextContinuationToken;
-  }
-
-
-  /**
-   * Returns start after.
-   */
-  public String startAfter() {
-    return startAfter;
-  }
-
-
-  /**
-   * Returns key count.
-   */
-  public String keyCount() {
-    return keyCount;
+  public String marker() {
+    return marker;
   }
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -354,9 +354,9 @@ try {
 ```
 
 <a name="listObjects"></a>
-### listObjects(String bucketName, String prefix, boolean recursive)
+### listObjects(String bucketName, String prefix, boolean recursive, boolean useVersion1)
 
-`public Iterable<Result<Item>> listObjects(String bucketName, String prefix, boolean recursive)`
+`public Iterable<Result<Item>> listObjects(String bucketName, String prefix, boolean recursive, boolean useVersion1)`
 
 Lists all objects in a bucket.
 
@@ -371,6 +371,7 @@ __Parameters__
 | ``bucketName``  | _String_  | Name of the bucket.  |
 | ``prefix``  | _String_  | Prefix string. List objects whose name starts with ``prefix``. |
 | ``recursive``  | _boolean_  | when false, emulates a directory structure where each listing returned is either a full object or part of the object's key up to the first '/'. All objects with the same prefix up to the first '/' will be merged into one entry. |
+| ``useVersion1``  | _boolean_  | when true, version 1 of REST API is used. |
 
 
 |Return Type	  | Exceptions	  |

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -424,6 +424,34 @@ public class FunctionalTest {
   }
 
   /**
+   * Test: listObjects(bucketName, final String prefix, final boolean recursive, final boolean useVersion1).
+   */
+  public static void listObject_test5() throws Exception {
+    int i;
+    System.out.println("Test: listObjects(final String bucketName, final String prefix, final boolean recursive,"
+                       + " final boolean useVersion1)");
+    String[] filenames = new String[3];
+    for (i = 0; i < 3; i++) {
+      String filename = createFile(1 * MB);
+      client.putObject(bucketName, filename, filename);
+      Files.delete(Paths.get(filename));
+      filenames[i] = filename;
+    }
+
+    i = 0;
+    for (Result<?> r : client.listObjects(bucketName, "minio", true, true)) {
+      ignore(i++, r.get());
+      if (i == 10) {
+        break;
+      }
+    }
+
+    for (i = 0; i < 3; i++) {
+      client.removeObject(bucketName, filenames[i]);
+    }
+  }
+
+  /**
    * Test: removeObject(String bucketName, String objectName).
    */
   public static void removeObject_test1() throws Exception {
@@ -1120,6 +1148,7 @@ public class FunctionalTest {
     listObject_test2();
     listObject_test3();
     listObject_test4();
+    listObject_test5();
 
     removeObject_test1();
     removeObject_test2();


### PR DESCRIPTION
Now ListObjects() API uses ReST API List Objects Version 2
(http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html)
as a default.

Added new method
listObjects(String bucketName, String prefix, boolean recursive,
            boolean useVersion1)

which can be used for ReST API List Objects Version 1 by passing true
to useVersion1 flag.

Fixes #413
