### PR TITLE
api: add support to putObject() with unknown sized input stream.

### DIFF
--- a/api/src/main/java/io/minio/Digest.java
+++ b/api/src/main/java/io/minio/Digest.java
@@ -162,7 +162,7 @@ class Digest {
       throw new IllegalArgumentException("unsupported input stream object");
     }
 
-    // hold current position of file/stream.
+    // hold current position of file/stream to reset back to this position.
     long pos = 0;
     if (file != null) {
       pos = file.getFilePointer();
@@ -205,6 +205,7 @@ class Digest {
       }
     }
 
+    // reset back to saved position.
     if (file != null) {
       file.seek(pos);
     } else {

--- a/api/src/main/java/io/minio/Digest.java
+++ b/api/src/main/java/io/minio/Digest.java
@@ -102,26 +102,8 @@ class Digest {
    */
   public static String md5Hash(Object inputStream, int len)
     throws NoSuchAlgorithmException, IOException, InsufficientDataException {
-    RandomAccessFile file = null;
-    BufferedInputStream stream = null;
-    if (inputStream instanceof RandomAccessFile) {
-      file = (RandomAccessFile) inputStream;
-    } else if (inputStream instanceof BufferedInputStream) {
-      stream = (BufferedInputStream) inputStream;
-    } else {
-      throw new IllegalArgumentException("unsupported input stream object");
-    }
-
-    long pos = 0;
     MessageDigest md5Digest = MessageDigest.getInstance("MD5");
-    pos = readBytes(len, file, stream, pos, null, md5Digest);
-
-    if (file != null) {
-      file.seek(pos);
-    } else {
-      stream.reset();
-    }
-
+    updateDigests(inputStream, len, null, md5Digest);
     return BaseEncoding.base64().encode(md5Digest.digest());
   }
 
@@ -157,6 +139,19 @@ class Digest {
    */
   public static String[] sha256md5Hashes(Object inputStream, int len)
     throws NoSuchAlgorithmException, IOException, InsufficientDataException {
+    MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
+    MessageDigest md5Digest = MessageDigest.getInstance("MD5");
+    updateDigests(inputStream, len, sha256Digest, md5Digest);
+    return new String[] { BaseEncoding.base16().encode(sha256Digest.digest()).toLowerCase(),
+                        BaseEncoding.base64().encode(md5Digest.digest()) };
+  }
+
+
+  /**
+   * Updated MessageDigest with bytes read from file and stream.
+   */
+  private static int updateDigests(Object inputStream, int len, MessageDigest sha256Digest, MessageDigest md5Digest)
+    throws IOException, InsufficientDataException {
     RandomAccessFile file = null;
     BufferedInputStream stream = null;
     if (inputStream instanceof RandomAccessFile) {
@@ -167,47 +162,22 @@ class Digest {
       throw new IllegalArgumentException("unsupported input stream object");
     }
 
-    MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
-    MessageDigest md5Digest = MessageDigest.getInstance("MD5");
+    // hold current position of file/stream.
     long pos = 0;
-    pos = readBytes(len, file, stream, pos, sha256Digest, md5Digest);
-
-    if (file != null) {
-      file.seek(pos);
-    } else {
-      stream.reset();
-    }
-
-    return new String[] { BaseEncoding.base16().encode(sha256Digest.digest()).toLowerCase(),
-                        BaseEncoding.base64().encode(md5Digest.digest()) };
-  }
-
-
-  /**
-   * Updated MessageDigest with bytes read from file and stream.
-   */
-  private static long readBytes(int len,
-                                RandomAccessFile file,
-                                BufferedInputStream stream,
-                                long pos,
-                                MessageDigest sha256Digest,
-                                MessageDigest md5Digest) throws IOException, InsufficientDataException {
-    // 16KiB buffer for optimization
-    byte[] buf = new byte[16384];
-    int bytesToRead = buf.length;
-    int bytesRead;
-    int totalBytesRead = 0;
-    int length = len;
-
     if (file != null) {
       pos = file.getFilePointer();
     } else {
       stream.mark(len);
     }
 
-    do {
-      if ((length - totalBytesRead) < bytesToRead) {
-        bytesToRead = length - totalBytesRead;
+    // 16KiB buffer for optimization
+    byte[] buf = new byte[16384];
+    int bytesToRead = buf.length;
+    int bytesRead = 0;
+    int totalBytesRead = 0;
+    while (totalBytesRead < len) {
+      if ((len - totalBytesRead) < bytesToRead) {
+        bytesToRead = len - totalBytesRead;
       }
 
       if (file != null) {
@@ -217,21 +187,30 @@ class Digest {
       }
 
       if (bytesRead < 0) {
+        // reached EOF 
         throw new InsufficientDataException("Insufficient data.  bytes read " + totalBytesRead + " expected "
-                + length);
-      } else if (bytesRead == 0) {
-        continue;
+                                            + len);
       }
 
-      if (sha256Digest != null) {
-        sha256Digest.update(buf, 0, bytesRead);
-      }
-      if (md5Digest != null) {
-        md5Digest.update(buf, 0, bytesRead);
-      }
+      if (bytesRead > 0) {
+        if (sha256Digest != null) {
+          sha256Digest.update(buf, 0, bytesRead);
+        }
 
-      totalBytesRead += bytesRead;
-    } while (totalBytesRead < length);
-    return pos;
+        if (md5Digest != null) {
+          md5Digest.update(buf, 0, bytesRead);
+        }
+
+        totalBytesRead += bytesRead;
+      }
+    }
+
+    if (file != null) {
+      file.seek(pos);
+    } else {
+      stream.reset();
+    }
+
+    return totalBytesRead;
   }
 }

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -2781,6 +2781,69 @@ public final class MinioClient {
 
 
   /**
+   * Uploads data from given stream as object to given bucket where the stream size is unknown.
+   * <p>
+   * If the stream has more than 525MiB data, the client uses a multipart session automatically.
+   * </p>
+   * <p>
+   * If the session fails, the user may attempt to re-upload the object by attempting to create
+   * the exact same object again. The client will examine all parts of any current upload session
+   * and attempt to reuse the session automatically. If a mismatch is discovered, the upload will fail
+   * before uploading any more data. Otherwise, it will resume uploading where the session left off.
+   * </p>
+   * <p>
+   * If the multipart session fails, the user is responsible for resuming or removing the session.
+   * </p>
+   *
+   * </p><b>Example:</b><br>
+   * <pre>{@code StringBuilder builder = new StringBuilder();
+   * for (int i = 0; i < 1000; i++) {
+   *   builder.append("Sphinx of black quartz, judge my vow: Used by Adobe InDesign to display font samples. ");
+   *   builder.append("(29 letters)\n");
+   *   builder.append("Jackdaws love my big sphinx of quartz: Similarly, used by Windows XP for some fonts. ");
+   *   builder.append("(31 letters)\n");
+   *   builder.append("Pack my box with five dozen liquor jugs: According to Wikipedia, this one is used on ");
+   *   builder.append("NASAs Space Shuttle. (32 letters)\n");
+   *   builder.append("The quick onyx goblin jumps over the lazy dwarf: Flavor text from an Unhinged Magic Card. ");
+   *   builder.append("(39 letters)\n");
+   *   builder.append("How razorback-jumping frogs can level six piqued gymnasts!: Not going to win any brevity ");
+   *   builder.append("awards at 49 letters long, but old-time Mac users may recognize it.\n");
+   *   builder.append("Cozy lummox gives smart squid who asks for job pen: A 41-letter tester sentence for Mac ");
+   *   builder.append("computers after System 7.\n");
+   *   builder.append("A few others we like: Amazingly few discotheques provide jukeboxes; Now fax quiz Jack! my ");
+   *   builder.append("brave ghost pled; Watch Jeopardy!, Alex Trebeks fun TV quiz game.\n");
+   *   builder.append("---\n");
+   * }
+   * ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
+   * // create object
+   * minioClient.putObject("my-bucketname", "my-objectname", bais, "application/octet-stream");
+   * bais.close();
+   * System.out.println("my-bucketname is uploaded successfully"); }</pre>
+   *
+   * @param bucketName  Bucket name.
+   * @param objectName  Object name to create in the bucket.
+   * @param stream      stream to upload.
+   * @param contentType Content type of the stream.
+   *
+   * @throws InvalidBucketNameException  upon invalid bucket name is given
+   * @throws NoResponseException         upon no response from server
+   * @throws IOException                 upon connection error
+   * @throws XmlPullParserException      upon parsing response xml
+   * @throws ErrorResponseException      upon unsuccessful execution
+   * @throws InternalException           upon internal library error
+   *
+   * @see #putObject(String bucketName, String objectName, String fileName)
+   */
+  public void putObject(String bucketName, String objectName, InputStream stream, String contentType)
+    throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
+           InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
+           InternalException,
+           InvalidArgumentException, InsufficientDataException {
+    putObject(bucketName, objectName, contentType, null, new BufferedInputStream(stream));
+  }
+
+
+  /**
    * Executes put object and returns ETag of the object.
    *
    * @param bucketName   Bucket name.
@@ -2826,19 +2889,24 @@ public final class MinioClient {
    * @param size         Size of object data.
    * @param data         Object data.
    */
-  private void putObject(String bucketName, String objectName, String contentType, long size, Object data)
+  private void putObject(String bucketName, String objectName, String contentType, Long size, Object data)
     throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
            InternalException,
            InvalidArgumentException, InsufficientDataException {
+    boolean unknownSize = false;
+    if (size == null) {
+      unknownSize = true;
+      size = MAX_OBJECT_SIZE;
+    }
+
     if (size <= MIN_MULTIPART_SIZE) {
       // Single put object.
-      putObject(bucketName, objectName, (int) size, data, null, contentType, 0);
+      putObject(bucketName, objectName, size.intValue(), data, null, contentType, 0);
       return;
     }
 
     /* Multipart upload */
-
     int[] rv = calculateMultipartSize(size);
     int partSize = rv[0];
     int partCount = rv[1];
@@ -2865,6 +2933,25 @@ public final class MinioClient {
     for (int partNumber = 1; partNumber <= partCount; partNumber++) {
       if (partNumber == partCount) {
         expectedReadSize = lastPartSize;
+      }
+
+      // For unknown sized stream, check available size.
+      int availableSize = 0;
+      if (unknownSize) {
+        availableSize = getAvailableSize(data, expectedReadSize);
+        if (availableSize != expectedReadSize) {
+          // the stream has less data
+          if (partNumber == 1) {
+            // We do single put object here.
+            putObject(bucketName, objectName, availableSize, data, null, contentType, 0);
+            abortMultipartUpload(bucketName, objectName, uploadId);
+            return;
+          }
+
+          // We have reached last part.
+          expectedReadSize = availableSize;
+          partCount = partNumber;
+        }
       }
 
       if (part != null && partNumber == part.partNumber() && expectedReadSize == part.partSize()) {
@@ -3635,6 +3722,58 @@ public final class MinioClient {
     }
 
     return new int[] { (int) partSize, (int) partCount, (int) lastPartSize };
+  }
+
+
+  private int getAvailableSize(Object inputStream, int expectedReadSize) throws IOException, InternalException {
+    RandomAccessFile file = null;
+    BufferedInputStream stream = null;
+    if (inputStream instanceof RandomAccessFile) {
+      file = (RandomAccessFile) inputStream;
+    } else if (inputStream instanceof BufferedInputStream) {
+      stream = (BufferedInputStream) inputStream;
+    } else {
+      throw new InternalException("Unknown input stream. This should not happen.  Please report");
+    }
+
+    long pos = 0;
+    if (file != null) {
+      pos = file.getFilePointer();
+    } else {
+      stream.mark(expectedReadSize);
+    }
+
+    // 16KiB buffer for optimization
+    byte[] buf = new byte[16384];
+    int bytesToRead = buf.length;
+    int bytesRead = 0;
+    int totalBytesRead = 0;
+    while (totalBytesRead < expectedReadSize) {
+      if ((expectedReadSize - totalBytesRead) < bytesToRead) {
+        bytesToRead = expectedReadSize - totalBytesRead;
+      }
+
+      if (file != null) {
+        bytesRead = file.read(buf, 0, bytesToRead);
+      } else {
+        bytesRead = stream.read(buf, 0, bytesToRead);
+      }
+
+      if (bytesRead < 0) {
+        // reached EOF
+        break;
+      }
+
+      totalBytesRead += bytesRead;
+    }
+
+    if (file != null) {
+      file.seek(pos);
+    } else {
+      stream.reset();
+    }
+
+    return totalBytesRead;
   }
 
 

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -247,6 +247,25 @@ public class FunctionalTest {
   }
 
   /**
+   * Test: putObject(String bucketName, String objectName, String contentType, InputStream body).
+   */
+  public static void putObject_test7() throws Exception {
+    System.out.println("Test: putObject(String bucketName, String objectName, InputStream body, "
+                       + "String contentType)");
+    String filename = createFile(3 * MB);
+    InputStream is = Files.newInputStream(Paths.get(filename));
+    client.putObject(bucketName, filename, is, customContentType);
+    is.close();
+    Files.delete(Paths.get(filename));
+    ObjectStat objectStat = client.statObject(bucketName, filename);
+    if (!customContentType.equals(objectStat.contentType())) {
+      throw new Exception("[FAILED] Test: putObject(String bucketName, String objectName, String contentType, "
+                          + "long size, InputStream body)");
+    }
+    client.removeObject(bucketName, filename);
+  }
+
+  /**
    * Test: statObject(String bucketName, String objectName).
    */
   public static void statObject_test() throws Exception {
@@ -1281,6 +1300,7 @@ public class FunctionalTest {
     putObject_test4();
     putObject_test5();
     putObject_test6();
+    putObject_test7();
 
     statObject_test();
     getObject_test1();

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -40,7 +40,7 @@ import io.minio.errors.*;
 
 public class FunctionalTest {
   private static final int MB = 1024 * 1024;
-  private static final SecureRandom random = new SecureRandom();
+  private static final Random random = new Random(new SecureRandom().nextLong());
   private static final String bucketName = getRandomName();
   private static final String customContentType = "application/javascript";
   private static String endpoint;
@@ -247,12 +247,31 @@ public class FunctionalTest {
   }
 
   /**
-   * Test: putObject(String bucketName, String objectName, String contentType, InputStream body).
+   * Test: putObject(String bucketName, String objectName, InputStream body, String contentType).
    */
   public static void putObject_test7() throws Exception {
     System.out.println("Test: putObject(String bucketName, String objectName, InputStream body, "
                        + "String contentType)");
     String filename = createFile(3 * MB);
+    InputStream is = Files.newInputStream(Paths.get(filename));
+    client.putObject(bucketName, filename, is, customContentType);
+    is.close();
+    Files.delete(Paths.get(filename));
+    ObjectStat objectStat = client.statObject(bucketName, filename);
+    if (!customContentType.equals(objectStat.contentType())) {
+      throw new Exception("[FAILED] Test: putObject(String bucketName, String objectName, String contentType, "
+                          + "long size, InputStream body)");
+    }
+    client.removeObject(bucketName, filename);
+  }
+
+  /**
+   * Test: multipart: putObject(String bucketName, String objectName, InputStream body, String contentType).
+   */
+  public static void putObject_test8() throws Exception {
+    System.out.println("Test: multipart: putObject(String bucketName, String objectName, InputStream body, "
+                       + "String contentType)");
+    String filename = createFile(537 * MB);
     InputStream is = Files.newInputStream(Paths.get(filename));
     client.putObject(bucketName, filename, is, customContentType);
     is.close();
@@ -1301,6 +1320,7 @@ public class FunctionalTest {
     putObject_test5();
     putObject_test6();
     putObject_test7();
+    putObject_test8();
 
     statObject_test();
     getObject_test1();


### PR DESCRIPTION
This patch brings new putObject() API.
```java
public void putObject(String bucketName, String objectName,
                      InputStream stream, String contentType)
```
Fixes #341