### PR TITLE
Read functional test args from env.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,17 +257,17 @@ project(':functional') {
         main = 'FunctionalTest'
         classpath = sourceSets.main.runtimeClasspath
 
-        ext.endPoint = 'https://play.minio.io:9000'
+        ext.endPoint = "$System.env.S3_ENDPOINT"
         if (rootProject.hasProperty('endPoint')) {
             ext.endPoint = rootProject.properties['endPoint']
         }
 
-        ext.accessKey = 'Q3AM3UQ867SPQQA43P2F'
+        ext.accessKey = "$System.env.ACCESS_KEY" 
         if (project.properties.containsKey('accessKey')) {
             ext.accessKey = rootProject.properties['accessKey']
         }
 
-        ext.secretKey = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'
+        ext.secretKey = "$System.env.SECRET_KEY" 
         if (project.properties.containsKey('secretKey')) {
             ext.secretKey = rootProject.properties['secretKey']
         }


### PR DESCRIPTION
- Read the endpoint, access key and secret key from env in build.gradle so that the
  functional test can be easily used for testing.
- It'll be easy to use it in Mint too.