### PR TITLE
ResumeMultipart

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -3841,16 +3841,11 @@ public class MinioClient {
       }
 
       if (part != null && partNumber == part.partNumber() && expectedReadSize == part.partSize()) {
-        String md5Hash = Digest.md5Hash(data, expectedReadSize);
-        if (md5Hash.equals(part.etag())) {
-          // this part is already uploaded
-          totalParts[partNumber - 1] = new Part(part.partNumber(), part.etag());
-          skipStream(data, expectedReadSize);
+        totalParts[partNumber - 1] = new Part(part.partNumber(), part.etag());
+        skipStream(data, expectedReadSize);
 
-          part = getPart(existingParts);
-
-          continue;
-        }
+        part = getPart(existingParts);
+        continue;
       }
 
       // In multi-part uploads, Set encryption headers in the case of SSE-C.


### PR DESCRIPTION
For Resuming the multipart the Etag was compared with md5, which were never equal and
thus every time new upload was done. The check has been removed so that upload can
skip the already uploaded part

Resolves the [issue](https://github.com/minio/minio-java/issues/738) 

For S3
```The ETag value returned by S3 for objects uploaded using the multipart upload API is computed differently than for objects uploaded with PUT object, and does not represent the MD5 of the object data, though it still uniquely represents the object.```
[Refer](https://forums.aws.amazon.com/thread.jspa?messageID=293789) 

