### PR TITLE
Set prefix, delimiter params even when empty

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1,6 +1,6 @@
 /*
  * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017 Minio, Inc.
+ * (C) 2015, 2016, 2017, 2018, 2019 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3019,10 +3019,14 @@ public class MinioClient {
 
     if (prefix != null) {
       queryParamMap.put("prefix", prefix);
+    } else {
+      queryParamMap.put("prefix", "");
     }
 
     if (delimiter != null) {
       queryParamMap.put("delimiter", delimiter);
+    } else {
+      queryParamMap.put("delimiter", "");
     }
 
     HttpResponse response = executeGet(bucketName, null, null, queryParamMap);
@@ -3186,10 +3190,14 @@ public class MinioClient {
 
     if (prefix != null) {
       queryParamMap.put("prefix", prefix);
+    } else {
+      queryParamMap.put("prefix", "");
     }
 
     if (delimiter != null) {
       queryParamMap.put("delimiter", delimiter);
+    } else {
+      queryParamMap.put("delimiter", "");
     }
 
     HttpResponse response = executeGet(bucketName, null, null, queryParamMap);
@@ -4672,10 +4680,26 @@ public class MinioClient {
     Map<String,String> queryParamMap = new HashMap<>();
     queryParamMap.put("uploads", "");
     queryParamMap.put("max-uploads", Integer.toString(maxUploads));
-    queryParamMap.put("prefix", prefix);
-    queryParamMap.put("key-marker", keyMarker);
-    queryParamMap.put("upload-id-marker", uploadIdMarker);
-    queryParamMap.put("delimiter", delimiter);
+
+    if (prefix != null) {
+      queryParamMap.put("prefix", prefix);
+    } else {
+      queryParamMap.put("prefix", "");
+    }
+
+    if (delimiter != null) {
+      queryParamMap.put("delimiter", delimiter);
+    } else {
+      queryParamMap.put("delimiter", "");
+    }
+
+    if (keyMarker != null) {
+      queryParamMap.put("key-marker", keyMarker);
+    }
+
+    if (uploadIdMarker != null) {
+      queryParamMap.put("upload-id-marker", uploadIdMarker);
+    }
 
     HttpResponse response = executeGet(bucketName, null, null, queryParamMap);
 


### PR DESCRIPTION
We have never set values which are empty on the request
because they are perhaps not useful in the List query,
but this assumption is wrong when there are restricted
policies for a given user, because empty is actually
a valid value in IAM or Bucket policy conditions.

For example following condition would never work with our
ListObjects call and AWS cli would work fine.

            "Condition": {
                "StringEquals": {
                    "s3:prefix": [
                        "",
                        "data/",
                        "data"
                    ],
                    "s3:delimiter": [
                        "/",
                        ""
                    ]
                }
            }

The reason is empty or not prefix and delimiter should be
added to the query param in List operation, such that server
can use the value to validate the policies for the incoming
request.

Refer minio/minio-go#1064