### PR TITLE
Object name should not be part of URL in a Post object with policy method

### DIFF
--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1630,7 +1630,7 @@ public class FunctionalTest {
       is.close();
 
       Request.Builder requestBuilder = new Request.Builder();
-      String urlString = client.getObjectUrl(bucketName, objectName);
+      String urlString = client.getObjectUrl(bucketName, "");
       Request request = requestBuilder.url(urlString).post(multipartBuilder.build()).build();
       OkHttpClient transport = new OkHttpClient();
       Response response = transport.newCall(request).execute();


### PR DESCRIPTION
S3 spec requires that the object name is not part of the URL in
post object with policy method.

Fixes #637