### PR TITLE
Add PutObject with custom Metadata sans Input stream Size

### DIFF
--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -559,7 +559,7 @@ public class MinioClientTest {
     String inputString = HELLO_WORLD;
     ByteArrayInputStream data = new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
 
-    client.putObject(BUCKET, "key", data, 11, APPLICATION_OCTET_STREAM);
+    client.putObject(BUCKET, "key", data, 11L, null, null, APPLICATION_OCTET_STREAM);
   }
 
   // this case only occurs for minio cloud storage
@@ -584,7 +584,7 @@ public class MinioClientTest {
     String inputString = HELLO_WORLD;
     ByteArrayInputStream data = new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
 
-    client.putObject(BUCKET, "key", data, 11, APPLICATION_OCTET_STREAM);
+    client.putObject(BUCKET, "key", data, 11L, null, null, APPLICATION_OCTET_STREAM);
     throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
   }
 
@@ -609,7 +609,7 @@ public class MinioClientTest {
     String inputString = "hello worl";
     ByteArrayInputStream data = new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
 
-    client.putObject(BUCKET, "key", data, 11, APPLICATION_OCTET_STREAM);
+    client.putObject(BUCKET, "key", data, 11L, null, null, APPLICATION_OCTET_STREAM);
     throw new RuntimeException(EXPECTED_EXCEPTION_DID_NOT_FIRE);
   }
 
@@ -638,7 +638,7 @@ public class MinioClientTest {
       ascii[i - 1] = (byte) i;
     }
     String contentType = null;
-    client.putObject(BUCKET, "世界" + new String(ascii, "UTF-8"), data, 11, contentType);
+    client.putObject(BUCKET, "世界" + new String(ascii, "UTF-8"), data, 11L, null, null, contentType);
   }
 
   @SuppressFBWarnings("NP")
@@ -662,7 +662,7 @@ public class MinioClientTest {
     ByteArrayInputStream data = new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
 
     String contentType = null;
-    client.putObject(BUCKET, "key", data, 11, contentType);
+    client.putObject(BUCKET, "key", data, 11L, null, null, contentType);
   }
 
   @Test
@@ -684,7 +684,7 @@ public class MinioClientTest {
     String inputString = HELLO_WORLD;
     ByteArrayInputStream data = new ByteArrayInputStream(inputString.getBytes(StandardCharsets.UTF_8));
 
-    client.putObject(BUCKET, "key", data, 11, APPLICATION_JAVASCRIPT);
+    client.putObject(BUCKET, "key", data, 11L, null, null, APPLICATION_JAVASCRIPT);
   }
 
   @Test
@@ -828,7 +828,7 @@ public class MinioClientTest {
     server.start();
 
     MinioClient client = new MinioClient(server.url("").toString(), "access_key", "secret_key", "us-east-1");
-    client.putObject(BUCKET, "key", new ByteArrayInputStream(new byte[]{'a'}), 1, headerMap);
+    client.putObject(BUCKET, "key", new ByteArrayInputStream(new byte[]{'a'}), 1L, headerMap, null, null);
 
     return server.takeRequest();
   }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1772,6 +1772,75 @@ StringBuilder builder = new StringBuilder();
  System.out.println("my-objectname is uploaded successfully");
 ```
 
+
+<a name="putObject"></a>
+### putObject(String bucketName, String objectName, InputStream stream, Map<String,String> headerMap)
+
+`public void putObject(String bucketName, String objectName, InputStream stream, long size, Map<String,String> headerMap)`
+Uploads data from given stream as object to given bucket with specified meta data.
+If the object is larger than 5MB, the client will automatically use a multipart session.
+
+If the session fails, the user may attempt to re-upload the object by attempting to create the exact same object again. The client will examine all parts of any current upload session and attempt to reuse the session automatically. If a mismatch is discovered, the upload will fail before uploading any more data. Otherwise, it will resume uploading where the session left off.
+
+If the multipart session fails, the user is responsible for resuming or removing the session.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#putObject-java.lang.String-java.io.InputStream-long-java.util.Map-)
+
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_  | Name of the bucket.  |
+| ``objectName``  | _String_  | Object name in the bucket. |
+| ``stream``  | _InputStream_  | stream to upload. |
+| ``headerMap``  | _Map<String,String>_  | Custom/additional meta data of the object. |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+|  None  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidArgumentException`` : upon invalid value is passed to a method.        |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+
+__Example__
+
+```java
+ StringBuilder builder = new StringBuilder();
+ for (int i = 0; i < 1000; i++) {
+   builder.append("Sphinx of black quartz, judge my vow: Used by Adobe InDesign to display font samples. ");
+   builder.append("(29 letters)\n");
+   builder.append("Jackdaws love my big sphinx of quartz: Similarly, used by Windows XP for some fonts. ");
+   builder.append("(31 letters)\n");
+   builder.append("Pack my box with five dozen liquor jugs: According to Wikipedia, this one is used on ");
+   builder.append("NASAs Space Shuttle. (32 letters)\n");
+   builder.append("The quick onyx goblin jumps over the lazy dwarf: Flavor text from an Unhinged Magic Card. ");
+   builder.append("(39 letters)\n");
+   builder.append("How razorback-jumping frogs can level six piqued gymnasts!: Not going to win any brevity ");
+   builder.append("awards at 49 letters long, but old-time Mac users may recognize it.\n");
+   builder.append("Cozy lummox gives smart squid who asks for job pen: A 41-letter tester sentence for Mac ");
+   builder.append("computers after System 7.\n");
+   builder.append("A few others we like: Amazingly few discotheques provide jukeboxes; Now fax quiz Jack! my ");
+   builder.append("brave ghost pled; Watch Jeopardy!, Alex Trebeks fun TV quiz game.\n");
+   builder.append("---\n");
+ }
+ ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
+ // create object
+ Map<String, String> headerMap = new HashMap<>();
+ headerMap.put("Content-Type", "application/octet-stream");
+ minioClient.putObject("my-bucketname", "my-objectname", bais, headerMap);
+ bais.close();
+ System.out.println("my-objectname is uploaded successfully");
+```
+
 <a name="putObject"></a>
 ### putObject(String bucketName, String objectName, InputStream stream, long size, Map<String,String> headerMap)
 
@@ -1838,6 +1907,7 @@ __Example__
  bais.close();
  System.out.println("my-objectname is uploaded successfully");
 ```
+
 <a name="putObject"></a>
 ### putObject(String bucketName, String objectName, InputStream stream, long size, Map<String, String> headerMap, SecretKey key)
  `public void putObject(String bucketName, String objectName, InputStream stream, long size, Map<String, String> headerMap,
@@ -1966,7 +2036,7 @@ try {
 
 
 <a name="putObject"></a>
-### putObject(String bucketName, String objectName,vServerSideEncryption sse, String fileName)
+### putObject(String bucketName, String objectName, ServerSideEncryption sse, String fileName)
 
 `public void putObject(String bucketName, String objectName, ServerSideEncryption sse, String fileName)`
 
@@ -2011,6 +2081,211 @@ try {
 } catch(MinioException e) {
   System.out.println("Error occurred: " + e);
 }
+```
+
+<a name="putObject"></a>
+### putObject(String bucketName, String objectName, InputStream stream, Map<String,String> headerMap, ServerSideEncryption sse)
+
+`public void putObject(String bucketName, String objectName, InputStream stream, Map<String,String> headerMap, ServerSideEncryption sse)`
+Uploads data from given stream as object to given bucket with specified meta data and encrypt with a sse key.
+If the object is larger than 5MB, the client will automatically use a multipart session.
+
+If the session fails, the user may attempt to re-upload the object by attempting to create the exact same object again. The client will examine all parts of any current upload session and attempt to reuse the session automatically. If a mismatch is discovered, the upload will fail before uploading any more data. Otherwise, it will resume uploading where the session left off.
+
+If the multipart session fails, the user is responsible for resuming or removing the session.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#putObject-java.lang.String-java.lang.String-java.util.Map-io.minio.ServerSideEncryption-)
+
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_  | Name of the bucket.  |
+| ``objectName``  | _String_  | Object name in the bucket. |
+| ``stream``  | _InputStream_  | stream to upload. |
+| ``headerMap``  | _Map<String,String>_  | Custom/additional meta data of the object. |
+| ``sse``  | _ServerSideEncryption_  | Form of server-side encryption [ServerSideEncryption](http://minio.github.io/minio-java/io/minio/ServerSideEncryption.html). |
+
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+|  None  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidArgumentException`` : upon invalid value is passed to a method.        |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+
+__Example__
+
+```java
+ StringBuilder builder = new StringBuilder();
+ for (int i = 0; i < 1000; i++) {
+   builder.append("Sphinx of black quartz, judge my vow: Used by Adobe InDesign to display font samples. ");
+   builder.append("(29 letters)\n");
+   builder.append("Jackdaws love my big sphinx of quartz: Similarly, used by Windows XP for some fonts. ");
+   builder.append("(31 letters)\n");
+   builder.append("Pack my box with five dozen liquor jugs: According to Wikipedia, this one is used on ");
+   builder.append("NASAs Space Shuttle. (32 letters)\n");
+   builder.append("The quick onyx goblin jumps over the lazy dwarf: Flavor text from an Unhinged Magic Card. ");
+   builder.append("(39 letters)\n");
+   builder.append("How razorback-jumping frogs can level six piqued gymnasts!: Not going to win any brevity ");
+   builder.append("awards at 49 letters long, but old-time Mac users may recognize it.\n");
+   builder.append("Cozy lummox gives smart squid who asks for job pen: A 41-letter tester sentence for Mac ");
+   builder.append("computers after System 7.\n");
+   builder.append("A few others we like: Amazingly few discotheques provide jukeboxes; Now fax quiz Jack! my ");
+   builder.append("brave ghost pled; Watch Jeopardy!, Alex Trebeks fun TV quiz game.\n");
+   builder.append("---\n");
+ }
+ ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
+ KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+ keyGen.init(256);
+ ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+ // create object
+ Map<String, String> headerMap = new HashMap<>();
+ headerMap.put("Content-Type", "application/octet-stream");
+ minioClient.putObject("my-bucketname", "my-objectname", bais, headerMap, sse);
+ bais.close();
+ System.out.println("my-objectname is uploaded successfully");
+```
+
+
+<a name="putObject"></a>
+### putObject(String bucketName, String objectName, String fileName, Long size, Map<String, String> headerMap, ServerSideEncryption sse, String contentType)
+
+`public void putObject(String bucketName, String objectName, String fileName, Long size, Map<String, String> headerMap, ServerSideEncryption sse, String contentType)`
+Uploads contents from a file as object to given bucket with specified meta data and encrypt with a sse key.
+If the object is larger than 5MB, the client will automatically use a multipart session.
+
+If the session fails, the user may attempt to re-upload the object by attempting to create the exact same object again. The client will examine all parts of any current upload session and attempt to reuse the session automatically. If a mismatch is discovered, the upload will fail before uploading any more data. Otherwise, it will resume uploading where the session left off.
+
+If the multipart session fails, the user is responsible for resuming or removing the session.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#putObject-java.lang.String-java.lang.String-java.lang.String-java.lang.Long-java.util.Map-io.minio.ServerSideEncryption-java.lang.String)
+
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_  | Name of the bucket.  |
+| ``fineName``  | _String_  | File name to upload. |
+| ``stream``  | _InputStream_  | stream to upload. |
+| ``size``  | _long_  | Size of the file. |
+| ``headerMap``  | _Map<String,String>_  | Custom/additional meta data of the object. |
+| ``sse``  | _ServerSideEncryption_  | Form of server-side encryption [ServerSideEncryption](http://minio.github.io/minio-java/io/minio/ServerSideEncryption.html). |
+| ``contentType``  | _String_ | File content type of the object, user supplied. |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+|  None  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidArgumentException`` : upon invalid value is passed to a method.        |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+
+__Example__
+
+```java
+try {
+  KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+  keyGen.init(256);
+  ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+  Map<String, String> headerMap = new HashMap<>();
+  headerMap.put("my-custom-data", "foo");
+  minioClient.putObject("mybucket",  "island.jpg", "/mnt/photos/island.jpg",headerMap,sse, "application/octet-stream" );
+  System.out.println("island.jpg is uploaded successfully");
+} catch(MinioException e) {
+  System.out.println("Error occurred: " + e);
+}
+
+
+<a name="putObject"></a>
+### putObject(String bucketName, String objectName, InputStream stream, Long size, Map<String, String> headerMap, ServerSideEncryption sse, String contentType)
+
+`public void putObject(String bucketName, String objectName, InputStream stream, Long size, Map<String, String> headerMap, ServerSideEncryption sse, String contentType)`
+Uploads data from given stream as object to given bucket with specified meta data and encrypt with a sse key.
+If the object is larger than 5MB, the client will automatically use a multipart session.
+
+If the session fails, the user may attempt to re-upload the object by attempting to create the exact same object again. The client will examine all parts of any current upload session and attempt to reuse the session automatically. If a mismatch is discovered, the upload will fail before uploading any more data. Otherwise, it will resume uploading where the session left off.
+
+If the multipart session fails, the user is responsible for resuming or removing the session.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#putObject-java.lang.String-java.lang.String-java.io.InputStream-java.util.Map-io.minio.ServerSideEncryption-java.lang.String)
+
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_  | Name of the bucket.  |
+| ``objectName``  | _String_  | Object name in the bucket. |
+| ``stream``  | _InputStream_  | stream to upload. |
+| ``size``  | _long_  | Size of the data to read from ``stream`` that will be uploaded. |
+| ``headerMap``  | _Map<String,String>_  | Custom/additional meta data of the object. |
+| ``sse``  | _ServerSideEncryption_  | Form of server-side encryption [ServerSideEncryption](http://minio.github.io/minio-java/io/minio/ServerSideEncryption.html). |
+| ``contentType``  | _String_ | File content type of the object, user supplied. |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+|  None  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidArgumentException`` : upon invalid value is passed to a method.        |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+
+__Example__
+
+```java
+ StringBuilder builder = new StringBuilder();
+ for (int i = 0; i < 1000; i++) {
+   builder.append("Sphinx of black quartz, judge my vow: Used by Adobe InDesign to display font samples. ");
+   builder.append("(29 letters)\n");
+   builder.append("Jackdaws love my big sphinx of quartz: Similarly, used by Windows XP for some fonts. ");
+   builder.append("(31 letters)\n");
+   builder.append("Pack my box with five dozen liquor jugs: According to Wikipedia, this one is used on ");
+   builder.append("NASAs Space Shuttle. (32 letters)\n");
+   builder.append("The quick onyx goblin jumps over the lazy dwarf: Flavor text from an Unhinged Magic Card. ");
+   builder.append("(39 letters)\n");
+   builder.append("How razorback-jumping frogs can level six piqued gymnasts!: Not going to win any brevity ");
+   builder.append("awards at 49 letters long, but old-time Mac users may recognize it.\n");
+   builder.append("Cozy lummox gives smart squid who asks for job pen: A 41-letter tester sentence for Mac ");
+   builder.append("computers after System 7.\n");
+   builder.append("A few others we like: Amazingly few discotheques provide jukeboxes; Now fax quiz Jack! my ");
+   builder.append("brave ghost pled; Watch Jeopardy!, Alex Trebeks fun TV quiz game.\n");
+   builder.append("---\n");
+ }
+ ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
+ KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+ keyGen.init(256);
+ ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+ // create object
+ Map<String, String> headerMap = new HashMap<>();
+ headerMap.put("my-custom-data", "foo");
+ minioClient.putObject("my-bucketname", "my-objectname", bais, bias.available(), headerMap, sse, contentType);
+ bais.close();
+ System.out.println("my-objectname is uploaded successfully");
 ```
 
 

--- a/examples/CopyObject.java
+++ b/examples/CopyObject.java
@@ -65,7 +65,8 @@ public class CopyObject {
       ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
 
       // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), "application/octet-stream");
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, null,
+              "application/octet-stream");
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 

--- a/examples/CopyObjectEncrypted.java
+++ b/examples/CopyObjectEncrypted.java
@@ -61,7 +61,7 @@ public class CopyObjectEncrypted {
       ServerSideEncryption sseTarget = ServerSideEncryption.withCustomerKey(secretKeySpecTarget);
         
       // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), ssePut);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, ssePut, null);
       System.out.println("my-objectname is uploaded successfully");
         
       minioClient.copyObject("my-bucketname", "my-objectname", sseSource, "my-destbucketname",

--- a/examples/CopyObjectEncryptedKms.java
+++ b/examples/CopyObjectEncryptedKms.java
@@ -57,7 +57,7 @@ public class CopyObjectEncryptedKms {
       ServerSideEncryption sse = ServerSideEncryption.withManagedKeys("Key-Id", myContext);
         
       // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), sse);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, sse, null);
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 

--- a/examples/CopyObjectEncryptedS3.java
+++ b/examples/CopyObjectEncryptedS3.java
@@ -51,7 +51,7 @@ public class CopyObjectEncryptedS3 {
       ServerSideEncryption sse = ServerSideEncryption.atRest();
         
       // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), sse);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, sse, null);
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 

--- a/examples/CopyObjectMetadata.java
+++ b/examples/CopyObjectMetadata.java
@@ -67,7 +67,8 @@ public class CopyObjectMetadata {
       ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
 
       // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), "application/octet-stream");
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()),null, null,
+              "application/octet-stream");
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 

--- a/examples/PutGetObjectEncrypted.java
+++ b/examples/PutGetObjectEncrypted.java
@@ -61,7 +61,7 @@ public class PutGetObjectEncrypted {
       // To test SSE-C
       ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
 
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), sse);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()),null, sse, null);
         
       bais.close();
 

--- a/examples/PutGetObjectEncryptedFile.java
+++ b/examples/PutGetObjectEncryptedFile.java
@@ -3,12 +3,14 @@ import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
 
+
 import javax.crypto.KeyGenerator;
 import org.xmlpull.v1.XmlPullParserException;
 
 import io.minio.MinioClient;
 import io.minio.ServerSideEncryption;
 import io.minio.errors.MinioException;
+
 
 public class PutGetObjectEncryptedFile {
 /**
@@ -36,7 +38,7 @@ public class PutGetObjectEncryptedFile {
 
       // To test SSE-C
       ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
-      minioClient.putObject(bucketName, objectName, sse, inputfile);
+      minioClient.putObject(bucketName, objectName, inputfile, null, null, sse, null);
       System.out.println("my-objectname is encrypted and uploaded successfully.");
 
       minioClient.getObject(bucketName, objectName, sse, outputfile);

--- a/examples/PutObject.java
+++ b/examples/PutObject.java
@@ -64,7 +64,8 @@ public class PutObject {
       ByteArrayInputStream bais = new ByteArrayInputStream(builder.toString().getBytes("UTF-8"));
 
       // Create object 'my-objectname' in 'my-bucketname' with content from the input stream.
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), "application/octet-stream");
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, null,
+              "application/octet-stream");
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
     } catch (MinioException e) {

--- a/examples/PutObjectEncryptedKms.java
+++ b/examples/PutObjectEncryptedKms.java
@@ -56,7 +56,7 @@ public class PutObjectEncryptedKms {
       // To test SSE-KMS
       ServerSideEncryption sse = ServerSideEncryption.withManagedKeys("Key-Id", myContext);
 
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), sse);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, sse, null);
             
       bais.close();
 

--- a/examples/PutObjectEncryptedS3.java
+++ b/examples/PutObjectEncryptedS3.java
@@ -52,7 +52,7 @@ public class PutObjectEncryptedS3 {
       // To test SSE-S3
       ServerSideEncryption sse = ServerSideEncryption.atRest();
       
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), sse);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, sse, null);
         
       bais.close();
     

--- a/examples/PutObjectProgressBar.java
+++ b/examples/PutObjectProgressBar.java
@@ -59,7 +59,8 @@ public class PutObjectProgressBar {
     InputStream pis = new BufferedInputStream(new ProgressStream("Uploading... ",
                                                                  ProgressBarStyle.ASCII,
                                                                  new FileInputStream(file)));
-    minioClient.putObject(bucketName, objectName, pis, pis.available(), "application/octet-stream");
+    minioClient.putObject(bucketName, objectName, pis, Long.valueOf(pis.available()), null, null,
+            "application/octet-stream");
     pis.close();
     System.out.println("my-objectname is uploaded successfully");
   }

--- a/examples/PutObjectUiProgressBar.java
+++ b/examples/PutObjectUiProgressBar.java
@@ -93,7 +93,8 @@ public class PutObjectUiProgressBar extends JFrame {
           bis);
 
       pmis.getProgressMonitor().setMillisToPopup(10);
-      minioClient.putObject("bank", "my-objectname", pmis, bis.available(), "application/octet-stream");
+      minioClient.putObject("bank", "my-objectname", pmis, Long.valueOf(pmis.available()), null, null,
+              "application/octet-stream");
       System.out.println("my-objectname is uploaded successfully");
     } catch (FileNotFoundException e) {
       // TODO Auto-generated catch block

--- a/examples/PutObjectWithMetadata.java
+++ b/examples/PutObjectWithMetadata.java
@@ -78,7 +78,8 @@ public class PutObjectWithMetadata {
       headerMap.put("X-Amz-Storage-Class", "REDUCED_REDUNDANCY");
 
       // Create object 'my-objectname' in 'my-bucketname' with custom metadata in headerMap
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), headerMap); 
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), headerMap,
+              null, null);
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
     } catch (MinioException e) {

--- a/examples/PutStatObjectEncrypted.java
+++ b/examples/PutStatObjectEncrypted.java
@@ -59,7 +59,7 @@ public class PutStatObjectEncrypted {
       // To test SSE-C
       ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
         
-      minioClient.putObject("my-bucketname", "my-objectname", bais, bais.available(), sse);
+      minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, sse, null);
       
       bais.close();
 

--- a/examples/UploadObject.java
+++ b/examples/UploadObject.java
@@ -20,6 +20,9 @@ import java.security.InvalidKeyException;
 
 import org.xmlpull.v1.XmlPullParserException;
 
+import static java.nio.file.StandardOpenOption.*;
+import java.nio.file.*;
+
 import io.minio.MinioClient;
 import io.minio.errors.MinioException;
 
@@ -39,7 +42,7 @@ public class UploadObject {
       //                                           "YOUR-SECRETACCESSKEY");
 
       // Upload 'my-filename' as object 'my-objectname' in 'my-bucketname'.
-      minioClient.putObject("my-bucketname", "my-objectname", "my-filename");
+      minioClient.putObject("my-bucketname", "my-objectname", "my-filename", null, null, null, null);
       System.out.println("my-filename is uploaded to my-objectname successfully");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -414,7 +414,7 @@ public class FunctionalTest {
     long startTime = System.currentTimeMillis();
     try {
       String filename = createFile1Kb();
-      client.putObject(bucketName, filename, filename);
+      client.putObject(bucketName, filename, filename, null, null, null, null);
       Files.delete(Paths.get(filename));
       client.removeObject(bucketName, filename);
       mintSuccessLog("putObject(String bucketName, String objectName, String filename)", "filename: 1KB", startTime);
@@ -437,12 +437,12 @@ public class FunctionalTest {
     long startTime = System.currentTimeMillis();
     try {
       String filename = createFile6Mb();
-      client.putObject(bucketName, filename, filename);
+      client.putObject(bucketName, filename, filename, null, null, null , null);
       Files.delete(Paths.get(filename));
       client.removeObject(bucketName, filename);
-      mintSuccessLog("putObject(String bucketName, String objectName, String filename)", "filename: 65MB", startTime);
+      mintSuccessLog("putObject(String bucketName, String objectName, String filename)", "filename: 6MB", startTime);
     } catch (Exception e) {
-      mintFailedLog("putObject(String bucketName, String objectName, String filename)", "filename: 65MB", startTime,
+      mintFailedLog("putObject(String bucketName, String objectName, String filename)", "filename: 6MB", startTime,
           null, e.toString() + " >>> " + Arrays.toString(e.getStackTrace()));
       throw e;
     }
@@ -461,7 +461,7 @@ public class FunctionalTest {
     long startTime = System.currentTimeMillis();
     try {
       String filename = createFile1Kb();
-      client.putObject(bucketName, filename, filename, customContentType);
+      client.putObject(bucketName, filename, filename, null, null, null, customContentType);
       Files.delete(Paths.get(filename));
       client.removeObject(bucketName, filename);
       mintSuccessLog("putObject(String bucketName, String objectName, String filename, String contentType)",
@@ -488,7 +488,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, customContentType);
+        client.putObject(bucketName, objectName, is , Long.valueOf(1 * KB), null, null,customContentType);
       }
 
       client.removeObject(bucketName, objectName);
@@ -517,7 +517,7 @@ public class FunctionalTest {
     try {
       String objectName = "/path/to/" + getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, customContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB), null, null,customContentType);
       }
       client.removeObject(bucketName, objectName);
       mintSuccessLog(
@@ -545,7 +545,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(size)) {
-        client.putObject(bucketName, objectName, is, customContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(is.available()), null, null,customContentType);
       }
 
       client.removeObject(bucketName, objectName);
@@ -592,7 +592,7 @@ public class FunctionalTest {
       Map<String, String> headerMap = new HashMap<>();
       headerMap.put("Content-Type", customContentType);
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, headerMap);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB), headerMap, null, null);
       }
 
       client.removeObject(bucketName, objectName);
@@ -628,7 +628,7 @@ public class FunctionalTest {
       headerMap.put("Content-Type", customContentType);
       headerMap.put("X-Amz-Storage-Class", storageClass);
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, headerMap);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB), headerMap, null, null);
       }
 
       ObjectStat objectStat = client.statObject(bucketName, objectName);
@@ -670,7 +670,7 @@ public class FunctionalTest {
       headerMap.put("Content-Type", customContentType);
       headerMap.put("X-Amz-Storage-Class", storageClass);
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, headerMap);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB), headerMap, null, null);
       }
 
       ObjectStat objectStat = client.statObject(bucketName, objectName);
@@ -716,7 +716,7 @@ public class FunctionalTest {
       headerMap.put("X-Amz-Storage-Class", storageClass);
 
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, headerMap);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB), headerMap, null, null);
       } catch (ErrorResponseException e) {
         if (!e.errorResponse().code().equals("InvalidStorageClass")) {
           throw e;
@@ -754,7 +754,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, sse);
+        client.putObject(bucketName, objectName,  is, Long.valueOf(1 * KB), null, sse, null);
       }
 
       client.removeObject(bucketName, objectName);
@@ -786,7 +786,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, sse);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB),null, sse,null);
       }
 
       client.removeObject(bucketName, objectName);
@@ -826,7 +826,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, sse);
+        client.putObject(bucketName, objectName, is , Long.valueOf(1 * KB), null, sse, null);
       }
 
       client.removeObject(bucketName, objectName);
@@ -860,7 +860,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(6 * MB)) {
-        client.putObject(bucketName, objectName, is, 6 * MB, sse);
+        client.putObject(bucketName, objectName, is, Long.valueOf(6 * MB), null, sse, null);
       }
 
       client.removeObject(bucketName, objectName);
@@ -895,7 +895,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       String filename = createFile1Kb();
-      client.putObject(bucketName, objectName, sse, filename);
+      client.putObject(bucketName, objectName,filename, null, null, sse, null);
       Files.delete(Paths.get(filename));
       client.removeObject(bucketName, objectName);
 
@@ -925,7 +925,7 @@ public class FunctionalTest {
       headerMap.put("Content-Type", customContentType);
       headerMap.put("my-custom-data", "foo");
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, headerMap);
+        client.putObject(bucketName, objectName, is, 1L, headerMap, null, customContentType);
       }
 
       ObjectStat objectStat = client.statObject(bucketName, objectName);
@@ -975,7 +975,7 @@ public class FunctionalTest {
       ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
 
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, sse);
+        client.putObject(bucketName, objectName, is, 1L, null, sse, null);
       }
 
       ObjectStat objectStat = client.statObject(bucketName, objectName, sse);
@@ -1019,7 +1019,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB), null, null, nullContentType);
       }
 
       client.getObject(bucketName, objectName).close();
@@ -1045,7 +1045,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB),null, null, nullContentType);
       }
 
       client.getObject(bucketName, objectName, 1000L).close();
@@ -1071,7 +1071,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(6 * MB)) {
-        client.putObject(bucketName, objectName, is, 6 * MB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 6 * MB), null, null, nullContentType);
       }
 
       client.getObject(bucketName, objectName, 1000L, 64 * 1024L).close();
@@ -1097,7 +1097,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB),null, null, nullContentType);
       }
 
       client.getObject(bucketName, objectName, objectName + ".downloaded");
@@ -1127,7 +1127,7 @@ public class FunctionalTest {
     String objectName = "path/to/" + baseObjectName;
     try {
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB),null, null, nullContentType);
       }
 
       client.getObject(bucketName, objectName, baseObjectName + ".downloaded");
@@ -1155,7 +1155,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(0)) {
-        client.putObject(bucketName, objectName, is, 0, nullContentType);
+        client.putObject(bucketName, objectName, is, 0L, null, null , nullContentType);
       }
 
       client.getObject(bucketName, objectName).close();
@@ -1189,7 +1189,7 @@ public class FunctionalTest {
       int bytes_read_put;
       try (final InputStream is = new ContentInputStream(1 * KB)) {
 
-        client.putObject(bucketName, objectName, is, 1 * KB, sse);
+        client.putObject(bucketName, objectName, is, Long.valueOf(1 * KB),null, sse, null);
         byte[] putbyteArray = new byte[is.available()];
         bytes_read_put = is.read(putbyteArray);
         putString = new String(putbyteArray, StandardCharsets.UTF_8);
@@ -1232,7 +1232,7 @@ public class FunctionalTest {
     final String objectName = getRandomName();
     try {
       try (final InputStream is = new ContentInputStream(fullLength)) {
-        client.putObject(bucketName, objectName, is, fullLength, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf(fullLength),null, null, nullContentType);
       }
 
       try (final InputStream partialObjectStream = client.getObject(bucketName, objectName, offset,
@@ -1275,7 +1275,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       String filename = createFile1Kb();
-      client.putObject(bucketName, objectName, sse, filename);
+      client.putObject(bucketName, objectName, filename, null, null, sse, null);
       client.getObject(bucketName, objectName, sse, objectName + ".downloaded");
       Files.delete(Paths.get(objectName + ".downloaded"));
       client.removeObject(bucketName, objectName);
@@ -1306,7 +1306,7 @@ public class FunctionalTest {
       for (i = 0; i < 3; i++) {
         objectNames[i] = getRandomName();
         try (final InputStream is = new ContentInputStream(1)) {
-          client.putObject(bucketName, objectNames[i], is, 1, nullContentType);
+          client.putObject(bucketName, objectNames[i], is, 1L, null, null, nullContentType);
         }
       }
 
@@ -1345,7 +1345,7 @@ public class FunctionalTest {
       for (i = 0; i < 3; i++) {
         objectNames[i] = getRandomName();
         try (final InputStream is = new ContentInputStream(1)) {
-          client.putObject(bucketName, objectNames[i], is, 1, nullContentType);
+          client.putObject(bucketName, objectNames[i], is, 1L, null, null, nullContentType);
         }
       }
 
@@ -1384,7 +1384,7 @@ public class FunctionalTest {
       for (i = 0; i < 3; i++) {
         objectNames[i] = getRandomName();
         try (final InputStream is = new ContentInputStream(1)) {
-          client.putObject(bucketName, objectNames[i], is, 1, nullContentType);
+          client.putObject(bucketName, objectNames[i], is, 1L, null, null, nullContentType);
         }
       }
 
@@ -1456,7 +1456,7 @@ public class FunctionalTest {
       for (i = 0; i < objCount; i++) {
         objectNames[i] = getRandomName();
         try (final InputStream is = new ContentInputStream(1)) {
-          client.putObject(bucketName, objectNames[i], is, 1, nullContentType);
+          client.putObject(bucketName, objectNames[i], is , 1L, null, null, nullContentType);
         }
       }
 
@@ -1501,7 +1501,7 @@ public class FunctionalTest {
       for (i = 0; i < 3; i++) {
         objectNames[i] = getRandomName();
         try (final InputStream is = new ContentInputStream(1)) {
-          client.putObject(bucketName, objectNames[i], is, 1, nullContentType);
+          client.putObject(bucketName, objectNames[i], is, 1L, null, null, nullContentType);
         }
       }
 
@@ -1543,7 +1543,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, nullContentType);
+        client.putObject(bucketName, objectName, is, 1L, null, null, nullContentType);
       }
 
       client.removeObject(bucketName, objectName);
@@ -1570,7 +1570,7 @@ public class FunctionalTest {
       for (int i = 0; i < 3; i++) {
         objectNames[i] = getRandomName();
         try (final InputStream is = new ContentInputStream(1)) {
-          client.putObject(bucketName, objectNames[i], is, 1, nullContentType);
+          client.putObject(bucketName, objectNames[i], is, 1L, null, null, nullContentType);
         }
       }
       objectNames[3] = "nonexistent-object";
@@ -1598,7 +1598,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(6 * MB)) {
-        client.putObject(bucketName, objectName, is, 9 * MB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 9 * MB), null, null, nullContentType);
       } catch (ErrorResponseException e) {
         if (!e.errorResponse().code().equals("IncompleteBody")) {
           throw e;
@@ -1636,7 +1636,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(6 * MB)) {
-        client.putObject(bucketName, objectName, is, 9 * MB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 9 * MB), null, null, nullContentType);
       } catch (ErrorResponseException e) {
         if (!e.errorResponse().code().equals("IncompleteBody")) {
           throw e;
@@ -1676,7 +1676,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(6 * MB)) {
-        client.putObject(bucketName, objectName, is, 9 * MB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 9 * MB), null, null, nullContentType);
       } catch (ErrorResponseException e) {
         if (!e.errorResponse().code().equals("IncompleteBody")) {
           throw e;
@@ -1716,7 +1716,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(6 * MB)) {
-        client.putObject(bucketName, objectName, is, 9 * MB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 9 * MB), null, null, nullContentType);
       } catch (ErrorResponseException e) {
         if (!e.errorResponse().code().equals("IncompleteBody")) {
           throw e;
@@ -1754,7 +1754,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       byte[] inBytes;
@@ -1791,7 +1791,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       byte[] inBytes;
@@ -1827,7 +1827,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       byte[] inBytes;
@@ -2005,7 +2005,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2038,7 +2038,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2083,7 +2083,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2125,7 +2125,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2168,7 +2168,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName,  is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2216,7 +2216,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2260,7 +2260,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, nullContentType);
+        client.putObject(bucketName, objectName, is, Long.valueOf( 1 * KB), null, null, nullContentType);
       }
 
       String destBucketName = getRandomName();
@@ -2311,7 +2311,7 @@ public class FunctionalTest {
     try {
       String objectName = getRandomName();
       try (final InputStream is = new ContentInputStream(1 * KB)) {
-        client.putObject(bucketName, objectName, is, 1 * KB, "application/octet-stream");
+        client.putObject(bucketName, objectName,  is, Long.valueOf( 1 * KB), null, null, "application/octet-stream");
       }
 
       String destBucketName = getRandomName();
@@ -2362,7 +2362,7 @@ public class FunctionalTest {
       headerMap.put("Test", "testValue");
 
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, headerMap);
+        client.putObject(bucketName, objectName,  is, 1L, headerMap, null, null);
       }
 
       // Attempt to remove the user-defined metadata from the object
@@ -2415,7 +2415,7 @@ public class FunctionalTest {
       ServerSideEncryption sseTarget = ServerSideEncryption.withCustomerKey(secretKeySpecTarget);
 
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, ssePut);
+        client.putObject(bucketName, objectName, is, 1L, null, ssePut, null);
       }
 
       // Attempt to remove the user-defined metadata from the object
@@ -2456,7 +2456,7 @@ public class FunctionalTest {
       ServerSideEncryption sse = ServerSideEncryption.atRest();
 
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, sse);
+        client.putObject(bucketName, objectName,is, 1L, null, sse, null);
       }
 
       // Attempt to remove the user-defined metadata from the object
@@ -2508,7 +2508,7 @@ public class FunctionalTest {
       ServerSideEncryption sse = ServerSideEncryption.withManagedKeys("keyId", myContext);
 
       try (final InputStream is = new ContentInputStream(1)) {
-        client.putObject(bucketName, objectName, is, 1, sse);
+        client.putObject(bucketName, objectName, is, 1L, null, sse, null);
       }
 
       // Attempt to remove the user-defined metadata from the object
@@ -2888,7 +2888,7 @@ public class FunctionalTest {
       // in a loop because bucket listening is called in a thread
       // and may or may not be executed at this point.
       for (int i = 0; i < 20; i++) {
-        client.putObject(bucketName, "prefix-random-suffix", file);
+        client.putObject(bucketName, "prefix-random-suffix", file,null,null,null, null);
         Thread.sleep(500);
         if (bl.eventsReceived > 0 || bl.lastException != null) {
           break;

--- a/functional/PutObjectRunnable.java
+++ b/functional/PutObjectRunnable.java
@@ -38,7 +38,7 @@ class PutObjectRunnable implements Runnable {
 
     try {
       traceBuffer.append("[" + filename + "]: threaded put object\n");
-      client.putObject(bucketName, filename, filename);
+      client.putObject(bucketName, filename, filename, null, null, null, null);
       traceBuffer.append("[" + filename + "]: delete file\n");
       Files.delete(Paths.get(filename));
       traceBuffer.append("[" + filename + "]: delete object\n");


### PR DESCRIPTION
All variance of putObject is deprecated and two new versions are added.

1.  For Streams
```  
public void putObject(String bucketName, String objectName, InputStream data, Long size, Map<String, String> headerMap, ServerSideEncryption sse, String contentType) 
```
2.  For files
```  
public void putObject(String bucketName, String objectName, String fileName,  Long size, Map<String, String> headerMap, ServerSideEncryption sse, String contentType)
```

Fixes #662 
Fixes #745
