### PR TITLE
GetObject to N bytes when offset is 0

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1620,7 +1620,7 @@ public class MinioClient {
     }
 
     Map<String,String> headerMap = new HashMap<>();
-    if (offset > 0) {
+    if (offset >= 0) {
       if (length != null) {
         headerMap.put("Range", "bytes=" + offset + "-" + (offset + length - 1));
       } else {


### PR DESCRIPTION
GetObject was returning the entire file when Offset was 0.  Specifying a 0 offset and X length would return an entire file rather than bytes from 0 - X-1. It was working correctly when the Offset was greater than 0. Issue #706