### PR TITLE
tests: increase timeout to 5 seconds in setBucketPolicy tests

### DIFF
--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -2351,8 +2351,8 @@ public class FunctionalTest {
     try {
       String objectPrefix = "set-bucket-policy-none";
       client.setBucketPolicy(bucketName, objectPrefix, PolicyType.NONE);
-      // Wait for 3 seconds for server to set the policy into effect.
-      Thread.sleep(3000);
+      // Wait for 5 seconds for server to set the policy into effect.
+      Thread.sleep(5000);
 
       String objectName = objectPrefix + "/" + getRandomName();
       InputStream is = new ContentInputStream(16);
@@ -2410,8 +2410,8 @@ public class FunctionalTest {
     long startTime = System.currentTimeMillis();
     try {
       client.setBucketPolicy(bucketName, objectPrefix, policyType);
-      // Wait for 3 seconds for server to set the policy into effect.
-      Thread.sleep(3000);
+      // Wait for 5 seconds for server to set the policy into effect.
+      Thread.sleep(5000);
 
       String objectName = objectPrefix + "/" + getRandomName();
       String urlString = client.getObjectUrl(bucketName, objectName);


### PR DESCRIPTION
Mint shows failures for setBucketPolicy() tests even after 3 seconds
timeout against minio gateway where backend is Amazon AWS S3.  This
patch increases timeout to 5 seconds.