### PR TITLE
fix: allow range headers to be set in getObject request when offset is 0 (#706)

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1620,12 +1620,10 @@ public class MinioClient {
     }
 
     Map<String,String> headerMap = new HashMap<>();
-    if (offset > 0) {
-      if (length != null) {
-        headerMap.put("Range", "bytes=" + offset + "-" + (offset + length - 1));
-      } else {
-        headerMap.put("Range", "bytes=" + offset + "-");
-      }
+    if (length != null) {
+      headerMap.put("Range", "bytes=" + offset + "-" + (offset + length - 1));
+    } else if (offset > 0) {
+      headerMap.put("Range", "bytes=" + offset + "-");
     }
 
     HttpResponse response = executeGet(bucketName, objectName, headerMap, null);


### PR DESCRIPTION
fix: allow range headers to be set in getObject request when offset is 0 (#706)

fixes #706