### PR TITLE
Update Jackson dependency to 2.9.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,9 @@ subprojects {
         compile "com.squareup.okhttp3:okhttp:3.7.0"
         compile "com.squareup.okio:okio:1.12.0"
         compile "joda-time:joda-time:2.7"
-        compile "com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr3"
-        compile "com.fasterxml.jackson.core:jackson-core:2.9.0.pr3"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.9.0.pr3"
+        compile "com.fasterxml.jackson.core:jackson-annotations:2.9.6"
+        compile "com.fasterxml.jackson.core:jackson-core:2.9.6"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.6"
         compile 'com.google.code.findbugs:annotations:3.0.1'
         compile 'com.google.code.findbugs:jsr305:3.0.1'
 


### PR DESCRIPTION
Update the Jackson dependency to a version that doesn't have a known deserialization attack.