### PR TITLE
[security] Fix security issues in dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,12 +46,12 @@ subprojects {
     dependencies {
         compile "com.google.http-client:google-http-client-xml:1.20.0"
         compile "com.google.guava:guava:18.0"
-        compile "com.squareup.okhttp:okhttp:2.7.2"
+        compile "com.squareup.okhttp:okhttp:2.7.5"
         compile "com.squareup.okio:okio:1.6.0"
         compile "joda-time:joda-time:2.7"
-        compile "com.fasterxml.jackson.core:jackson-annotations:2.8.4"
-        compile "com.fasterxml.jackson.core:jackson-core:2.8.4"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.8.4"
+        compile "com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr3"
+        compile "com.fasterxml.jackson.core:jackson-core:2.9.0.pr3"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.0.pr3"
         compile 'com.google.code.findbugs:annotations:3.0.1'
         compile 'com.google.code.findbugs:jsr305:3.0.1'
 


### PR DESCRIPTION
SourceClear tool reported vulnerabilities in dependencies used by
minio-java. This patch updates the vulnerable libraries to their
latest versions.

Vulnerabilities found via the tool:

https://github.com/FasterXML/jackson-databind/issues/1599 (RCE)
https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-273 (Certificate
Pinning Bypass)
https://issues.jboss.org/browse/JBEAP-6316?_sscc=t (DOS)