### PR TITLE
fix: handle http response code 307 - temporary redirect

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -81,6 +81,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.io.StringReader;
+import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
@@ -172,6 +173,8 @@ public final class MinioClient {
   private static final String END_HTTP = "----------END-HTTP----------";
   private static final String US_EAST_1 = "us-east-1";
   private static final String UPLOAD_ID = "uploadId";
+  // value 21 is default followup count in Firefox, Chrome and OkHttp
+  private static final int TEMP_REDIRECT_TRY_COUNT = 21;
 
   private static XmlPullParserFactory xmlPullParserFactory = null;
 
@@ -981,32 +984,56 @@ public final class MinioClient {
       request = Signer.signV4(request, region, accessKey, secretKey);
     }
 
-    if (this.traceStream != null) {
-      this.traceStream.println("---------START-HTTP---------");
-      String encodedPath = request.url().encodedPath();
-      String encodedQuery = request.url().encodedQuery();
-      if (encodedQuery != null) {
-        encodedPath += "?" + encodedQuery;
-      }
-      this.traceStream.println(request.method() + " " + encodedPath + " HTTP/1.1");
-      String headers = request.headers().toString()
-          .replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*")
-          .replaceAll("Credential=([^/]+)", "Credential=*REDACTED*");
-      this.traceStream.println(headers);
-    }
+    Response response = null;
 
-    Response response = this.httpClient.newCall(request).execute();
-    if (response == null) {
+    // Loop to retry with new location of 307.
+    for (int i = 0; i < TEMP_REDIRECT_TRY_COUNT; i++) {
       if (this.traceStream != null) {
-        this.traceStream.println("<NO RESPONSE>");
-        this.traceStream.println(END_HTTP);
+        this.traceStream.println("---------START-HTTP---------");
+        String encodedPath = request.url().encodedPath();
+        String encodedQuery = request.url().encodedQuery();
+        if (encodedQuery != null) {
+          encodedPath += "?" + encodedQuery;
+        }
+        this.traceStream.println(request.method() + " " + encodedPath + " HTTP/1.1");
+        String headers = request.headers().toString()
+            .replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*")
+            .replaceAll("Credential=([^/]+)", "Credential=*REDACTED*");
+        this.traceStream.println(headers);
       }
-      throw new NoResponseException();
+
+      response = this.httpClient.newCall(request).execute();
+      if (response == null) {
+        if (this.traceStream != null) {
+          this.traceStream.println("<NO RESPONSE>");
+          this.traceStream.println(END_HTTP);
+        }
+        throw new NoResponseException();
+      }
+
+      if (this.traceStream != null) {
+        this.traceStream.println(response.protocol().toString().toUpperCase() + " " + response.code());
+        this.traceStream.println(response.headers());
+      }
+
+      if (response.code() != 307) {
+        break;
+      }
+
+      // Handle 307 (temporary redirect) specially.
+      String location = response.headers().get("Location");
+      if (location == null || location.isEmpty()) {
+        throw new InternalException("unexpected empty value in location header");
+      }
+
+      request = request.newBuilder()
+        .url(location)
+        .build();
     }
 
-    if (this.traceStream != null) {
-      this.traceStream.println(response.protocol().toString().toUpperCase() + " " + response.code());
-      this.traceStream.println(response.headers());
+    // As we have tried maximum rediect, throw an error
+    if (response.code() == 307) {
+      throw new ProtocolException("Too many follow-up requests:" + TEMP_REDIRECT_TRY_COUNT);
     }
 
     ResponseHeader header = new ResponseHeader();


### PR DESCRIPTION
Previously the SDK throws below exception when it gets response code 307.
```
java.io.EOFException: input contained no data
        at org.xmlpull.mxp1.MXParser.fillBuf(MXParser.java:3003)
        at org.xmlpull.mxp1.MXParser.more(MXParser.java:3046)
        at org.xmlpull.mxp1.MXParser.parseProlog(MXParser.java:1410)
        at org.xmlpull.mxp1.MXParser.nextImpl(MXParser.java:1395)
        at org.xmlpull.mxp1.MXParser.next(MXParser.java:1093)
        at com.google.api.client.xml.Xml.parseElementInternal(Xml.java:245)
        at com.google.api.client.xml.Xml.parseElement(Xml.java:222)
        at io.minio.messages.XmlEntity.parseXml(XmlEntity.java:75)
        at io.minio.messages.ErrorResponse.parseXml(ErrorResponse.java:159)
        at io.minio.messages.ErrorResponse.<init>(ErrorResponse.java:64)
        at io.minio.MinioClient.execute(MinioClient.java:970)
        at io.minio.MinioClient.executePut(MinioClient.java:1197)
        at io.minio.MinioClient.makeBucket(MinioClient.java:2597)
        at io.minio.MinioClient.makeBucket(MinioClient.java:2554)
        at FunctionalTest.makeBucket_test1(FunctionalTest.java:86)
        at FunctionalTest.runTests(FunctionalTest.java:1264)
        at FunctionalTest.main(FunctionalTest.java:1380)
```
This patch handles response code and returns Amazon S3 error.