### PR TITLE
remove java-photo-api-service links from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ The full API Reference is available here.
 ## Explore Further
 * [Complete Documentation](https://docs.minio.io)
 * [Minio Java Client SDK API Reference](https://docs.minio.io/docs/java-client-api-reference)
-* [Build your own Photo API Service - Full Application Example ](https://docs.minio.io/docs/java-photo-api-service)
 
 ## Contribute
 [Contributors Guide](https://github.com/minio/minio-java/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The full API Reference is available here.
 ## Explore Further
 * [Complete Documentation](https://docs.minio.io)
 * [Minio Java Client SDK API Reference](https://docs.minio.io/docs/java-client-api-reference)
+* [Build your own Photo API Service - Full Application Example ](https://github.com/minio/minio-java-rest-example)
 
 ## Contribute
 [Contributors Guide](https://github.com/minio/minio-java/blob/master/CONTRIBUTING.md)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -157,7 +157,6 @@ mc ls play/asiatrip/
 ## 了解更多
 * [Minio官方文档](https://docs.minio.io)
 * [Minio Java Client SDK API文档](https://docs.minio.io/docs/java-client-api-reference)
-* [创建属于你的照片API服务-完整示例](https://docs.minio.io/docs/java-photo-api-service)
 
 ## 贡献
 [贡献者指南](https://github.com/minio/minio-java/blob/master/docs/zh_CN/CONTRIBUTING.md)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -157,6 +157,7 @@ mc ls play/asiatrip/
 ## 了解更多
 * [Minio官方文档](https://docs.minio.io)
 * [Minio Java Client SDK API文档](https://docs.minio.io/docs/java-client-api-reference)
+* [创建属于你的照片API服务-完整示例](https://github.com/minio/minio-java-rest-example)
 
 ## 贡献
 [贡献者指南](https://github.com/minio/minio-java/blob/master/docs/zh_CN/CONTRIBUTING.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -2763,4 +2763,4 @@ try {
 ## 5. Explore Further
 
 - [Build your own Photo API Service - Full Application Example ](https://github.com/minio/minio-java-rest-example)
-- [Complete JavaDoc](http://minio.github.io/minio-java/io/minio/MinioClient.html)
+- [Complete JavaDoc](http://minio.github.io/minio-java/)

--- a/docs/API.md
+++ b/docs/API.md
@@ -2762,4 +2762,5 @@ try {
 
 ## 5. Explore Further
 
+- [Build your own Photo API Service - Full Application Example ](https://github.com/minio/minio-java-rest-example)
 - [Complete JavaDoc](http://minio.github.io/minio-java/io/minio/MinioClient.html)

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -1442,6 +1442,5 @@ try {
 
 ## 5. 了解更多
 
-
-- [创建属于你的照片API服务示例](https://docs.minio.io/docs/java-photo-api-service)
+- [创建属于你的照片API服务示例](https://github.com/minio/minio-java-rest-example)
 - [完整的JavaDoc](http://minio.github.io/minio-java/)


### PR DESCRIPTION
The page is no longer available
https://docs.minio.io/docs/java-photo-api-service