### PR TITLE
fix: conditionally calculate sha256/md5 hash for request.

### DIFF
--- a/api/src/main/java/io/minio/Digest.java
+++ b/api/src/main/java/io/minio/Digest.java
@@ -67,6 +67,19 @@ class Digest {
 
 
   /**
+   * Returns SHA-256 of given input stream and it's length.
+   *
+   * @param inputStream  Input stream whose type is either {@link RandomAccessFile} or {@link BufferedInputStream}.
+   * @param len          Length of Input stream.
+   */
+  public static String sha256Hash(Object inputStream, int len)
+    throws NoSuchAlgorithmException, IOException, InsufficientDataException {
+    MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
+    updateDigests(inputStream, len, sha256Digest, null);
+    return BaseEncoding.base16().encode(sha256Digest.digest()).toLowerCase();
+  }
+
+  /**
    * Returns MD5 hash of given string.
    */
   public static String md5Hash(String string) throws NoSuchAlgorithmException {
@@ -108,46 +121,6 @@ class Digest {
   }
 
   /**
-   * Returns SHA-256 and MD5 hashes for given string.
-   */
-  public static String[] sha256md5Hashes(String string) throws NoSuchAlgorithmException {
-    return sha256md5Hashes(string.getBytes(StandardCharsets.UTF_8));
-  }
-
-
-  /**
-   * Returns SHA-256 and MD5 hashes for given byte array.
-   */
-  public static String[] sha256md5Hashes(byte[] data) throws NoSuchAlgorithmException {
-    return sha256md5Hashes(data, data.length);
-  }
-
-
-  /**
-   * Returns SHA-256 and MD5 hashes for given byte array and it's length.
-   */
-  public static String[] sha256md5Hashes(byte[] data, int length) throws NoSuchAlgorithmException {
-    return new String[] { sha256Hash(data, length), md5Hash(data, length) };
-  }
-
-
-  /**
-   * Returns SHA-256 and MD5 hashes of given input stream and it's length.
-   *
-   * @param inputStream  Input stream whose type is either {@link RandomAccessFile} or {@link BufferedInputStream}.
-   * @param len          Length of Input stream.
-   */
-  public static String[] sha256md5Hashes(Object inputStream, int len)
-    throws NoSuchAlgorithmException, IOException, InsufficientDataException {
-    MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
-    MessageDigest md5Digest = MessageDigest.getInstance("MD5");
-    updateDigests(inputStream, len, sha256Digest, md5Digest);
-    return new String[] { BaseEncoding.base16().encode(sha256Digest.digest()).toLowerCase(),
-                        BaseEncoding.base64().encode(md5Digest.digest()) };
-  }
-
-
-  /**
    * Updated MessageDigest with bytes read from file and stream.
    */
   private static int updateDigests(Object inputStream, int len, MessageDigest sha256Digest, MessageDigest md5Digest)
@@ -158,8 +131,6 @@ class Digest {
       file = (RandomAccessFile) inputStream;
     } else if (inputStream instanceof BufferedInputStream) {
       stream = (BufferedInputStream) inputStream;
-    } else {
-      throw new IllegalArgumentException("unsupported input stream object");
     }
 
     // hold current position of file/stream to reset back to this position.

--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -20,7 +20,6 @@ package io.minio;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -45,6 +44,7 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 
 import io.minio.errors.ErrorResponseException;
 import io.minio.errors.InvalidArgumentException;
+import io.minio.errors.InsufficientDataException;
 import io.minio.errors.InvalidExpiresRangeException;
 import io.minio.errors.InvalidEndpointException;
 import io.minio.errors.MinioException;
@@ -574,7 +574,7 @@ public class MinioClientTest {
     throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
   }
 
-  @Test(expected = EOFException.class)
+  @Test(expected = InsufficientDataException.class)
   public void testPutIncompleteSmallPut()
       throws NoSuchAlgorithmException, InvalidKeyException, IOException, XmlPullParserException, MinioException {
     MockWebServer server = new MockWebServer();


### PR DESCRIPTION
* For authenticated access
  - For HTTPS (secure) request, SHA-256 hash is set to "UNSIGNED-PAYLOAD" and MD5 hash is calculated.
  - For HTTP (insecure) request, only SHA-256 hash is calculated.
* For anonymous access, for any secure/insecure request, only MD5 hash is calculated.

Fixes #567