### PR TITLE
Fix: Do not base64 encode md5Hash

### DIFF
--- a/api/src/main/java/io/minio/Digest.java
+++ b/api/src/main/java/io/minio/Digest.java
@@ -119,7 +119,17 @@ class Digest {
                                   + "please report this issue at https://github.com/minio/minio-java/issues");
     }
 
-    return BaseEncoding.base64().encode(md5Digest.digest());
+    byte[] hash = md5Digest.digest();
+    StringBuffer hexString = new StringBuffer();
+    for (int i = 0; i < hash.length; i++) {
+      if ((0xff & hash[i]) < 0x10) {
+        hexString.append("0"
+              + Integer.toHexString((0xFF & hash[i])));
+      } else {
+        hexString.append(Integer.toHexString(0xFF & hash[i]));
+      }
+    }
+    return hexString.toString();
   }
 
 


### PR DESCRIPTION
Should not have to base64 encode the calculated md5Hash.

Fixes #738