### PR TITLE
Fix: update starting position of buffer in ChunkedInputStream.readData()

### DIFF
--- a/api/src/main/java/io/minio/ChunkedInputStream.java
+++ b/api/src/main/java/io/minio/ChunkedInputStream.java
@@ -111,7 +111,7 @@ class ChunkedInputStream extends InputStream {
       }
 
       totalBytesRead += bytesRead;
-      pos = bytesRead;
+      pos += bytesRead;
       len = buf.length - totalBytesRead;
     }
 


### PR DESCRIPTION
When Input Stream is Network, the data uploaded
was wrong. This PR fixes this ambiguity.

[Fixes ](https://github.com/minio/minio-java/issues/744)