### PR TITLE
 Protocol set to 1.1

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -68,6 +68,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.Protocol;
 
 import org.joda.time.DateTime;
 import org.xmlpull.v1.XmlPullParser;
@@ -655,11 +656,14 @@ public class MinioClient {
     if (httpClient != null) {
       this.httpClient = httpClient;
     } else {
+      List<Protocol> protocol = new LinkedList<>();
+      protocol.add(Protocol.HTTP_1_1);
       this.httpClient = new OkHttpClient();
       this.httpClient = this.httpClient.newBuilder()
         .connectTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.SECONDS)
         .writeTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.SECONDS)
         .readTimeout(DEFAULT_CONNECTION_TIMEOUT, TimeUnit.SECONDS)
+        .protocols(protocol)
         .build();
     }
 

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1196,13 +1196,10 @@ public class FunctionalTest {
       }
 
       InputStream stream = client.getObject(bucketName, objectName, sse);
-      byte[] getbyteArray = new byte[stream.available()];
+      byte[] getbyteArray = new byte[stream.available()]; 
       int bytes_read_get = stream.read(getbyteArray);
       String getString = new String(getbyteArray, StandardCharsets.UTF_8);
       stream.close();
-
-      // client.getObject(bucketName, objectName, sse)
-      // .close();
 
       // Compare if contents received are same as the initial uploaded object.
       if ((!putString.equals(getString)) || (bytes_read_put != bytes_read_get)) {


### PR DESCRIPTION
`okhttp3.OkHttpClient` uses default http2.0  by default, which has been changed to 1.1 as  web server behaved incorrectly when HTTP/2 is enabled. 
With http2.0 errors like `okhttp3.internal.http2.StreamResetException: stream was reset: PROTOCOL_ERROR`  and `okhttp3.internal.http2.StreamResetException: stream was reset: NO_ERROR` arises


The resolution to this issue as suggested in community is to change the protocol to 1.1 
[Refer](https://github.com/square/okhttp/issues/3955)  and thus this PR restricts the protocol to 1.1


[Fixes](https://github.com/minio/minio/issues/7501)
[Refer](https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html)  

```
 public OkHttpClient.Builder protocols(List<Protocol> protocols)
Configure the protocols used by this client to communicate with remote servers. 
By default this client will prefer the most efficient transport available, falling back to more
 ubiquitous protocols. Applications should only call this method to avoid specific 
compatibility problems, such as web servers that behave incorrectly when HTTP/2 is enabled.
```