### PR TITLE
Fix isValidEndpoint function to match spec

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -621,7 +621,7 @@ public final class MinioClient {
         return false;
       }
 
-      if (!(label.matches("^[a-zA-Z0-9][a-zA-Z0-9-]*") && endpoint.matches(".*[a-zA-Z0-9]$"))) {
+      if (!(label.matches("^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$"))) {
         return false;
       }
     }
@@ -2132,7 +2132,7 @@ public final class MinioClient {
     return listObjectsV2(bucketName, prefix, recursive);
   }
 
-  
+
   private Iterable<Result<Item>> listObjectsV2(final String bucketName, final String prefix, final boolean recursive) {
     return new Iterable<Result<Item>>() {
       @Override
@@ -3011,7 +3011,7 @@ public final class MinioClient {
            XmlPullParserException, ErrorResponseException, InternalException {
     Map<String,String> queryParamMap = new HashMap<>();
     queryParamMap.put("notification", "");
-  
+
     HttpResponse response = executeGet(bucketName, null, null, queryParamMap);
     NotificationConfiguration result = new NotificationConfiguration();
     try {
@@ -3022,8 +3022,8 @@ public final class MinioClient {
 
     return result;
   }
-  
-  
+
+
   /**
    * Set bucket notification configuration
    *
@@ -3051,8 +3051,8 @@ public final class MinioClient {
     HttpResponse response = executePut(bucketName, null, null, queryParamMap, notificationConfiguration.toString(), 0);
     response.body().close();
   }
-  
-  
+
+
   /**
    * Remove all bucket notification.
    *
@@ -3077,8 +3077,8 @@ public final class MinioClient {
     NotificationConfiguration notificationConfiguration = new NotificationConfiguration();
     setBucketNotification(bucketName, notificationConfiguration);
   }
-  
-  
+
+
   /**
    * Returns next part if exists.
    */

--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -46,6 +46,7 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 import io.minio.errors.ErrorResponseException;
 import io.minio.errors.InvalidArgumentException;
 import io.minio.errors.InvalidExpiresRangeException;
+import io.minio.errors.InvalidEndpointException;
 import io.minio.errors.MinioException;
 import io.minio.errors.RegionConflictException;
 import io.minio.messages.Bucket;
@@ -94,6 +95,30 @@ public class MinioClientTest {
   public void newClientWithNullUrlFails() throws NullPointerException, MinioException {
     URL url = null;
     new MinioClient(url);
+    throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
+  }
+
+  @Test(expected = InvalidEndpointException.class)
+  public void testIsValidEndpoint1() throws MinioException {
+    new MinioClient("minio-.example.com");
+    throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
+  }
+
+  @Test(expected = InvalidEndpointException.class)
+  public void testIsValidEndpoint2() throws MinioException {
+    new MinioClient("-minio.example.com");
+    throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
+  }
+
+  @Test(expected = InvalidEndpointException.class)
+  public void testIsValidEndpoint3() throws MinioException {
+    new MinioClient("minio..example.com");
+    throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
+  }
+
+  @Test(expected = InvalidEndpointException.class)
+  public void testIsValidEndpoint4() throws MinioException {
+    new MinioClient("minio._.com");
     throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
   }
 


### PR DESCRIPTION
Existing code had a bug. For example "minio-.example.com" would be permitted by the existing code, but this is clearly not allowed by the spec.

Spec - https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names