### PR TITLE
api: Enhance copyObject to support metadata.

### DIFF
--- a/api/src/main/java/io/minio/CopyConditions.java
+++ b/api/src/main/java/io/minio/CopyConditions.java
@@ -30,6 +30,9 @@ import io.minio.errors.InvalidArgumentException;
  * before copying an object.
  */
 public class CopyConditions {
+  // Metadata directive "REPLACE" used to replace metadata on
+  // destination object in copyObject().
+  private static final String METADATA_DIRECTIVE_REPLACE = "REPLACE";
 
   private Map<String, String> copyConditions = new HashMap<>();
 
@@ -86,6 +89,15 @@ public class CopyConditions {
       throw new InvalidArgumentException("ETag cannot be empty");
     }
     copyConditions.put("x-amz-copy-source-if-none-match", etag);
+  }
+
+  /**
+   * Set replace metadata directive which specifies that
+   * destination object after copyObject() sets new
+   * metadata provided in the request.
+   */
+  public void setReplaceMetadataDirective() {
+    copyConditions.put("x-amz-metadata-directive", METADATA_DIRECTIVE_REPLACE);
   }
 
   /**

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1807,7 +1807,7 @@ public final class MinioClient {
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException {
 
-    copyObject(bucketName, objectName, destBucketName, null, null);
+    copyObject(bucketName, objectName, destBucketName, null, null, null);
   }
 
   /**
@@ -1842,7 +1842,7 @@ public final class MinioClient {
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException {
 
-    copyObject(bucketName, objectName, destBucketName, destObjectName, null);
+    copyObject(bucketName, objectName, destBucketName, destObjectName, null, null);
   }
 
   /**
@@ -1880,7 +1880,7 @@ public final class MinioClient {
         NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
         InvalidArgumentException {
 
-    copyObject(bucketName, objectName, destBucketName, null, copyConditions);
+    copyObject(bucketName, objectName, destBucketName, null, copyConditions, null);
   }
 
   /**
@@ -1921,6 +1921,51 @@ public final class MinioClient {
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException {
 
+    copyObject(bucketName, objectName, destBucketName, destObjectName, copyConditions, null);
+  }
+
+  /**
+   * Copy a source object into a new object with the provided name in the provided bucket.
+   * optionally can take a key value CopyConditions as well for conditionally attempting
+   * copyObject.
+   *
+   * </p>
+   * <b>Example:</b><br>
+   *
+   * <pre>
+   * {@code minioClient.copyObject("my-bucketname", "my-objectname", "my-destbucketname",
+   * "my-destobjname", copyConditions, metadata);}
+   * </pre>
+   *
+   * @param bucketName
+   *          Bucket name where the object to be copied exists.
+   * @param objectName
+   *          Object name source to be copied.
+   * @param destBucketName
+   *          Bucket name where the object will be copied to.
+   * @param destObjectName
+   *          Object name to be created, if not provided uses source object name
+   *          as destination object name.
+   * @param copyConditions
+   *          CopyConditions object with collection of supported CopyObject conditions.
+   * @param metadata
+   *          Additional metadata to set on the destination object when
+   *          setMetadataDirective is set to 'REPLACE'.
+   *
+   * @throws InvalidBucketNameException
+   *           upon an invalid bucket name, invalid object name.
+   * @throws NoSuchAlgorithmException
+   *           upon requested algorithm was not found during signature calculation
+   * @throws InvalidKeyException
+   *           upon an invalid access key or secret key
+   */
+  public void copyObject(String bucketName, String objectName, String destBucketName,
+                         String destObjectName, CopyConditions copyConditions,
+                         Map<String,String> metadata)
+      throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
+      NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
+      InvalidArgumentException {
+
     if (bucketName == null) {
       throw new InvalidArgumentException("Source bucket name cannot be empty");
     }
@@ -1947,6 +1992,11 @@ public final class MinioClient {
     // If no conditions available, skip addition else add the conditions to the header
     if (copyConditions != null) {
       headerMap.putAll(copyConditions.getConditions());
+    }
+
+    // Set metadata on the destination of object.
+    if (metadata != null) {
+      headerMap.putAll(metadata);
     }
 
     HttpResponse response = executePut(destBucketName, destObjectName, headerMap,

--- a/docs/API.md
+++ b/docs/API.md
@@ -1162,16 +1162,15 @@ try {
 ```
 
 <a name="copyObject"></a>
-### copyObject(String bucketName, String objectName, String destBucketName, String destObjectName, CopyConditions cpConds)
+### copyObject(String bucketName, String objectName, String destBucketName, String destObjectName, CopyConditions cpConds, Map<String, String> metadata)
 
-*`public void copyObject(String bucketName, String objectName, String destBucketName, String destObjectName, CopyConditions cpConds)`*
+*`public void copyObject(String bucketName, String objectName, String destBucketName, String destObjectName, CopyConditions cpConds, Map<String, String> metadata)`*
 
 Copies content from objectName to destObjectName.
 
 [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#copyObject-java.lang.String-java.lang.String-java.lang.String-java.lang.String-io.minio.CopyConditions-)
 
 __Parameters__
-
 
 |Param   | Type	  | Description  |
 |:--- |:--- |:--- |
@@ -1180,6 +1179,7 @@ __Parameters__
 | ``destBucketName``  | _String_  | Destination bucket name. |
 | ``destObjectName`` | _String_ | Destination object name to be created, if not provided defaults to source object name.|
 | ``copyConditions`` | _CopyConditions_ | Map of conditions useful for applying restrictions on copy operation.|
+| ``metadata``  | _Map_ | Map of object metadata for destination object.|
 
 
 | Return Type	  | Exceptions	  |

--- a/examples/CopyObjectMetadata.java
+++ b/examples/CopyObjectMetadata.java
@@ -1,0 +1,88 @@
+/*
+ * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.StringBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
+import java.util.Map;
+import java.util.HashMap;
+import org.xmlpull.v1.XmlPullParserException;
+
+import io.minio.MinioClient;
+import io.minio.CopyConditions;
+import io.minio.errors.MinioException;
+
+public class CopyObjectMetadata {
+  /**
+   * MinioClient.copyObject() example.
+   */
+  public static void main(String[] args)
+    throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
+    try {
+      /* play.minio.io for test and development. */
+      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+                                                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+
+      /* Amazon S3: */
+      // MinioClient minioClient = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSKEYID",
+      //                                           "YOUR-SECRETACCESSKEY");
+
+      // Create some content for the object.
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < 1000; i++) {
+        builder.append("Sphinx of black quartz, judge my vow: Used by Adobe InDesign to display font samples. ");
+        builder.append("(29 letters)\n");
+        builder.append("Jackdaws love my big sphinx of quartz: Similarly, used by Windows XP for some fonts. ");
+        builder.append("(31 letters)\n");
+        builder.append("Pack my box with five dozen liquor jugs: According to Wikipedia, this one is used on ");
+        builder.append("NASAs Space Shuttle. (32 letters)\n");
+        builder.append("The quick onyx goblin jumps over the lazy dwarf: Flavor text from an Unhinged Magic Card. ");
+        builder.append("(39 letters)\n");
+        builder.append("How razorback-jumping frogs can level six piqued gymnasts!: Not going to win any brevity ");
+        builder.append("awards at 49 letters long, but old-time Mac users may recognize it.\n");
+        builder.append("Cozy lummox gives smart squid who asks for job pen: A 41-letter tester sentence for Mac ");
+        builder.append("computers after System 7.\n");
+        builder.append("A few others we like: Amazingly few discotheques provide jukeboxes; Now fax quiz Jack! my ");
+        builder.append("brave ghost pled; Watch Jeopardy!, Alex Trebeks fun TV quiz game.\n");
+        builder.append("---\n");
+      }
+
+      // Create a InputStream for object upload.
+      ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
+
+      // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
+      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), "application/octet-stream");
+      bais.close();
+      System.out.println("my-objectname is uploaded successfully");
+
+      CopyConditions copyConditions = new CopyConditions();
+      // Replace metadata on destination object with custom metadata.
+      copyConditions.setReplaceMetadataDirective();
+
+      Map<String, String> metadata = new HashMap<>();
+      metadata.put("Content-Type", "application/javascript");
+
+      minioClient.copyObject("my-bucketname", "my-objectname", "my-destbucketname",
+                             "my-objectname-copy", copyConditions, metadata);
+      System.out.println("my-objectname-copy copied to my-destbucketname successfully");
+    } catch (MinioException e) {
+      System.out.println("Error occurred: " + e);
+    }
+  }
+}


### PR DESCRIPTION
This change allows copyObject() to replace metadata
with new metadata on the destination object. Additionally
this also allows for replacing metadata on existing objects
as well.