### PR TITLE
tests: delay check in set bucket policy in functional test

### DIFF
--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -2043,6 +2043,8 @@ public class FunctionalTest {
     try {
       String objectPrefix = "set-bucket-policy-none";
       client.setBucketPolicy(bucketName, objectPrefix, PolicyType.NONE);
+      // Wait for 3 seconds for server to set the policy into effect.
+      Thread.sleep(3000);
 
       String objectName = objectPrefix + "/" + getRandomName();
       InputStream is = new ContentInputStream(16);
@@ -2088,6 +2090,8 @@ public class FunctionalTest {
     long startTime = System.currentTimeMillis();
     try {
       client.setBucketPolicy(bucketName, objectPrefix, policyType);
+      // Wait for 3 seconds for server to set the policy into effect.
+      Thread.sleep(3000);
 
       String objectName = objectPrefix + "/" + getRandomName();
       String urlString = client.getObjectUrl(bucketName, objectName);


### PR DESCRIPTION
After setBucketPolicy(), backend server of gateway does not take the
policy into effect immediately.  This patch fixes the issue by
introducing 3 seconds delay after policy is set.