### PR TITLE
Enable gradle check in travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
 - oraclejdk7
 - openjdk7
 script:
+- ./gradlew check
 - if java -version 2>&1 | grep -q 'java version "1.8.'; then ./gradlew runFunctionalTest; else true; fi
 notifications:
   slack:


### PR DESCRIPTION
With this change, minio-java examples will be built with each PR. This is important to ensure the examples are working as expected.