### PR TITLE
#732 Minio Server with explicitly set region results in ErrorResponseException when creating bucket

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -2949,13 +2949,14 @@ public class MinioClient {
     if (region == null || US_EAST_1.equals(region)) {
       // for 'us-east-1', location constraint is not required.  for more info
       // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+      region = US_EAST_1;
       configString = "";
     } else {
       CreateBucketConfiguration config = new CreateBucketConfiguration(region);
       configString = config.toString();
     }
 
-    HttpResponse response = executePut(bucketName, null, null, null, US_EAST_1, configString, 0);
+    HttpResponse response = executePut(bucketName, null, null, null, region, configString, 0);
     response.body().close();
   }
 


### PR DESCRIPTION
### Actual:

**Minio Server:** 

- `MINIO_REGION=test-region`

**Minio Client:**
```
String region = "test-region"; 
minioClient = MinioClient(endpoint, acccessKey, secretKey, region);
minioClient.makeBucket(bucketName, region); 
```

results in 

> ErrorResponseException: The authorization header is malformed; the region is wrong; expecting 'us-east-1'.


### Expected:
- Bucket is created in `test-region` region.