### PR TITLE
Fix bug causing wrong region with AWS

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1226,7 +1226,7 @@ public class MinioClient {
 
       xpp.setInput(response.body().charStream());
       while (xpp.getEventType() != XmlPullParser.END_DOCUMENT) {
-        if (xpp.getEventType() ==  XmlPullParser.START_TAG && xpp.getName() == "LocationConstraint") {
+        if (xpp.getEventType() ==  XmlPullParser.START_TAG && "LocationConstraint".equals(xpp.getName())) {
           xpp.next();
           location = getText(xpp, location);
           break;


### PR DESCRIPTION
Bug causes message like this:
"The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-west-1'"

The bug causes Minio to connect to the wrong region and thus get rejected.

It happens because Strings are objects more or less like all other objects. They
should always be compared with equals(). Only two constant strings can be compared
with == without using .intern().