### PR TITLE
fix: do not initialize httpClient in MinioClient class level.

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -199,7 +199,7 @@ public class MinioClient {
 
   private String userAgent = DEFAULT_USER_AGENT;
 
-  private OkHttpClient httpClient = new OkHttpClient();
+  private OkHttpClient httpClient;
 
 
   /**
@@ -635,6 +635,7 @@ public class MinioClient {
     if (httpClient != null) {
       this.httpClient = httpClient;
     } else {
+      this.httpClient = new OkHttpClient();
       this.httpClient = this.httpClient.newBuilder()
         .connectTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.SECONDS)
         .writeTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.SECONDS)


### PR DESCRIPTION
Previously httpClient was initialized at class level which causes
error with custom PKI implementation. In this situation any java
program using MinioClient (import io.minio.MinioClient;) would cause
failure.

This patch fixes the issue by initalizing httpClient in constructor
level

Fixes #628