### PR TITLE
Replaces Minio refs with MinIO and minio.io links with min.io

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,7 +32,7 @@ EOF
 ```
 
 #### Upload to maven
-Upload all artifacts belonging to `io.minio` artifact repository, additionally this step requires you to have access toMinIO's trusted private key.
+Upload all artifacts belonging to `io.minio` artifact repository, additionally this step requires you to have access to MinIO's trusted private key.
 ```sh
 $ ./gradlew uploadArchives
 ```

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,7 +44,7 @@ $ ./gradlew closeAndReleaseRepository
 ```
 
 ### Tag
-Tag and sign your release commit, additionally this step requires you to have access toMinIO's trusted private key.
+Tag and sign your release commit, additionally this step requires you to have access to MinIO's trusted private key.
 ```
 $ export GNUPGHOME=/media/${USER}/Minio2/trusted
 $ git tag -s 0.3.0

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,7 +32,7 @@ EOF
 ```
 
 #### Upload to maven
-Upload all artifacts belonging to `io.minio` artifact repository, additionally this step requires you to have access to Minio's trusted private key.
+Upload all artifacts belonging to `io.minio` artifact repository, additionally this step requires you to have access toMinIO's trusted private key.
 ```sh
 $ ./gradlew uploadArchives
 ```
@@ -44,7 +44,7 @@ $ ./gradlew closeAndReleaseRepository
 ```
 
 ### Tag
-Tag and sign your release commit, additionally this step requires you to have access to Minio's trusted private key.
+Tag and sign your release commit, additionally this step requires you to have access toMinIO's trusted private key.
 ```
 $ export GNUPGHOME=/media/${USER}/Minio2/trusted
 $ git tag -s 0.3.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Minio Java SDK for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+#MinIO Java SDK for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-The Minio Java Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
+TheMinIO Java Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
 
-This quickstart guide will show you how to install the client SDK and execute an example java program. For a complete list of APIs and examples, please take a look at the [Java Client API Reference](http://docs.minio.io/docs/java-client-api-reference) documentation.
+This quickstart guide will show you how to install the client SDK and execute an example java program. For a complete list of APIs and examples, please take a look at the [Java Client API Reference](http://docs.min.io/docs/java-client-api-reference) documentation.
 
 ## Minimum Requirements
 Java 1.8 or above, with one of the following environments:
@@ -40,7 +40,7 @@ You need three items in order to connect to an object storage server.
 | Access Key    | Access key is like user ID that uniquely identifies your account.   |
 | Secret Key     | Secret key is the password to your account.    |
 
-For the following example, we will use a freely hosted Minio server running at [https://play.minio.io:9000](https://play.minio.io:9000). Feel free to use this service for test and development. Access credentials shown in this example are open to the public.
+For the following example, we will use a freely hostedMinIO server running at [https://play.min.io:9000](https://play.min.io:9000). Feel free to use this service for test and development. Access credentials shown in this example are open to the public.
 
 #### FileUploader.java
 ```java
@@ -56,8 +56,8 @@ import io.minio.errors.MinioException;
 public class FileUploader {
   public static void main(String[] args) throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
-      // Create a minioClient with the Minio Server name, Port, Access key and Secret key.
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+      // Create a minioClient with theMinIO Server name, Port, Access key and Secret key.
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       // Check if the bucket already exists.
       boolean isExist = minioClient.bucketExists("asiatrip");
@@ -95,32 +95,32 @@ mc ls play/asiatrip/
 ## API Reference
 The full API Reference is available here.
 
-* [Complete API Reference](https://docs.minio.io/docs/java-client-api-reference)
+* [Complete API Reference](https://docs.min.io/docs/java-client-api-reference)
 
 ### API Reference: Bucket Operations
-* [`makeBucket`](https://docs.minio.io/docs/java-client-api-reference#makeBucket)
-* [`listBuckets`](https://docs.minio.io/docs/java-client-api-reference#listBuckets)
-* [`bucketExists`](https://docs.minio.io/docs/java-client-api-reference#bucketExists)
-* [`removeBucket`](https://docs.minio.io/docs/java-client-api-reference#removeBucket)
-* [`listObjects`](https://docs.minio.io/docs/java-client-api-reference#listObjects)
-* [`listIncompleteUploads`](https://docs.minio.io/docs/java-client-api-reference#listIncompleteUploads)
+* [`makeBucket`](https://docs.min.io/docs/java-client-api-reference#makeBucket)
+* [`listBuckets`](https://docs.min.io/docs/java-client-api-reference#listBuckets)
+* [`bucketExists`](https://docs.min.io/docs/java-client-api-reference#bucketExists)
+* [`removeBucket`](https://docs.min.io/docs/java-client-api-reference#removeBucket)
+* [`listObjects`](https://docs.min.io/docs/java-client-api-reference#listObjects)
+* [`listIncompleteUploads`](https://docs.min.io/docs/java-client-api-reference#listIncompleteUploads)
 
 ### API Reference: Object Operations
-* [`getObject`](https://docs.minio.io/docs/java-client-api-reference#getObject)
-* [`putObject`](https://docs.minio.io/docs/java-client-api-reference#putObject)
-* [`copyObject`](https://docs.minio.io/docs/java-client-api-reference#copyObject)
-* [`statObject`](https://docs.minio.io/docs/java-client-api-reference#statObject)
-* [`removeObject`](https://docs.minio.io/docs/java-client-api-reference#removeObject)
-* [`removeIncompleteUpload`](https://docs.minio.io/docs/java-client-api-reference#removeIncompleteUpload)
+* [`getObject`](https://docs.min.io/docs/java-client-api-reference#getObject)
+* [`putObject`](https://docs.min.io/docs/java-client-api-reference#putObject)
+* [`copyObject`](https://docs.min.io/docs/java-client-api-reference#copyObject)
+* [`statObject`](https://docs.min.io/docs/java-client-api-reference#statObject)
+* [`removeObject`](https://docs.min.io/docs/java-client-api-reference#removeObject)
+* [`removeIncompleteUpload`](https://docs.min.io/docs/java-client-api-reference#removeIncompleteUpload)
 
 ### API Reference: Presigned Operations
-* [`presignedGetObject`](https://docs.minio.io/docs/java-client-api-reference#presignedGetObject)
-* [`presignedPutObject`](https://docs.minio.io/docs/java-client-api-reference#presignedPutObject)
-* [`presignedPostPolicy`](https://docs.minio.io/docs/java-client-api-reference#presignedPostPolicy)
+* [`presignedGetObject`](https://docs.min.io/docs/java-client-api-reference#presignedGetObject)
+* [`presignedPutObject`](https://docs.min.io/docs/java-client-api-reference#presignedPutObject)
+* [`presignedPostPolicy`](https://docs.min.io/docs/java-client-api-reference#presignedPostPolicy)
 
 ### API Reference: Bucket Policy Operations
-* [`getBucketPolicy`](https://docs.minio.io/docs/java-client-api-reference#getBucketPolicy)
-* [`setBucketPolicy`](https://docs.minio.io/docs/java-client-api-reference#setBucketPolicy)
+* [`getBucketPolicy`](https://docs.min.io/docs/java-client-api-reference#getBucketPolicy)
+* [`setBucketPolicy`](https://docs.min.io/docs/java-client-api-reference#setBucketPolicy)
 
 ## Full Examples
 
@@ -160,8 +160,8 @@ The full API Reference is available here.
 * [PutObjectEncryptedS3.java](https://github.com/minio/minio-java/tree/master/examples/PutObjectEncryptedS3.java)
 
 ## Explore Further
-* [Complete Documentation](https://docs.minio.io)
-* [Minio Java Client SDK API Reference](https://docs.minio.io/docs/java-client-api-reference)
+* [Complete Documentation](https://docs.min.io)
+* [Minio Java Client SDK API Reference](https://docs.min.io/docs/java-client-api-reference)
 * [Build your own Photo API Service - Full Application Example ](https://github.com/minio/minio-java-rest-example)
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#MinIO Java SDK for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
+# MinIO Java SDK for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-TheMinIO Java Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
+The MinIO Java Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
 
 This quickstart guide will show you how to install the client SDK and execute an example java program. For a complete list of APIs and examples, please take a look at the [Java Client API Reference](http://docs.min.io/docs/java-client-api-reference) documentation.
 
@@ -40,7 +40,7 @@ You need three items in order to connect to an object storage server.
 | Access Key    | Access key is like user ID that uniquely identifies your account.   |
 | Secret Key     | Secret key is the password to your account.    |
 
-For the following example, we will use a freely hostedMinIO server running at [https://play.min.io:9000](https://play.min.io:9000). Feel free to use this service for test and development. Access credentials shown in this example are open to the public.
+For the following example, we will use a freely hosted MinIO server running at [https://play.min.io:9000](https://play.min.io:9000). Feel free to use this service for test and development. Access credentials shown in this example are open to the public.
 
 #### FileUploader.java
 ```java
@@ -56,7 +56,7 @@ import io.minio.errors.MinioException;
 public class FileUploader {
   public static void main(String[] args) throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
-      // Create a minioClient with theMinIO Server name, Port, Access key and Secret key.
+      // Create a minioClient with the MinIO Server name, Port, Access key and Secret key.
       MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       // Check if the bucket already exists.

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -1,8 +1,8 @@
-# 适用于与Amazon S3兼容的云存储的Minio Java SDK [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# 适用于与Amazon S3兼容的云存储的Minio Java SDK [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
 Minio Java Client SDK提供简单的API来访问任何与Amazon S3兼容的对象存储服务。
 
-本快速入门指南将向你展示如何安装客户端SDK并执行示例java程序。有关API和示例的完整列表，请查看[Java Client API Reference](http://docs.minio.io/docs/java-client-api-reference)文档。
+本快速入门指南将向你展示如何安装客户端SDK并执行示例java程序。有关API和示例的完整列表，请查看[Java Client API Reference](http://docs.min.io/docs/java-client-api-reference)文档。
 
 ## 最低需求
 Java 1.8或更高版本:
@@ -41,7 +41,7 @@ dependencies {
 | Secret Key     | Secret key是你账户的密码。    |
 
 
-在下面的例子的中，我们将使用一个运行在[https://play.minio.io:9000](https://play.minio.io:9000)的免费托管的Minio服务。你可以随意使用此服务进行测试和开发。此示例中显示的访问凭据是公开的。
+在下面的例子的中，我们将使用一个运行在[https://play.min.io:9000](https://play.min.io:9000)的免费托管的Minio服务。你可以随意使用此服务进行测试和开发。此示例中显示的访问凭据是公开的。
 
 #### FileUploader.java
 
@@ -59,7 +59,7 @@ public class FileUploader {
   public static void main(String[] args) throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       // 使用Minio服务的URL，端口，Access key和Secret key创建一个MinioClient对象
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       // 检查存储桶是否已经存在
       boolean isExist = minioClient.bucketExists("asiatrip");
@@ -98,32 +98,32 @@ mc ls play/asiatrip/
 
 下面链接是完整的API文档
 
-* [API完整文档](https://docs.minio.io/docs/java-client-api-reference)
+* [API完整文档](https://docs.min.io/docs/java-client-api-reference)
 
 ### API文档: 操作存储桶
-* [`makeBucket`](https://docs.minio.io/docs/java-client-api-reference#makeBucket)
-* [`listBuckets`](https://docs.minio.io/docs/java-client-api-reference#listBuckets)
-* [`bucketExists`](https://docs.minio.io/docs/java-client-api-reference#bucketExists)
-* [`removeBucket`](https://docs.minio.io/docs/java-client-api-reference#removeBucket)
-* [`listObjects`](https://docs.minio.io/docs/java-client-api-reference#listObjects)
-* [`listIncompleteUploads`](https://docs.minio.io/docs/java-client-api-reference#listIncompleteUploads)
+* [`makeBucket`](https://docs.min.io/docs/java-client-api-reference#makeBucket)
+* [`listBuckets`](https://docs.min.io/docs/java-client-api-reference#listBuckets)
+* [`bucketExists`](https://docs.min.io/docs/java-client-api-reference#bucketExists)
+* [`removeBucket`](https://docs.min.io/docs/java-client-api-reference#removeBucket)
+* [`listObjects`](https://docs.min.io/docs/java-client-api-reference#listObjects)
+* [`listIncompleteUploads`](https://docs.min.io/docs/java-client-api-reference#listIncompleteUploads)
 
 ### API文档: 操作文件对象
-* [`getObject`](https://docs.minio.io/docs/java-client-api-reference#getObject)
-* [`putObject`](https://docs.minio.io/docs/java-client-api-reference#putObject)
-* [`copyObject`](https://docs.minio.io/docs/java-client-api-reference#copyObject)
-* [`statObject`](https://docs.minio.io/docs/java-client-api-reference#statObject)
-* [`removeObject`](https://docs.minio.io/docs/java-client-api-reference#removeObject)
-* [`removeIncompleteUpload`](https://docs.minio.io/docs/java-client-api-reference#removeIncompleteUpload)
+* [`getObject`](https://docs.min.io/docs/java-client-api-reference#getObject)
+* [`putObject`](https://docs.min.io/docs/java-client-api-reference#putObject)
+* [`copyObject`](https://docs.min.io/docs/java-client-api-reference#copyObject)
+* [`statObject`](https://docs.min.io/docs/java-client-api-reference#statObject)
+* [`removeObject`](https://docs.min.io/docs/java-client-api-reference#removeObject)
+* [`removeIncompleteUpload`](https://docs.min.io/docs/java-client-api-reference#removeIncompleteUpload)
 
 ### API文档: Presigned操作
-* [`presignedGetObject`](https://docs.minio.io/docs/java-client-api-reference#presignedGetObject)
-* [`presignedPutObject`](https://docs.minio.io/docs/java-client-api-reference#presignedPutObject)
-* [`presignedPostPolicy`](https://docs.minio.io/docs/java-client-api-reference#presignedPostPolicy)
+* [`presignedGetObject`](https://docs.min.io/docs/java-client-api-reference#presignedGetObject)
+* [`presignedPutObject`](https://docs.min.io/docs/java-client-api-reference#presignedPutObject)
+* [`presignedPostPolicy`](https://docs.min.io/docs/java-client-api-reference#presignedPostPolicy)
 
 ### API文档: 操作存储桶策略
-* [`getBucketPolicy`](https://docs.minio.io/docs/java-client-api-reference#getBucketPolicy)
-* [`setBucketPolicy`](https://docs.minio.io/docs/java-client-api-reference#setBucketPolicy)
+* [`getBucketPolicy`](https://docs.min.io/docs/java-client-api-reference#getBucketPolicy)
+* [`setBucketPolicy`](https://docs.min.io/docs/java-client-api-reference#setBucketPolicy)
 
 ## 完整示例
 
@@ -155,8 +155,8 @@ mc ls play/asiatrip/
 * [GetBucketPolicy.Java](https://github.com/minio/minio-java/tree/master/examples/GetBucketPolicy.java)
 
 ## 了解更多
-* [Minio官方文档](https://docs.minio.io)
-* [Minio Java Client SDK API文档](https://docs.minio.io/docs/java-client-api-reference)
+* [Minio官方文档](https://docs.min.io)
+* [Minio Java Client SDK API文档](https://docs.min.io/docs/java-client-api-reference)
 * [创建属于你的照片API服务-完整示例](https://github.com/minio/minio-java-rest-example)
 
 ## 贡献

--- a/api/src/main/java/io/minio/AwsS3Endpoints.java
+++ b/api/src/main/java/io/minio/AwsS3Endpoints.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/AwsS3Endpoints.java
+++ b/api/src/main/java/io/minio/AwsS3Endpoints.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/BucketEventListener.java
+++ b/api/src/main/java/io/minio/BucketEventListener.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/BucketEventListener.java
+++ b/api/src/main/java/io/minio/BucketEventListener.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/BucketRegionCache.java
+++ b/api/src/main/java/io/minio/BucketRegionCache.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/BucketRegionCache.java
+++ b/api/src/main/java/io/minio/BucketRegionCache.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ChunkedInputStream.java
+++ b/api/src/main/java/io/minio/ChunkedInputStream.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ChunkedInputStream.java
+++ b/api/src/main/java/io/minio/ChunkedInputStream.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/CopyConditions.java
+++ b/api/src/main/java/io/minio/CopyConditions.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017MinIO,Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 MinIO,Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/CopyConditions.java
+++ b/api/src/main/java/io/minio/CopyConditions.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017 Minio,Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017MinIO,Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/DateFormat.java
+++ b/api/src/main/java/io/minio/DateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/DateFormat.java
+++ b/api/src/main/java/io/minio/DateFormat.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/Digest.java
+++ b/api/src/main/java/io/minio/Digest.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/Digest.java
+++ b/api/src/main/java/io/minio/Digest.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ErrorCode.java
+++ b/api/src/main/java/io/minio/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ErrorCode.java
+++ b/api/src/main/java/io/minio/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/HttpRequestBody.java
+++ b/api/src/main/java/io/minio/HttpRequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/HttpRequestBody.java
+++ b/api/src/main/java/io/minio/HttpRequestBody.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/HttpResponse.java
+++ b/api/src/main/java/io/minio/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/HttpResponse.java
+++ b/api/src/main/java/io/minio/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017, 2018, 2019MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017, 2018, 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,7 @@ public class MinioClient {
 
 
   /**
-   * CreatesMinIO client object with given endpoint using anonymous access.
+   * Creates MinIO client object with given endpoint using anonymous access.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient("https://play.minio.io:9000"); }</pre>
@@ -258,7 +258,7 @@ public class MinioClient {
 
 
   /**
-   * CreatesMinIO client object with given URL object using anonymous access.
+   * Creates MinIO client object with given URL object using anonymous access.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(new URL("https://play.minio.io:9000")); }</pre>
@@ -281,7 +281,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given HttpUrl object using anonymous access.
+   * Creates MinIO client object with given HttpUrl object using anonymous access.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(new HttpUrl.parse("https://play.minio.io:9000")); }</pre>
@@ -305,7 +305,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given endpoint, access key and secret key.
+   * Creates MinIO client object with given endpoint, access key and secret key.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient("https://play.minio.io:9000",
@@ -343,7 +343,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given endpoint, access key, secret key and region name
+   * Creates MinIO client object with given endpoint, access key, secret key and region name
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient("https://play.minio.io:9000",
@@ -382,7 +382,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given URL object, access key and secret key.
+   * Creates MinIO client object with given URL object, access key and secret key.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(new URL("https://play.minio.io:9000"),
@@ -409,7 +409,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given URL object, access key and secret key.
+   * Creates MinIO client object with given URL object, access key and secret key.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(HttpUrl.parse("https://play.minio.io:9000"),
@@ -437,7 +437,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.
+   * Creates MinIO client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -478,7 +478,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object with given endpoint, access key and secret key using secure (HTTPS) connection.
+   * Creates MinIO client object with given endpoint, access key and secret key using secure (HTTPS) connection.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -519,7 +519,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object using given endpoint, port, access key, secret key and secure option.
+   * Creates MinIO client object using given endpoint, port, access key, secret key and secure option.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -561,7 +561,7 @@ public class MinioClient {
   }
 
   /**
-   * CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option.
+   * Creates MinIO client object using given endpoint, port, access key, secret key, region and secure option.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -604,7 +604,7 @@ public class MinioClient {
 
 
   /**
-   * CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option.
+   * Creates MinIO client object using given endpoint, port, access key, secret key, region and secure option.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017, 2018, 2019 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017, 2018, 2019MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,7 @@ public class MinioClient {
 
 
   /**
-   * Creates Minio client object with given endpoint using anonymous access.
+   * CreatesMinIO client object with given endpoint using anonymous access.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient("https://play.minio.io:9000"); }</pre>
@@ -258,7 +258,7 @@ public class MinioClient {
 
 
   /**
-   * Creates Minio client object with given URL object using anonymous access.
+   * CreatesMinIO client object with given URL object using anonymous access.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(new URL("https://play.minio.io:9000")); }</pre>
@@ -281,7 +281,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given HttpUrl object using anonymous access.
+   * CreatesMinIO client object with given HttpUrl object using anonymous access.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(new HttpUrl.parse("https://play.minio.io:9000")); }</pre>
@@ -305,7 +305,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given endpoint, access key and secret key.
+   * CreatesMinIO client object with given endpoint, access key and secret key.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient("https://play.minio.io:9000",
@@ -343,7 +343,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given endpoint, access key, secret key and region name
+   * CreatesMinIO client object with given endpoint, access key, secret key and region name
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient("https://play.minio.io:9000",
@@ -382,7 +382,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given URL object, access key and secret key.
+   * CreatesMinIO client object with given URL object, access key and secret key.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(new URL("https://play.minio.io:9000"),
@@ -409,7 +409,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given URL object, access key and secret key.
+   * CreatesMinIO client object with given URL object, access key and secret key.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient = new MinioClient(HttpUrl.parse("https://play.minio.io:9000"),
@@ -437,7 +437,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.
+   * CreatesMinIO client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -478,7 +478,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object with given endpoint, access key and secret key using secure (HTTPS) connection.
+   * CreatesMinIO client object with given endpoint, access key and secret key using secure (HTTPS) connection.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -519,7 +519,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object using given endpoint, port, access key, secret key and secure option.
+   * CreatesMinIO client object using given endpoint, port, access key, secret key and secure option.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -561,7 +561,7 @@ public class MinioClient {
   }
 
   /**
-   * Creates Minio client object using given endpoint, port, access key, secret key, region and secure option.
+   * CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =
@@ -604,7 +604,7 @@ public class MinioClient {
 
 
   /**
-   * Creates Minio client object using given endpoint, port, access key, secret key, region and secure option.
+   * CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option.
    *
    * </p><b>Example:</b><br>
    * <pre>{@code MinioClient minioClient =

--- a/api/src/main/java/io/minio/MinioProperties.java
+++ b/api/src/main/java/io/minio/MinioProperties.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/MinioProperties.java
+++ b/api/src/main/java/io/minio/MinioProperties.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ObjectStat.java
+++ b/api/src/main/java/io/minio/ObjectStat.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ObjectStat.java
+++ b/api/src/main/java/io/minio/ObjectStat.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/PostPolicy.java
+++ b/api/src/main/java/io/minio/PostPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/PostPolicy.java
+++ b/api/src/main/java/io/minio/PostPolicy.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ResponseHeader.java
+++ b/api/src/main/java/io/minio/ResponseHeader.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ResponseHeader.java
+++ b/api/src/main/java/io/minio/ResponseHeader.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/Result.java
+++ b/api/src/main/java/io/minio/Result.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/Result.java
+++ b/api/src/main/java/io/minio/Result.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/S3Escaper.java
+++ b/api/src/main/java/io/minio/S3Escaper.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2016MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/S3Escaper.java
+++ b/api/src/main/java/io/minio/S3Escaper.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2016MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ServerSideEncryption.java
+++ b/api/src/main/java/io/minio/ServerSideEncryption.java
@@ -1,5 +1,5 @@
 /*
-  * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2018 Minio, Inc.
+  *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2018MinIO, Inc.
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/ServerSideEncryption.java
+++ b/api/src/main/java/io/minio/ServerSideEncryption.java
@@ -1,5 +1,5 @@
 /*
-  *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2018MinIO, Inc.
+  * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2018 MinIO, Inc.
   *
   * Licensed under the Apache License, Version 2.0 (the "License");
   * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/Signer.java
+++ b/api/src/main/java/io/minio/Signer.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ class Signer {
     }
 
     // Building a multimap which only order keys, ordering values is not performed
-    // until Minio server supports it.
+    // untilMinIO server supports it.
     Multimap<String, String> signedQueryParams = MultimapBuilder.treeKeys().arrayListValues().build();
 
     for (String queryParam : encodedQuery.split("&")) {

--- a/api/src/main/java/io/minio/Signer.java
+++ b/api/src/main/java/io/minio/Signer.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ class Signer {
     }
 
     // Building a multimap which only order keys, ordering values is not performed
-    // untilMinIO server supports it.
+    // until MinIO server supports it.
     Multimap<String, String> signedQueryParams = MultimapBuilder.treeKeys().arrayListValues().build();
 
     for (String queryParam : encodedQuery.split("&")) {

--- a/api/src/main/java/io/minio/errors/BucketPolicyTooLargeException.java
+++ b/api/src/main/java/io/minio/errors/BucketPolicyTooLargeException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/BucketPolicyTooLargeException.java
+++ b/api/src/main/java/io/minio/errors/BucketPolicyTooLargeException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/ErrorResponseException.java
+++ b/api/src/main/java/io/minio/errors/ErrorResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/ErrorResponseException.java
+++ b/api/src/main/java/io/minio/errors/ErrorResponseException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InsufficientDataException.java
+++ b/api/src/main/java/io/minio/errors/InsufficientDataException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InsufficientDataException.java
+++ b/api/src/main/java/io/minio/errors/InsufficientDataException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InternalException.java
+++ b/api/src/main/java/io/minio/errors/InternalException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InternalException.java
+++ b/api/src/main/java/io/minio/errors/InternalException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidArgumentException.java
+++ b/api/src/main/java/io/minio/errors/InvalidArgumentException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidArgumentException.java
+++ b/api/src/main/java/io/minio/errors/InvalidArgumentException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidBucketNameException.java
+++ b/api/src/main/java/io/minio/errors/InvalidBucketNameException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidBucketNameException.java
+++ b/api/src/main/java/io/minio/errors/InvalidBucketNameException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidEndpointException.java
+++ b/api/src/main/java/io/minio/errors/InvalidEndpointException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidEndpointException.java
+++ b/api/src/main/java/io/minio/errors/InvalidEndpointException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidExpiresRangeException.java
+++ b/api/src/main/java/io/minio/errors/InvalidExpiresRangeException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidExpiresRangeException.java
+++ b/api/src/main/java/io/minio/errors/InvalidExpiresRangeException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidObjectPrefixException.java
+++ b/api/src/main/java/io/minio/errors/InvalidObjectPrefixException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidObjectPrefixException.java
+++ b/api/src/main/java/io/minio/errors/InvalidObjectPrefixException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidPortException.java
+++ b/api/src/main/java/io/minio/errors/InvalidPortException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/InvalidPortException.java
+++ b/api/src/main/java/io/minio/errors/InvalidPortException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/MinioException.java
+++ b/api/src/main/java/io/minio/errors/MinioException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/MinioException.java
+++ b/api/src/main/java/io/minio/errors/MinioException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/NoResponseException.java
+++ b/api/src/main/java/io/minio/errors/NoResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/NoResponseException.java
+++ b/api/src/main/java/io/minio/errors/NoResponseException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/RegionConflictException.java
+++ b/api/src/main/java/io/minio/errors/RegionConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/errors/RegionConflictException.java
+++ b/api/src/main/java/io/minio/errors/RegionConflictException.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/Header.java
+++ b/api/src/main/java/io/minio/http/Header.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/Header.java
+++ b/api/src/main/java/io/minio/http/Header.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/HeaderParser.java
+++ b/api/src/main/java/io/minio/http/HeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/HeaderParser.java
+++ b/api/src/main/java/io/minio/http/HeaderParser.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/Method.java
+++ b/api/src/main/java/io/minio/http/Method.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/Method.java
+++ b/api/src/main/java/io/minio/http/Method.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/Scheme.java
+++ b/api/src/main/java/io/minio/http/Scheme.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/http/Scheme.java
+++ b/api/src/main/java/io/minio/http/Scheme.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Bucket.java
+++ b/api/src/main/java/io/minio/messages/Bucket.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Bucket.java
+++ b/api/src/main/java/io/minio/messages/Bucket.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Buckets.java
+++ b/api/src/main/java/io/minio/messages/Buckets.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Buckets.java
+++ b/api/src/main/java/io/minio/messages/Buckets.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CloudFunctionConfiguration.java
+++ b/api/src/main/java/io/minio/messages/CloudFunctionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CloudFunctionConfiguration.java
+++ b/api/src/main/java/io/minio/messages/CloudFunctionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CompleteMultipartUpload.java
+++ b/api/src/main/java/io/minio/messages/CompleteMultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CompleteMultipartUpload.java
+++ b/api/src/main/java/io/minio/messages/CompleteMultipartUpload.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CopyObjectResult.java
+++ b/api/src/main/java/io/minio/messages/CopyObjectResult.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CopyObjectResult.java
+++ b/api/src/main/java/io/minio/messages/CopyObjectResult.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CreateBucketConfiguration.java
+++ b/api/src/main/java/io/minio/messages/CreateBucketConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/CreateBucketConfiguration.java
+++ b/api/src/main/java/io/minio/messages/CreateBucketConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteError.java
+++ b/api/src/main/java/io/minio/messages/DeleteError.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteError.java
+++ b/api/src/main/java/io/minio/messages/DeleteError.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteObject.java
+++ b/api/src/main/java/io/minio/messages/DeleteObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteObject.java
+++ b/api/src/main/java/io/minio/messages/DeleteObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteRequest.java
+++ b/api/src/main/java/io/minio/messages/DeleteRequest.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteRequest.java
+++ b/api/src/main/java/io/minio/messages/DeleteRequest.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteResult.java
+++ b/api/src/main/java/io/minio/messages/DeleteResult.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeleteResult.java
+++ b/api/src/main/java/io/minio/messages/DeleteResult.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeletedObject.java
+++ b/api/src/main/java/io/minio/messages/DeletedObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/DeletedObject.java
+++ b/api/src/main/java/io/minio/messages/DeletedObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ErrorResponse.java
+++ b/api/src/main/java/io/minio/messages/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ErrorResponse.java
+++ b/api/src/main/java/io/minio/messages/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/EventType.java
+++ b/api/src/main/java/io/minio/messages/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/EventType.java
+++ b/api/src/main/java/io/minio/messages/EventType.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Filter.java
+++ b/api/src/main/java/io/minio/messages/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Filter.java
+++ b/api/src/main/java/io/minio/messages/Filter.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/FilterRule.java
+++ b/api/src/main/java/io/minio/messages/FilterRule.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/FilterRule.java
+++ b/api/src/main/java/io/minio/messages/FilterRule.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Grant.java
+++ b/api/src/main/java/io/minio/messages/Grant.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Grant.java
+++ b/api/src/main/java/io/minio/messages/Grant.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Grantee.java
+++ b/api/src/main/java/io/minio/messages/Grantee.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Grantee.java
+++ b/api/src/main/java/io/minio/messages/Grantee.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/InitiateMultipartUploadResult.java
+++ b/api/src/main/java/io/minio/messages/InitiateMultipartUploadResult.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/InitiateMultipartUploadResult.java
+++ b/api/src/main/java/io/minio/messages/InitiateMultipartUploadResult.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Initiator.java
+++ b/api/src/main/java/io/minio/messages/Initiator.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Initiator.java
+++ b/api/src/main/java/io/minio/messages/Initiator.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Item.java
+++ b/api/src/main/java/io/minio/messages/Item.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Item.java
+++ b/api/src/main/java/io/minio/messages/Item.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListAllMyBucketsResult.java
+++ b/api/src/main/java/io/minio/messages/ListAllMyBucketsResult.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListAllMyBucketsResult.java
+++ b/api/src/main/java/io/minio/messages/ListAllMyBucketsResult.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListBucketResult.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResult.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListBucketResult.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResult.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListBucketResultV1.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResultV1.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListBucketResultV1.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResultV1.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016, 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListMultipartUploadsResult.java
+++ b/api/src/main/java/io/minio/messages/ListMultipartUploadsResult.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListMultipartUploadsResult.java
+++ b/api/src/main/java/io/minio/messages/ListMultipartUploadsResult.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListPartsResult.java
+++ b/api/src/main/java/io/minio/messages/ListPartsResult.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/ListPartsResult.java
+++ b/api/src/main/java/io/minio/messages/ListPartsResult.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/NotificationConfiguration.java
+++ b/api/src/main/java/io/minio/messages/NotificationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/NotificationConfiguration.java
+++ b/api/src/main/java/io/minio/messages/NotificationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Owner.java
+++ b/api/src/main/java/io/minio/messages/Owner.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Owner.java
+++ b/api/src/main/java/io/minio/messages/Owner.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Part.java
+++ b/api/src/main/java/io/minio/messages/Part.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Part.java
+++ b/api/src/main/java/io/minio/messages/Part.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Prefix.java
+++ b/api/src/main/java/io/minio/messages/Prefix.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Prefix.java
+++ b/api/src/main/java/io/minio/messages/Prefix.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/QueueConfiguration.java
+++ b/api/src/main/java/io/minio/messages/QueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/QueueConfiguration.java
+++ b/api/src/main/java/io/minio/messages/QueueConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/S3Key.java
+++ b/api/src/main/java/io/minio/messages/S3Key.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/S3Key.java
+++ b/api/src/main/java/io/minio/messages/S3Key.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/TopicConfiguration.java
+++ b/api/src/main/java/io/minio/messages/TopicConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/TopicConfiguration.java
+++ b/api/src/main/java/io/minio/messages/TopicConfiguration.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Upload.java
+++ b/api/src/main/java/io/minio/messages/Upload.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/Upload.java
+++ b/api/src/main/java/io/minio/messages/Upload.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/XmlEntity.java
+++ b/api/src/main/java/io/minio/messages/XmlEntity.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/messages/XmlEntity.java
+++ b/api/src/main/java/io/minio/messages/XmlEntity.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/BucketMeta.java
+++ b/api/src/main/java/io/minio/notification/BucketMeta.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/BucketMeta.java
+++ b/api/src/main/java/io/minio/notification/BucketMeta.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/EventMeta.java
+++ b/api/src/main/java/io/minio/notification/EventMeta.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/EventMeta.java
+++ b/api/src/main/java/io/minio/notification/EventMeta.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/Identity.java
+++ b/api/src/main/java/io/minio/notification/Identity.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/Identity.java
+++ b/api/src/main/java/io/minio/notification/Identity.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/NotificationEvent.java
+++ b/api/src/main/java/io/minio/notification/NotificationEvent.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/NotificationEvent.java
+++ b/api/src/main/java/io/minio/notification/NotificationEvent.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/NotificationInfo.java
+++ b/api/src/main/java/io/minio/notification/NotificationInfo.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/NotificationInfo.java
+++ b/api/src/main/java/io/minio/notification/NotificationInfo.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/ObjectMeta.java
+++ b/api/src/main/java/io/minio/notification/ObjectMeta.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/ObjectMeta.java
+++ b/api/src/main/java/io/minio/notification/ObjectMeta.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/SourceInfo.java
+++ b/api/src/main/java/io/minio/notification/SourceInfo.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/notification/SourceInfo.java
+++ b/api/src/main/java/io/minio/notification/SourceInfo.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,8 @@
 # Java Client API Reference [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 
-## InitializeMinIO Client object.
+## Initialize MinIO Client object.
 
-##MinIO
+## MinIO
 
 ```java
 MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
@@ -33,60 +33,60 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |  |
 |---|
 |`public MinioClient(String endpoint) throws InvalidEndpointException, InvalidPortException`   |
-| CreatesMinIO client object with given endpoint using anonymous access.  |
+| Creates MinIO client object with given endpoint using anonymous access.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-)  |
 
 
 |   |
 |---|
 |`public MinioClient(URL url) throws InvalidEndpointException, InvalidPortException`   |
-| CreatesMinIO client object with given url using anonymous access.  |
+| Creates MinIO client object with given url using anonymous access.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.net.URL-)  |
 
 
 |  |
 |---|
 | `public MinioClient(okhttp3.HttpUrl url) throws  InvalidEndpointException, InvalidPortException`  |
-|CreatesMinIO client object with given HttpUrl object using anonymous access.  |
+|Creates MinIO client object with given HttpUrl object using anonymous access.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-okhttp3.HttpUrl-)  |
 
 |   |
 |---|
 | `public MinioClient(String endpoint, String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-|  CreatesMinIO client object with given endpoint, access key and secret key. |
+|  Creates MinIO client object with given endpoint, access key and secret key. |
 |   [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-java.lang.String-java.lang.String-)|
 
 |   |
 |---|
 | `public MinioClient(String endpoint, int port,  String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-| CreatesMinIO client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.  |
+| Creates MinIO client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-)  |
 
 
 |   |
 |---|
 | `public MinioClient(String endpoint, String accessKey, String secretKey, boolean secure) throws InvalidEndpointException, InvalidPortException`  |
-| CreatesMinIO client object with given endpoint, access key and secret key using secure (HTTPS) connection.  |
+| Creates MinIO client object with given endpoint, access key and secret key using secure (HTTPS) connection.  |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-java.lang.String-java.lang.String-boolean-) |
 
 
 |   |
 |---|
 | `public MinioClient(String endpoint, int port, String accessKey, String secretKey, boolean secure) throws InvalidEndpointException, InvalidPortException`  |
-| CreatesMinIO client object using given endpoint, port, access key, secret key and secure option.  |
+| Creates MinIO client object using given endpoint, port, access key, secret key and secure option.  |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-boolean-) |
 
 |   |
 |---|
 | `public MinioClient(okhttp3.HttpUrl url, String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-| CreatesMinIO client object with given URL object, access key and secret key.  |
+| Creates MinIO client object with given URL object, access key and secret key.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-okhttp3.HttpUrl-java.lang.String-java.lang.String-)  |
 
 
 |   |
 |---|
 | `public MinioClient(URL url, String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-|  CreatesMinIO client object with given URL object, access key and secret key. |
+|  Creates MinIO client object with given URL object, access key and secret key. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.net.URL-java.lang.String-java.lang.String-) |
 
 
@@ -94,7 +94,7 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |   |
 |---|
 | `public MinioClient(String endpoint, String accessKey, String secretKey, String region) throws InvalidEndpointException, InvalidPortException`  |
-|  CreatesMinIO client object with given URL object, access key and secret key. |
+|  Creates MinIO client object with given URL object, access key and secret key. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) |
 
 
@@ -102,7 +102,7 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |   |
 |---|
 | `public MinioClient(String endpoint, int port, String accessKey, String secretKey, String region, boolean secure) throws InvalidEndpointException, InvalidPortException`  |
-|  CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option. |
+|  Creates MinIO client object using given endpoint, port, access key, secret key, region and secure option. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-java.lang.String-boolean-) |
 
 
@@ -110,7 +110,7 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |   |
 |---|
 | `public MinioClient(String endpoint, int port, String accessKey, String secretKey, String region, boolean secure, okhttp3.OkHttpClient httpClient) throws InvalidEndpointException, InvalidPortException`  |
-|  CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option. |
+|  Creates MinIO client object using given endpoint, port, access key, secret key, region and secure option. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-java.lang.String-boolean-) |
 
 
@@ -135,7 +135,7 @@ __Parameters__
 __Example__
 
 
-###MinIO
+### MinIO
 
 
 ```java

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,8 @@
 # Java Client API Reference [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 
-## Initialize Minio Client object.
+## InitializeMinIO Client object.
 
-## Minio
+##MinIO
 
 ```java
 MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
@@ -33,60 +33,60 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |  |
 |---|
 |`public MinioClient(String endpoint) throws InvalidEndpointException, InvalidPortException`   |
-| Creates Minio client object with given endpoint using anonymous access.  |
+| CreatesMinIO client object with given endpoint using anonymous access.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-)  |
 
 
 |   |
 |---|
 |`public MinioClient(URL url) throws InvalidEndpointException, InvalidPortException`   |
-| Creates Minio client object with given url using anonymous access.  |
+| CreatesMinIO client object with given url using anonymous access.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.net.URL-)  |
 
 
 |  |
 |---|
 | `public MinioClient(okhttp3.HttpUrl url) throws  InvalidEndpointException, InvalidPortException`  |
-|Creates Minio client object with given HttpUrl object using anonymous access.  |
+|CreatesMinIO client object with given HttpUrl object using anonymous access.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-okhttp3.HttpUrl-)  |
 
 |   |
 |---|
 | `public MinioClient(String endpoint, String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-|  Creates Minio client object with given endpoint, access key and secret key. |
+|  CreatesMinIO client object with given endpoint, access key and secret key. |
 |   [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-java.lang.String-java.lang.String-)|
 
 |   |
 |---|
 | `public MinioClient(String endpoint, int port,  String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-| Creates Minio client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.  |
+| CreatesMinIO client object with given endpoint, port, access key and secret key using secure (HTTPS) connection.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-)  |
 
 
 |   |
 |---|
 | `public MinioClient(String endpoint, String accessKey, String secretKey, boolean secure) throws InvalidEndpointException, InvalidPortException`  |
-| Creates Minio client object with given endpoint, access key and secret key using secure (HTTPS) connection.  |
+| CreatesMinIO client object with given endpoint, access key and secret key using secure (HTTPS) connection.  |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-java.lang.String-java.lang.String-boolean-) |
 
 
 |   |
 |---|
 | `public MinioClient(String endpoint, int port, String accessKey, String secretKey, boolean secure) throws InvalidEndpointException, InvalidPortException`  |
-| Creates Minio client object using given endpoint, port, access key, secret key and secure option.  |
+| CreatesMinIO client object using given endpoint, port, access key, secret key and secure option.  |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-boolean-) |
 
 |   |
 |---|
 | `public MinioClient(okhttp3.HttpUrl url, String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-| Creates Minio client object with given URL object, access key and secret key.  |
+| CreatesMinIO client object with given URL object, access key and secret key.  |
 | [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-okhttp3.HttpUrl-java.lang.String-java.lang.String-)  |
 
 
 |   |
 |---|
 | `public MinioClient(URL url, String accessKey, String secretKey) throws InvalidEndpointException, InvalidPortException`  |
-|  Creates Minio client object with given URL object, access key and secret key. |
+|  CreatesMinIO client object with given URL object, access key and secret key. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.net.URL-java.lang.String-java.lang.String-) |
 
 
@@ -94,7 +94,7 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |   |
 |---|
 | `public MinioClient(String endpoint, String accessKey, String secretKey, String region) throws InvalidEndpointException, InvalidPortException`  |
-|  Creates Minio client object with given URL object, access key and secret key. |
+|  CreatesMinIO client object with given URL object, access key and secret key. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) |
 
 
@@ -102,7 +102,7 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |   |
 |---|
 | `public MinioClient(String endpoint, int port, String accessKey, String secretKey, String region, boolean secure) throws InvalidEndpointException, InvalidPortException`  |
-|  Creates Minio client object using given endpoint, port, access key, secret key, region and secure option. |
+|  CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-java.lang.String-boolean-) |
 
 
@@ -110,7 +110,7 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 |   |
 |---|
 | `public MinioClient(String endpoint, int port, String accessKey, String secretKey, String region, boolean secure, okhttp3.OkHttpClient httpClient) throws InvalidEndpointException, InvalidPortException`  |
-|  Creates Minio client object using given endpoint, port, access key, secret key, region and secure option. |
+|  CreatesMinIO client object using given endpoint, port, access key, secret key, region and secure option. |
 |  [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#MinioClient-java.lang.String-int-java.lang.String-java.lang.String-java.lang.String-boolean-) |
 
 
@@ -135,7 +135,7 @@ __Parameters__
 __Example__
 
 
-### Minio
+###MinIO
 
 
 ```java

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -2,7 +2,7 @@
 
 ## 初始化Minio Client object。
 
-##MinIO
+## MinIO
 
 ```java
 MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
@@ -109,7 +109,7 @@ __参数__
 __示例__
 
 
-###MinIO
+### MinIO
 
 
 ```java

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -2,7 +2,7 @@
 
 ## 初始化Minio Client object。
 
-## Minio
+##MinIO
 
 ```java
 MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
@@ -109,7 +109,7 @@ __参数__
 __示例__
 
 
-### Minio
+###MinIO
 
 
 ```java

--- a/examples/BucketExists.java
+++ b/examples/BucketExists.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class BucketExists {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/BucketExists.java
+++ b/examples/BucketExists.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/CopyObject.java
+++ b/examples/CopyObject.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/CopyObject.java
+++ b/examples/CopyObject.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class CopyObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/CopyObjectEncrypted.java
+++ b/examples/CopyObjectEncrypted.java
@@ -19,7 +19,7 @@ public class CopyObjectEncrypted {
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/CopyObjectEncryptedKms.java
+++ b/examples/CopyObjectEncryptedKms.java
@@ -21,7 +21,7 @@ public class CopyObjectEncryptedKms {
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/CopyObjectEncryptedS3.java
+++ b/examples/CopyObjectEncryptedS3.java
@@ -18,7 +18,7 @@ public class CopyObjectEncryptedS3 {
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/CopyObjectMetadata.java
+++ b/examples/CopyObjectMetadata.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/CopyObjectMetadata.java
+++ b/examples/CopyObjectMetadata.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class CopyObjectMetadata {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/DeleteBucketLifeCycle.java
+++ b/examples/DeleteBucketLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/DeleteBucketLifeCycle.java
+++ b/examples/DeleteBucketLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/DownloadObject.java
+++ b/examples/DownloadObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class DownloadObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/DownloadObject.java
+++ b/examples/DownloadObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetBucketLifeCycle.java
+++ b/examples/GetBucketLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetBucketLifeCycle.java
+++ b/examples/GetBucketLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetBucketNotification.java
+++ b/examples/GetBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class GetBucketNotification {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/GetBucketNotification.java
+++ b/examples/GetBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetBucketPolicy.java
+++ b/examples/GetBucketPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class GetBucketPolicy {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/GetBucketPolicy.java
+++ b/examples/GetBucketPolicy.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetObject.java
+++ b/examples/GetObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetObject.java
+++ b/examples/GetObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class GetObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/GetObjectProgressBar.java
+++ b/examples/GetObjectProgressBar.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class GetObjectProgressBar {
       throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000",
           "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/GetObjectProgressBar.java
+++ b/examples/GetObjectProgressBar.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetPartialObject.java
+++ b/examples/GetPartialObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/GetPartialObject.java
+++ b/examples/GetPartialObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class GetPartialObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/ListBuckets.java
+++ b/examples/ListBuckets.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class ListBuckets {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/ListBuckets.java
+++ b/examples/ListBuckets.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ListIncompleteUploads.java
+++ b/examples/ListIncompleteUploads.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class ListIncompleteUploads {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/ListIncompleteUploads.java
+++ b/examples/ListIncompleteUploads.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ListObjects.java
+++ b/examples/ListObjects.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ListObjects.java
+++ b/examples/ListObjects.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class ListObjects {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/ListenBucketNotification.java
+++ b/examples/ListenBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ListenBucketNotification.java
+++ b/examples/ListenBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class ListenBucketNotification {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/MakeBucket.java
+++ b/examples/MakeBucket.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class MakeBucket {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/MakeBucket.java
+++ b/examples/MakeBucket.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PresignedGetObject.java
+++ b/examples/PresignedGetObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class PresignedGetObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PresignedGetObject.java
+++ b/examples/PresignedGetObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PresignedPostPolicy.java
+++ b/examples/PresignedPostPolicy.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PresignedPostPolicy.java
+++ b/examples/PresignedPostPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class PresignedPostPolicy {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */
@@ -52,7 +52,7 @@ public class PresignedPostPolicy {
       for (Map.Entry<String,String> entry : formData.entrySet()) {
         System.out.print(" -F " + entry.getKey() + "=" + entry.getValue());
       }
-      System.out.println(" -F file=@/tmp/userpic.png https://play.minio.io:9000/my-bucketname");
+      System.out.println(" -F file=@/tmp/userpic.png https://play.min.io:9000/my-bucketname");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);
     }

--- a/examples/PresignedPutObject.java
+++ b/examples/PresignedPutObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class PresignedPutObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PresignedPutObject.java
+++ b/examples/PresignedPutObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ProgressStream.java
+++ b/examples/ProgressStream.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ProgressStream.java
+++ b/examples/ProgressStream.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PutGetObjectEncrypted.java
+++ b/examples/PutGetObjectEncrypted.java
@@ -23,7 +23,7 @@ public class PutGetObjectEncrypted {
     throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PutGetObjectEncryptedFile.java
+++ b/examples/PutGetObjectEncryptedFile.java
@@ -18,7 +18,7 @@ public class PutGetObjectEncryptedFile {
         throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
         /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       //* Amazon S3: */

--- a/examples/PutObject.java
+++ b/examples/PutObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PutObject.java
+++ b/examples/PutObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class PutObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PutObjectEncryptedKms.java
+++ b/examples/PutObjectEncryptedKms.java
@@ -21,7 +21,7 @@ public class PutObjectEncryptedKms {
     throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PutObjectEncryptedS3.java
+++ b/examples/PutObjectEncryptedS3.java
@@ -18,7 +18,7 @@ public class PutObjectEncryptedS3 {
     throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PutObjectProgressBar.java
+++ b/examples/PutObjectProgressBar.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class PutObjectProgressBar {
       InsufficientDataException, NoResponseException, ErrorResponseException, InternalException,
       InvalidArgumentException, IOException, XmlPullParserException {
     /* play.minio.io for test and development. */
-    MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+    MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
         "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
     /* Amazon S3: */
     // MinioClient minioClient = new MinioClient("https://s3.amazonaws.com",

--- a/examples/PutObjectProgressBar.java
+++ b/examples/PutObjectProgressBar.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PutObjectUiProgressBar.java
+++ b/examples/PutObjectUiProgressBar.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class PutObjectUiProgressBar extends JFrame {
       ErrorResponseException, InternalException, InvalidArgumentException {
 
     /* play.minio.io for test and development. */
-    MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+    MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                               "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
     /* Amazon S3: */
     // MinioClient minioClient = new MinioClient("https://s3.amazonaws.com",

--- a/examples/PutObjectUiProgressBar.java
+++ b/examples/PutObjectUiProgressBar.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PutObjectWithMetadata.java
+++ b/examples/PutObjectWithMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class PutObjectWithMetadata {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/PutObjectWithMetadata.java
+++ b/examples/PutObjectWithMetadata.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/PutStatObjectEncrypted.java
+++ b/examples/PutStatObjectEncrypted.java
@@ -22,7 +22,7 @@ public class PutStatObjectEncrypted {
     throws NoSuchAlgorithmException, IOException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/RemoveAllBucketNotification.java
+++ b/examples/RemoveAllBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/RemoveAllBucketNotification.java
+++ b/examples/RemoveAllBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class RemoveAllBucketNotification {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/RemoveBucket.java
+++ b/examples/RemoveBucket.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/RemoveBucket.java
+++ b/examples/RemoveBucket.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class RemoveBucket {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/RemoveIncompleteUpload.java
+++ b/examples/RemoveIncompleteUpload.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class RemoveIncompleteUpload {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/RemoveIncompleteUpload.java
+++ b/examples/RemoveIncompleteUpload.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/RemoveObject.java
+++ b/examples/RemoveObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class RemoveObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/RemoveObject.java
+++ b/examples/RemoveObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/RemoveObjects.java
+++ b/examples/RemoveObjects.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class RemoveObjects {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/RemoveObjects.java
+++ b/examples/RemoveObjects.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/SetBucketLifeCycle.java
+++ b/examples/SetBucketLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/SetBucketLifeCycle.java
+++ b/examples/SetBucketLifeCycle.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/SetBucketNotification.java
+++ b/examples/SetBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017, 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class SetBucketNotification {
   public static void main(String[] args)
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
-      /* LocalMinIO for test and development. */
+      /* Local MinIO for test and development. */
       MinioClient minioClient = new MinioClient("http://127.0.0.1:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETKEY");
 
       /* Amazon S3: */

--- a/examples/SetBucketNotification.java
+++ b/examples/SetBucketNotification.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017, 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2017, 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class SetBucketNotification {
   public static void main(String[] args)
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
-      /* Local Minio for test and development. */
+      /* LocalMinIO for test and development. */
       MinioClient minioClient = new MinioClient("http://127.0.0.1:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETKEY");
 
       /* Amazon S3: */

--- a/examples/SetBucketPolicy.java
+++ b/examples/SetBucketPolicy.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/SetBucketPolicy.java
+++ b/examples/SetBucketPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class SetBucketPolicy {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/StatObject.java
+++ b/examples/StatObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class StatObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/StatObject.java
+++ b/examples/StatObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/UploadObject.java
+++ b/examples/UploadObject.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public class UploadObject {
     throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
     try {
       /* play.minio.io for test and development. */
-      MinioClient minioClient = new MinioClient("https://play.minio.io:9000", "Q3AM3UQ867SPQQA43P2F",
+      MinioClient minioClient = new MinioClient("https://play.min.io:9000", "Q3AM3UQ867SPQQA43P2F",
                                                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
       /* Amazon S3: */

--- a/examples/UploadObject.java
+++ b/examples/UploadObject.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/ContentInputStream.java
+++ b/functional/ContentInputStream.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/ContentInputStream.java
+++ b/functional/ContentInputStream.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1,7 +1,7 @@
 
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017, 2018MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1,7 +1,7 @@
 
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017, 2018 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017, 2018MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/MintLogger.java
+++ b/functional/MintLogger.java
@@ -1,6 +1,6 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/MintLogger.java
+++ b/functional/MintLogger.java
@@ -1,6 +1,6 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/PutObjectRunnable.java
+++ b/functional/PutObjectRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Minio Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016 Minio, Inc.
+ *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functional/PutObjectRunnable.java
+++ b/functional/PutObjectRunnable.java
@@ -1,5 +1,5 @@
 /*
- *MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015,2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Official company name `Minio` became `MinIO`. 
This change requires all references in the code and documentation to be modified as `MinIO` and the links, `....://xxx.minio.io`, to be `....://xxx.min.io`.

Information about the change:
Used Visual Studio Code Editor regular expressions to find and replace those patterns that match the text in all minio-java repo files. 

Here are the two regular expressions used to complete the job in 2 steps:

First, choose "Find in Files' from the Edit menu and activate `Match Case` and `Use Regular Expression` options.
1.  Replace the links using the following regular expressions:

| Find | Replace |
| ------ | ----------- |
| (//(slack\|docs\|play\|dl\|blog)\.\|//)minio\.io | $1min.io |

The above regular expression replaces the links that start with either `slack` or `docs` or ``play` or `dl` or `blog` or nothing before `minio.io`.

2. 
| Find | Replace |
| ------ | ----------- |
| \bMinio\b | MinIO |
