### PR TITLE
api: add new API to get all bucket policies

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -3804,7 +3804,7 @@ public class MinioClient {
   /**
    * Returns the parsed current bucket access policy.
    */
-  private BucketPolicy getBucketPolicy(String bucketName)
+  private BucketPolicy doGetBucketPolicy(String bucketName)
     throws InvalidBucketNameException, InvalidObjectPrefixException, NoSuchAlgorithmException,
            InsufficientDataException, IOException, InvalidKeyException, NoResponseException,
            XmlPullParserException, ErrorResponseException, InternalException {
@@ -3848,10 +3848,49 @@ public class MinioClient {
            XmlPullParserException, ErrorResponseException, InternalException {
     checkObjectPrefix(objectPrefix);
 
-    BucketPolicy policy = getBucketPolicy(bucketName);
+    BucketPolicy policy = this.doGetBucketPolicy(bucketName);
     return policy.getPolicy(objectPrefix);
   }
 
+  /**
+   * Get all policies in the given bucket.
+   *
+   * @param bucketName the name of the bucket for which policies are to be listed.
+   *
+   * </p><b>Example:</b><br>
+   * <pre>{@code
+   *
+   * final Map<String, PolicyType> policies = minioClient.getBucketPolicy("my-bucketname");
+   * for (final Map.Entry<String, PolicyType> policyEntry : policies.entrySet()) {
+   *    final String objectPrefix = policyEntry.getKey();
+   *    final PolicyType policyType = policyEntry.getValue();
+   *    System.out.println(
+   *        String.format("Access permission %s found for object prefix %s", policyType.getValue(), objectPrefix)
+   *    );
+   * }}
+   * </pre>
+   *
+   * @return a map of object prefixes (keys) to their policy types (values) for a given bucket.
+   * @throws InvalidBucketNameException   upon an invalid bucket name
+   * @throws IOException                  upon connection error
+   * @throws InvalidKeyException          upon an invalid access key or secret key
+   * @throws NoSuchAlgorithmException     upon requested algorithm was not found during signature calculation
+   * @throws InsufficientDataException    upon insufficient data
+   * @throws NoResponseException          upon no response from server
+   * @throws XmlPullParserException       upon parsing response xml
+   * @throws InternalException            upon internal library error
+   * @throws ErrorResponseException       upon unsuccessful execution
+   */
+  public Map<String, PolicyType> getBucketPolicy(String bucketName)
+      throws InvalidBucketNameException, IOException, InvalidKeyException, NoSuchAlgorithmException,
+      InsufficientDataException, NoResponseException, XmlPullParserException,
+      InternalException, ErrorResponseException, InvalidObjectPrefixException {
+    // Input validation.
+    checkBucketName(bucketName);
+
+    BucketPolicy bucketPolicy = this.doGetBucketPolicy(bucketName);
+    return bucketPolicy.getPolicies();
+  }
 
   /**
    * Sets the bucket access policy.
@@ -3889,7 +3928,7 @@ public class MinioClient {
            XmlPullParserException, ErrorResponseException, InternalException {
     checkObjectPrefix(objectPrefix);
 
-    BucketPolicy policy = getBucketPolicy(bucketName);
+    BucketPolicy policy = this.doGetBucketPolicy(bucketName);
 
     if (policyType == PolicyType.NONE && policy.statements() == null) {
       // As the request is for removing policy and the bucket

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -28,6 +28,8 @@ import static java.nio.file.StandardOpenOption.*;
 import java.nio.file.*;
 import java.nio.charset.StandardCharsets;
 
+import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 
 import okhttp3.OkHttpClient;
@@ -2232,6 +2234,75 @@ public class FunctionalTest {
   }
 
   /**
+   * Test listing all bucket policies.
+   */
+  public static void testGetBucketPolicies(final Map<String, PolicyType> policyMap) throws Exception {
+    final long startTime = System.currentTimeMillis();
+
+    final String bucketName = getRandomName();
+    client.makeBucket(bucketName);
+    try {
+      for (final Map.Entry<String, PolicyType> policyTypeEntry : policyMap.entrySet()) {
+        client.setBucketPolicy(bucketName, policyTypeEntry.getKey(), policyTypeEntry.getValue());
+      }
+
+      final Map<String, PolicyType> actualPolicies = client.getBucketPolicy(bucketName);
+
+      final Map<String, PolicyType> expectedPolicies = Maps.newHashMap();
+      policyMap.forEach((objectPrefix, policy) ->
+          expectedPolicies.put(String.format("%s/%s*", bucketName, objectPrefix), policy));
+
+      if (!actualPolicies.equals(expectedPolicies)) {
+        throw new Exception("[FAILED] policy list differs");
+      }
+
+      mintSuccessLog("getBucketPolicy(String bucketName)", null, startTime);
+    } catch (final Exception e) {
+      ErrorResponse errorResponse = null;
+      if (e instanceof ErrorResponseException) {
+        final ErrorResponseException exp = (ErrorResponseException) e;
+        errorResponse = exp.errorResponse();
+      }
+
+      // Ignore NotImplemented error
+      if (errorResponse != null && errorResponse.errorCode() == ErrorCode.NOT_IMPLEMENTED) {
+        mintIgnoredLog("getBucketPolicy(String bucketName)", null, startTime);
+      } else {
+        mintFailedLog("getBucketPolicy(String bucketName)", null, startTime, null,
+            e.toString() + " >>> " + Arrays.toString(e.getStackTrace()));
+      }
+      throw e;
+    } finally {
+      client.removeBucket(bucketName);
+    }
+  }
+
+  /**
+   * Test: single policy type: getBucketPolicy(String bucketName).
+   */
+  public static void getBucketPolicy_test5() throws Exception {
+    if (!mintEnv) {
+      System.out.println("Test: getBucketPolicy(String bucketName) (Single-Policy Case)");
+    }
+    final Map<String, PolicyType> policyTypeMap = ImmutableMap.of("list-policies-read-only", PolicyType.READ_ONLY);
+    testGetBucketPolicies(policyTypeMap);
+  }
+
+  /**
+   * Test: multiple policy types: getBucketPolicy(String bucketName).
+   */
+  public static void getBucketPolicy_test6() throws Exception {
+    if (!mintEnv) {
+      System.out.println("Test: getBucketPolicy(String bucketName) (Multi-Policy Case)");
+    }
+    final Map<String, PolicyType> policyTypeMap = ImmutableMap.of(
+        "list-policies-write-only", PolicyType.WRITE_ONLY,
+        "list-policies-read-write", PolicyType.READ_WRITE
+    );
+    testGetBucketPolicies(policyTypeMap);
+  }
+
+  /**
    * Test: setBucketNotification(String bucketName, NotificationConfiguration notificationConfiguration).
    */
   public static void setBucketNotification_test1() throws Exception {
@@ -2490,6 +2561,9 @@ public class FunctionalTest {
     setBucketPolicy_test2();
     setBucketPolicy_test3();
     setBucketPolicy_test4();
+
+    getBucketPolicy_test5();
+    getBucketPolicy_test6();
 
     threadedPutObject();
 


### PR DESCRIPTION
* ran imports optimization
* implemented ListBucketPolicies
* added test case to MinioClientTest

NB: the Go implementation does not seem to filter down the results by object prefix, so I've  done the same thing, here. I'll be happy to implement some sort of filter, if desired, but I didn't see that exhibited here: https://github.com/minio/minio-go/blob/master/api-get-policy.go#L50