### PR TITLE
Fix: redact signature/creds values on printing

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -921,7 +921,9 @@ public final class MinioClient {
         encodedPath += "?" + encodedQuery;
       }
       this.traceStream.println(request.method() + " " + encodedPath + " HTTP/1.1");
-      String headers = request.headers().toString().replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*");
+      String headers = request.headers().toString()
+          .replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*")
+          .replaceAll("Credential=([^/]+)", "Credential=*REDACTED*");
       this.traceStream.println(headers);
     }
 

--- a/api/src/main/java/io/minio/errors/ErrorResponseException.java
+++ b/api/src/main/java/io/minio/errors/ErrorResponseException.java
@@ -57,7 +57,9 @@ public class ErrorResponseException extends MinioException {
         + "request={"
         + "method=" + request.method() + ", "
         + "url=" + request.httpUrl() + ", "
-        + "headers=" + request.headers()
+        + "headers=" + request.headers().toString()
+                .replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*")
+                .replaceAll("Credential=([^/]+)", "Credential=*REDACTED*")
         + "}\n"
         + "response={"
         + "code=" + response.code() + ", "


### PR DESCRIPTION
Access key and signature were exposed in Exception description
and http tracing. This commit hides them.

Fixes #563 