### PR TITLE
Support releasing an minio-java artifact from maven.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,45 +4,58 @@ Minio Java SDK uses [gradle](https://gradle.org/) build system.
 ## Responsibilities
 Go through [Maintainer Responsibility Guide](https://gist.github.com/abperiasamy/f4d9b31d3186bbd26522).
 
-### Setup your minio-java Github Repository
-Fork [minio-java](https://github.com/minio/minio-java/fork) source repository to your own personal repository.
-```bash
-$ git clone https://github.com/$USER_ID/minio-java
+## Setup your minio-java Github Repository
+Clone [minio-java](https://github.com/minio/minio-java/) source repository locally.
+```sh
+$ git clone https://github.com/minio/minio-java
 $ cd minio-java
 ```
 
 ### Build and verify
 Run `runFunctionalTest` gradle task to build and verify the SDK.
-```bash
+```sh
 $ ./gradlew runFunctionalTest
 ```
 
-### Publishing new artifacts
+## Publishing new artifacts
 #### Setup your gradle properties
 Create a new gradle properties file
-
-```bash
-$ cat gradle.properties > ${HOME}/.gradle/gradle.properties <<EOF
+```sh
+$ cat > ${HOME}/.gradle/gradle.properties <<EOF
 signing.keyId=76A57749
-signing.password=**REDACTED**
-signing.secretKeyRingFile=/home/harsha/.gnupg/secring.gpg
-ossrhUsername=minio
-ossrhPassword=**REDACTED**
+signing.password=*******
+signing.secretKeyRingFile=/media/${USER}/Minio2/trusted/secring.gpg
+nexusUsername=********
+nexusPassword=********
 release=true
 EOF
 ```
 
-#### Import minio private key
-```bash
-$ gpg --import minio.asc
-```
-
-#### Upload archives to maven for publishing
-```bash
+#### Upload to maven
+Upload all artifacts belonging to `io.minio` artifact repository, additionally this step requires you to have access to Minio's trusted private key.
+```sh
 $ ./gradlew uploadArchives
 ```
 
-#### Cleanup
-```bash
-$ rm -v ${HOME}/.gradle/gradle.properties
+#### Release
+Closes and releases `io.minio` artifacts repository in Nexus to maven.
+```sh
+$ ./gradlew closeAndReleaseRepository
+```
+
+### Tag
+Tag and sign your release commit, additionally this step requires you to have access to Minio's trusted private key.
+```
+$ export GNUPGHOME=/media/${USER}/Minio2/trusted
+$ git tag -s 0.3.0
+$ git push
+$ git push --tags
+```
+
+### Announce
+Announce new release by adding release notes at https://github.com/minio/minio-java/releases from `trusted@minio.io` account. Release notes requires two sections `highlights` and `changelog`. Highlights is a bulleted list of salient features in this release and Changelog contains list of all commits since the last release.
+
+To generate `changelog`
+```sh
+git log --no-color --pretty=format:'-%d %s (%cr) <%an>' <last_release_tag>..<latest_release_tag>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
     }
 }
+
+apply plugin: 'io.codearte.nexus-staging'
 
 subprojects {
     apply plugin: 'java'
@@ -122,6 +125,11 @@ project(':api') {
 
     archivesBaseName = 'minio'
 
+    nexusStaging {
+        packageGroup = group
+        stagingProfileId = '9b746c9f8abc1'
+    }
+
     jar {
         manifest {
             attributes('Implementation-Title': archivesBaseName,
@@ -167,16 +175,6 @@ project(':api') {
         }
     }
 
-    ext.deployUsername = ''
-    if (project.properties.containsKey('ossrhUsername')) {
-        ext.deployUsername = ext.ossrhUsername
-    }
-
-    ext.deployPassword = ''
-    if (project.properties.containsKey('ossrhPassword')) {
-        ext.deployPassword = ext.ossrhPassword
-    }
-
     uploadArchives {
         repositories {
             mavenDeployer {
@@ -184,12 +182,15 @@ project(':api') {
                     MavenDeployment deployment -> signing.signPom(deployment)
                 }
 
+                ext.nexusUsername = project.properties['nexusUsername']
+                ext.nexusPassword = project.properties['nexusPassword']
+
                 repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                    authentication(userName: deployUsername, password: deployPassword)
+                    authentication(userName: ext.nexusUsername, password: ext.nexusPassword)
                 }
 
                 snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                    authentication(userName: deployUsername, password: deployPassword)
+                    authentication(userName: ext.nexusUsername, password: ext.nexusPassword)
                 }
 
                 pom.project {
@@ -197,6 +198,7 @@ project(':api') {
                     packaging 'jar'
                     description 'Minio Java SDK for Amazon S3 Compatible Cloud Storage'
                     url 'https://github.com/minio/minio-java'
+                    inceptionYear '2015'
 
                     scm {
                         connection 'scm:git:git@github.com:minio/minio-java.git'


### PR DESCRIPTION
Earlier we used to rely on Nexus repo manager to
release minio-java jar's, but with this change we
can now just `release` the repository after
`uploadArchives`.

Additionally MAINTAINERS.md is updated with relevant
instructions.