### PR TITLE
api: add new API to delete multiple objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The full API Reference is available here.
 * [GetObject.Java](https://github.com/minio/minio-java/tree/master/examples/GetObject.java)
 * [GetPartialObject.java](https://github.com/minio/minio-java/tree/master/examples/GetPartialObject.java)
 * [RemoveObject.java](https://github.com/minio/minio-java/tree/master/examples/RemoveObject.java)
+* [RemoveObjects.java](https://github.com/minio/minio-java/tree/master/examples/RemoveObjects.java)
 * [StatObject.java](https://github.com/minio/minio-java/tree/master/examples/StatObject.java)
 
 #### Full Examples: Presigned Operations

--- a/api/src/main/java/io/minio/messages/DeleteError.java
+++ b/api/src/main/java/io/minio/messages/DeleteError.java
@@ -1,0 +1,46 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.messages;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+
+/**
+ * Helper class to parse Amazon AWS S3 error response XML.
+ */
+@SuppressWarnings("unused")
+public class DeleteError extends ErrorResponse {
+  /**
+   * Constructs a new ErrorResponse object by reading given reader stream.
+   */
+  public DeleteError() throws XmlPullParserException {
+    super();
+    super.name = "Error";
+  }
+
+
+  /**
+   * Constructs a new ErrorResponse object by reading given reader stream.
+   */
+  public DeleteError(Reader reader) throws IOException, XmlPullParserException {
+    this();
+    this.parseXml(reader);
+  }
+}

--- a/api/src/main/java/io/minio/messages/DeleteObject.java
+++ b/api/src/main/java/io/minio/messages/DeleteObject.java
@@ -1,0 +1,51 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.messages;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import com.google.api.client.util.Key;
+
+
+/**
+ * Helper class to create Amazon AWS S3 request XML containing object information for Multiple object deletion.
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "URF_UNREAD_FIELD")
+public class DeleteObject extends XmlEntity {
+  @Key("Key")
+  private String name;
+  @Key("VersionId")
+  private String versionId;
+
+
+  public DeleteObject(String name) throws XmlPullParserException {
+    this(name, null);
+  }
+
+
+  /**
+   * Constructs new delete object for given name and version ID.
+   *
+   */
+  public DeleteObject(String name, String versionId) throws XmlPullParserException {
+    super();
+    super.name = "Object";
+
+    this.name = name;
+    this.versionId = versionId;
+  }
+}

--- a/api/src/main/java/io/minio/messages/DeleteRequest.java
+++ b/api/src/main/java/io/minio/messages/DeleteRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.messages;
+
+import java.util.List;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import com.google.api.client.util.Key;
+
+
+/**
+ * Helper class to create Amazon AWS S3 request XML containing information for Multiple object deletion.
+ */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "URF_UNREAD_FIELD")
+public class DeleteRequest extends XmlEntity {
+  @Key("Quiet")
+  private boolean quiet;
+  @Key("Object")
+  private List<DeleteObject> objectList;
+
+
+  public DeleteRequest(List<DeleteObject> objectList) throws XmlPullParserException {
+    this(objectList, true);
+  }
+
+
+  /**
+   * Constructs new delete request for given object list and quiet flag.
+   */
+  public DeleteRequest(List<DeleteObject> objectList, boolean quiet) throws XmlPullParserException {
+    super();
+    super.name = "Delete";
+    super.namespaceDictionary.set("", "http://s3.amazonaws.com/doc/2006-03-01/");
+
+    this.objectList = objectList;
+    this.quiet = quiet;
+  }
+}

--- a/api/src/main/java/io/minio/messages/DeleteResult.java
+++ b/api/src/main/java/io/minio/messages/DeleteResult.java
@@ -1,0 +1,58 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.messages;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import com.google.api.client.util.Key;
+
+
+/**
+ * Helper class to create Amazon AWS S3 request XML containing information for Multiple object deletion.
+ */
+@SuppressWarnings({"SameParameterValue", "unused"})
+public class DeleteResult extends XmlEntity {
+  @Key("Deleted")
+  private List<DeletedObject> objectList = new LinkedList<>();
+  @Key("Error")
+  private List<DeleteError> errorList = new LinkedList<>();
+
+
+  /**
+   * Constructs new delete result by parsing content on given reader.
+   */
+  public DeleteResult(Reader reader) throws IOException, XmlPullParserException {
+    super();
+    super.name = "DeleteResult";
+    this.parseXml(reader);
+  }
+
+
+  public List<DeletedObject> objectList() {
+    return objectList;
+  }
+
+
+  public List<DeleteError> errorList() {
+    return errorList;
+  }
+}

--- a/api/src/main/java/io/minio/messages/DeletedObject.java
+++ b/api/src/main/java/io/minio/messages/DeletedObject.java
@@ -1,0 +1,48 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.messages;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import com.google.api.client.util.Key;
+
+
+/**
+ * Helper class to create Amazon AWS S3 request XML containing information for Multiple object deletion.
+ */
+@SuppressWarnings({"SameParameterValue", "unused"})
+public class DeletedObject extends XmlEntity {
+  @Key("Key")
+  private String name;
+  @Key("VersionId")
+  private String versionId;
+  @Key("DeleteMarker")
+  private boolean deleteMarker;
+  @Key("DeleteMarkerVersionId")
+  private String deleteMarkerVersionId;
+
+
+  public DeletedObject() throws XmlPullParserException {
+    super();
+    super.name = "Deleted";
+  }
+
+
+  public String name() {
+    return name;
+  }
+}

--- a/api/src/main/java/io/minio/messages/ErrorResponse.java
+++ b/api/src/main/java/io/minio/messages/ErrorResponse.java
@@ -33,21 +33,21 @@ import io.minio.ErrorCode;
 @SuppressWarnings("unused")
 public class ErrorResponse extends XmlEntity {
   @Key("Code")
-  private String code;
+  protected String code;
   @Key("Message")
-  private String message;
+  protected String message;
   @Key("BucketName")
-  private String bucketName;
+  protected String bucketName;
   @Key("Key")
-  private String objectName;
+  protected String objectName;
   @Key("Resource")
-  private String resource;
+  protected String resource;
   @Key("RequestId")
-  private String requestId;
+  protected String requestId;
   @Key("HostId")
-  private String hostId;
+  protected String hostId;
 
-  private ErrorCode errorCode;
+  protected ErrorCode errorCode;
 
 
   public ErrorResponse() throws XmlPullParserException {

--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,11 @@ subprojects {
         compile "com.squareup.okhttp:okhttp:2.7.2"
         compile "com.squareup.okio:okio:1.6.0"
         compile "joda-time:joda-time:2.7"
-	compile "com.fasterxml.jackson.core:jackson-annotations:2.8.4"
-	compile "com.fasterxml.jackson.core:jackson-core:2.8.4"
-	compile "com.fasterxml.jackson.core:jackson-databind:2.8.4"
+        compile "com.fasterxml.jackson.core:jackson-annotations:2.8.4"
+        compile "com.fasterxml.jackson.core:jackson-core:2.8.4"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.8.4"
+        compile 'com.google.code.findbugs:annotations:3.0.1'
+        compile 'com.google.code.findbugs:jsr305:3.0.1'
 
         testCompile "com.squareup.okhttp:mockwebserver:2.7.2"
         testCompile "junit:junit:4.12"

--- a/docs/API.md
+++ b/docs/API.md
@@ -949,6 +949,48 @@ try {
 }
 ```
 
+<a name="removeObject"></a>
+### removeObject(String bucketName, Iterable<String> objectNames)
+
+`public Iterable<Result<DeleteError>> removeObject(String bucketName, Iterable<String> objectNames)`
+
+Removes multiple objects.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#removeObject-java.lang.String-java.lang.String-)
+
+__Parameters__
+
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_  | Name of the bucket.  |
+| ``objectNames`` | _Iterable<String>_  | Iterable object contains object names for removal. |
+
+|Return Type	  | Exceptions	  |
+|:--- |:--- |
+| ``Iterable<Result<DeleteError>>``:an iterator of Result DeleteError.  | _None_  |
+
+
+
+__Example__
+
+
+```java
+List<String> objectNames = new LinkedList<String>();
+objectNames.add("my-objectname1");
+objectNames.add("my-objectname2");
+objectNames.add("my-objectname3");
+try {
+      // Remove object all objects in objectNames list from the bucket my-bucketname.
+      for (Result<DeleteError> errorResult: minioClient.removeObject("my-bucketname", objectNames)) {
+        DeleteError error = errorResult.get();
+        System.out.println("Failed to remove '" + error.objectName() + "'. Error:" + error.message());
+      }
+} catch (MinioException e) {
+      System.out.println("Error: " + e);
+}
+```
+
 <a name="removeIncompleteUpload"></a>
 ### removeIncompleteUpload(String bucketName, String objectName)
 

--- a/examples/RemoveObjects.java
+++ b/examples/RemoveObjects.java
@@ -1,0 +1,59 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import io.minio.MinioClient;
+import io.minio.errors.MinioException;
+import io.minio.Result;
+import io.minio.messages.DeleteError;
+
+public class RemoveObjects {
+  /**
+   * MinioClient.removeObject() example removing multiple objects.
+   */
+  public static void main(String[] args)
+    throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
+    try {
+      /* play.minio.io for test and development. */
+      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+                                                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+
+      /* Amazon S3: */
+      // MinioClient minioClient = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSKEYID",
+      //                                           "YOUR-SECRETACCESSKEY");
+
+      List<String> objectNames = new LinkedList<String>();
+      objectNames.add("my-objectname1");
+      objectNames.add("my-objectname2");
+      objectNames.add("my-objectname3");
+
+      // Remove object all objects 'objectNames' list from 'my-bucketname'.
+      for (Result<DeleteError> errorResult: minioClient.removeObject("my-bucketname", objectNames)) {
+        DeleteError error = errorResult.get();
+        System.out.println("Failed to remove '" + error.objectName() + "'. Error:" + error.message());
+      }
+    } catch (MinioException e) {
+      System.out.println("Error occurred: " + e);
+    }
+  }
+}

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -426,12 +426,32 @@ public class FunctionalTest {
   /**
    * Test: removeObject(String bucketName, String objectName).
    */
-  public static void removeObject_test() throws Exception {
+  public static void removeObject_test1() throws Exception {
     System.out.println("Test: removeObject(String bucketName, String objectName)");
     String filename = createFile(3 * MB);
     client.putObject(bucketName, filename, filename);
     Files.delete(Paths.get(filename));
     client.removeObject(bucketName, filename);
+  }
+
+  /**
+   * Test: removeObject(final String bucketName, final Iterable&lt;String&gt; objectNames).
+   */
+  public static void removeObject_test2() throws Exception {
+    System.out.println("Test: removeObject(final String bucketName, final Iterable<String> objectNames)");
+
+    String[] filenames = new String[4];
+    for (int i = 0; i < 3; i++) {
+      String filename = createFile(1 * MB);
+      client.putObject(bucketName, filename, filename);
+      Files.delete(Paths.get(filename));
+      filenames[i] = filename;
+    }
+    filenames[3] = "nonexistent-object";
+
+    for (Result<?> r : client.removeObject(bucketName, Arrays.asList(filenames))) {
+      ignore(r.get());
+    }
   }
 
   /**
@@ -1101,7 +1121,8 @@ public class FunctionalTest {
     listObject_test3();
     listObject_test4();
 
-    removeObject_test();
+    removeObject_test1();
+    removeObject_test2();
 
     listIncompleteUploads_test1();
     listIncompleteUploads_test2();
@@ -1146,7 +1167,7 @@ public class FunctionalTest {
     statObject_test();
     getObject_test1();
     listObject_test1();
-    removeObject_test();
+    removeObject_test1();
     listIncompleteUploads_test1();
     removeIncompleteUploads_test();
     presignedGetObject_test1();


### PR DESCRIPTION
This patch adds new API

public Iterable<Result<DeleteError>> removeObject(final String bucketName,
    final Iterable<String> objectNames)

which uses "Delete Multiple Objects" ReST API
(http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html).

Fixes #467