### PR TITLE
api: add MinioClient.ignoreCertCheck() method

### DIFF
--- a/api/src/main/java/io/minio/HttpResponse.java
+++ b/api/src/main/java/io/minio/HttpResponse.java
@@ -16,8 +16,8 @@
 
 package io.minio;
 
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.ResponseBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 
 /**

--- a/api/src/main/java/io/minio/Signer.java
+++ b/api/src/main/java/io/minio/Signer.java
@@ -31,9 +31,9 @@ import org.joda.time.DateTime;
 
 import com.google.common.base.Joiner;
 import com.google.common.io.BaseEncoding;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Request;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
 
 
 /**
@@ -163,7 +163,7 @@ class Signer {
 
   private void setCanonicalRequest() throws NoSuchAlgorithmException {
     setCanonicalHeaders();
-    this.url = this.request.httpUrl();
+    this.url = this.request.url();
     setCanonicalQueryString();
 
     // CanonicalRequest =
@@ -243,7 +243,7 @@ class Signer {
     this.canonicalHeaders.put("host", this.request.headers().get("Host"));
     this.signedHeaders = "host";
 
-    HttpUrl.Builder urlBuilder = this.request.httpUrl().newBuilder();
+    HttpUrl.Builder urlBuilder = this.request.url().newBuilder();
     // order of queryparam addition is important ie has to be sorted.
     urlBuilder.addEncodedQueryParameter(S3Escaper.encode("X-Amz-Algorithm"),
                                         S3Escaper.encode("AWS4-HMAC-SHA256"));

--- a/api/src/main/java/io/minio/errors/ErrorResponseException.java
+++ b/api/src/main/java/io/minio/errors/ErrorResponseException.java
@@ -16,8 +16,8 @@
 
 package io.minio.errors;
 
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import io.minio.messages.ErrorResponse;
 
@@ -56,7 +56,7 @@ public class ErrorResponseException extends MinioException {
         + errorResponse.getString() + "\n"
         + "request={"
         + "method=" + request.method() + ", "
-        + "url=" + request.httpUrl() + ", "
+        + "url=" + request.url() + ", "
         + "headers=" + request.headers().toString()
                 .replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*")
                 .replaceAll("Credential=([^/]+)", "Credential=*REDACTED*")

--- a/api/src/main/java/io/minio/errors/NoResponseException.java
+++ b/api/src/main/java/io/minio/errors/NoResponseException.java
@@ -16,7 +16,7 @@
 
 package io.minio.errors;
 
-import com.squareup.okhttp.Request;
+import okhttp3.Request;
 
 
 /**

--- a/api/src/main/java/io/minio/http/HeaderParser.java
+++ b/api/src/main/java/io/minio/http/HeaderParser.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.squareup.okhttp.Headers;
+import okhttp3.Headers;
 
 
 /**

--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -51,8 +51,8 @@ import org.xmlpull.v1.XmlPullParserException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import io.minio.errors.InvalidEncryptionMetadataException;
 import io.minio.errors.ErrorResponseException;

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ subprojects {
     dependencies {
         compile "com.google.http-client:google-http-client-xml:1.20.0"
         compile "com.google.guava:guava:18.0"
-        compile "com.squareup.okhttp:okhttp:2.7.5"
-        compile "com.squareup.okio:okio:1.6.0"
+        compile "com.squareup.okhttp3:okhttp:3.7.0"
+        compile "com.squareup.okio:okio:1.12.0"
         compile "joda-time:joda-time:2.7"
         compile "com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr3"
         compile "com.fasterxml.jackson.core:jackson-core:2.9.0.pr3"
@@ -55,7 +55,7 @@ subprojects {
         compile 'com.google.code.findbugs:annotations:3.0.1'
         compile 'com.google.code.findbugs:jsr305:3.0.1'
 
-        testCompile "com.squareup.okhttp:mockwebserver:2.7.2"
+        testCompile "com.squareup.okhttp3:mockwebserver:3.7.0"
         testCompile "junit:junit:4.12"
     }
 
@@ -242,7 +242,7 @@ project(':examples') {
 
 project(':functional') {
     dependencies {
-    	compile project(':api')
+        compile project(':api')
     }
 
     sourceSets {

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -29,12 +29,12 @@ import java.nio.file.*;
 
 import org.joda.time.DateTime;
 
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.MultipartBuilder;
-import com.squareup.okhttp.Response;
+import okhttp3.OkHttpClient;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.MultipartBody;
+import okhttp3.Response;
 import com.google.common.io.ByteStreams;
 
 import io.minio.*;
@@ -1097,8 +1097,8 @@ public class FunctionalTest {
     policy.setContentRange(1 * MB, 4 * MB);
     Map<String, String> formData = client.presignedPostPolicy(policy);
 
-    MultipartBuilder multipartBuilder = new MultipartBuilder();
-    multipartBuilder.type(MultipartBuilder.FORM);
+    MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+    multipartBuilder.setType(MultipartBody.FORM);
     for (Map.Entry<String, String> entry : formData.entrySet()) {
       multipartBuilder.addFormDataPart(entry.getKey(), entry.getValue());
     }


### PR DESCRIPTION
This patch fixes below
* ignoreCertCheck() enables MinioClient to ignore server certificate
  verification for HTTPS.
* Upgrade OkHttp and Okio libraries to the latest version.