### PR TITLE
fix: handle SSE in copyObject() properly and have one source code.

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1301,6 +1301,17 @@ public class MinioClient {
     }
   }
 
+  private void checkWriteRequestSse(ServerSideEncryption sse) throws InvalidArgumentException {
+    if (sse == null) {
+      return;
+    }
+
+    if (sse.getType().requiresTls() && !this.baseUrl.isHttps()) {
+      throw new InvalidArgumentException(sse.getType().name()
+                                         + " operations must be performed over a secure connection.");
+    }
+  }
+
   /**
    * Executes GET method for given request parameters.
    *
@@ -2003,13 +2014,15 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
+   *
+   * @deprecated As of release 7.0
    */
+  @Deprecated
   public void copyObject(String bucketName, String objectName, String destBucketName)
       throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException, InvalidResponseException {
-
-    copyObject(bucketName, objectName, destBucketName, null, null, null);
+    copyObject(destBucketName, objectName, null, null, bucketName, objectName, null, null);
   }
 
   /**
@@ -2046,13 +2059,18 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
+   *
+   * @deprecated As of release 7.0
    */
+  @Deprecated
   public void copyObject(String bucketName, String objectName, String destBucketName, String destObjectName)
       throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException, InvalidResponseException {
-
-    copyObject(bucketName, objectName, destBucketName, destObjectName, null, null);
+    if (destObjectName == null) {
+      destObjectName = objectName;
+    }
+    copyObject(destBucketName, destObjectName, null, null, bucketName, objectName, null, null);
   }
 
   /**
@@ -2091,14 +2109,15 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
+   *
+   * @deprecated As of release 7.0
    */
-  public void copyObject(String bucketName, String objectName, String destBucketName,
-                         CopyConditions copyConditions)
+  @Deprecated
+  public void copyObject(String bucketName, String objectName, String destBucketName, CopyConditions copyConditions)
         throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
         NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
         InvalidArgumentException, InvalidResponseException {
-
-    copyObject(bucketName, objectName, destBucketName, null, copyConditions, null);
+    copyObject(destBucketName, objectName, null, null, bucketName, objectName, null, copyConditions);
   }
 
   /**
@@ -2140,14 +2159,19 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
+   *
+   * @deprecated As of release 7.0
    */
-  public void copyObject(String bucketName, String objectName, String destBucketName,
-                         String destObjectName, CopyConditions copyConditions)
+  @Deprecated
+  public void copyObject(String bucketName, String objectName, String destBucketName, String destObjectName,
+                         CopyConditions copyConditions)
       throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException, InvalidResponseException {
-
-    copyObject(bucketName, objectName, destBucketName, destObjectName, copyConditions, null);
+    if (destObjectName == null) {
+      destObjectName = objectName;
+    }
+    copyObject(destBucketName, destObjectName, null, null, bucketName, objectName, null, copyConditions);
   }
 
   /**
@@ -2193,30 +2217,19 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
+   *
+   * @deprecated As of release 7.0
    */
+  @Deprecated
   public void copyObject(String bucketName, String objectName, ServerSideEncryption sseSource, String destBucketName,
                          String destObjectName, CopyConditions copyConditions, ServerSideEncryption sseTarget)
       throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException, InvalidResponseException {
-
-    if ((sseTarget.getType() == ServerSideEncryption.Type.SSE_C) && (!this.baseUrl.isHttps())) {
-      throw new InvalidArgumentException("SSE_C operations must be performed over a secure connection.");
-    } else if ((sseTarget.getType() == (ServerSideEncryption.Type.SSE_KMS)) && (!this.baseUrl.isHttps())) {
-      throw new InvalidArgumentException("SSE_KMS operations must be performed over a secure connection.");
+    if (destObjectName == null) {
+      destObjectName = objectName;
     }
-    Map<String, String> headerTarget = new HashMap<>();
-    Map<String, String> headers = new HashMap<>();
-    sseTarget.marshal(headerTarget);
-    if (sseTarget.getType() == ServerSideEncryption.Type.SSE_C) {
-      Map<String, String> headerSource = new HashMap<>();
-      sseSource.marshal(headerSource);
-      headers.putAll(headerSource);
-      headers.putAll(headerTarget);
-    } else {
-      headers.putAll(headerTarget);
-    }
-    copyObject(bucketName, objectName, destBucketName, destObjectName, copyConditions, headers);
+    copyObject(destBucketName, destObjectName, null, sseTarget, bucketName, objectName, sseSource, copyConditions);
   }
 
   /**
@@ -2261,49 +2274,114 @@ public class MinioClient {
    * @throws InternalException           upon internal library error
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
+   *
+   * @deprecated As of release 7.0
    */
+  @Deprecated
   public void copyObject(String bucketName, String objectName, String destBucketName,
                          String destObjectName, CopyConditions copyConditions,
                          Map<String,String> metadata)
       throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
       NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
       InvalidArgumentException, InvalidResponseException {
-
-    if (bucketName == null) {
-      throw new InvalidArgumentException("Source bucket name cannot be empty");
-    }
-    if (objectName == null) {
-      throw new InvalidArgumentException("Source object name cannot be empty");
-    }
-    if (destBucketName == null) {
-      throw new InvalidArgumentException("Destination bucket name cannot be empty");
-    }
-
-    // Escape source object path.
-    String sourceObjectPath = S3Escaper.encodePath(bucketName + "/" + objectName);
-
-    // Destination object name is optional, if empty default to source object name.
     if (destObjectName == null) {
       destObjectName = objectName;
     }
+    copyObject(destBucketName, destObjectName, metadata, null, bucketName, objectName, null, copyConditions);
+  }
 
-    Map<String, String> headerMap = new HashMap<>();
 
-    // Set the object source
-    headerMap.put("x-amz-copy-source", sourceObjectPath);
+  /**
+   * Copy a source object into a new object with the provided name in the provided bucket.
+   * optionally can take a key value CopyConditions and server side encryption as well for
+   * conditionally attempting copyObject.
+   *
+   * </p>
+   * <b>Example:</b><br>
+   *
+   * <pre>
+   * {@code minioClient.copyObject("my-bucketname", "my-objectname", headers, sse, "my-srcbucketname",
+   * "my-srcobjname", srcSse, copyConditions);}
+   * </pre>
+   *
+   * @param bucketName
+   *          Destination bucket name.
+   * @param objectName
+   *          Destination object name.
+   * @param headerMap
+   *          Destination object custom metadata.
+   * @param sse
+   *          Server side encryption of destination object.
+   * @param srcBucketName
+   *          Source bucket name.
+   * @param srcObjectName
+   *          Source object name.
+   * @param srcSse
+   *          Server side encryption of source object.
+   * @param copyConditions
+   *          CopyConditions object with collection of supported CopyObject conditions.
+   *
+   * @throws InvalidBucketNameException  upon invalid bucket name is given
+   * @throws NoSuchAlgorithmException
+   *           upon requested algorithm was not found during signature calculation
+   * @throws InsufficientDataException  upon getting EOFException while reading given
+   *           InputStream even before reading given length
+   * @throws IOException                 upon connection error
+   * @throws InvalidKeyException
+   *           upon an invalid access key or secret key
+   * @throws NoResponseException         upon no response from server
+   * @throws XmlPullParserException      upon parsing response xml
+   * @throws ErrorResponseException      upon unsuccessful execution
+   * @throws InternalException           upon internal library error
+   * @throws InvalidArgumentException    upon invalid value is passed to a method.
+   * @throws InvalidResponseException    upon a non-xml response from server
+   */
+  public void copyObject(String bucketName, String objectName, Map<String,String> headerMap, ServerSideEncryption sse,
+                         String srcBucketName, String srcObjectName, ServerSideEncryption srcSse,
+                         CopyConditions copyConditions)
+    throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
+           NoResponseException, ErrorResponseException, InternalException, IOException, XmlPullParserException,
+           InvalidArgumentException, InvalidResponseException {
+    if (bucketName == null) {
+      throw new InvalidArgumentException("bucket name cannot be empty");
+    }
 
-    // If no conditions available, skip addition else add the conditions to the header
+    if (objectName == null) {
+      throw new InvalidArgumentException("object name cannot be empty");
+    }
+
+    checkWriteRequestSse(sse);
+
+    if (srcBucketName == null) {
+      throw new InvalidArgumentException("Source bucket name cannot be empty");
+    }
+
+    // Source object name is optional, if empty default to object name.
+    if (srcObjectName == null) {
+      srcObjectName = objectName;
+    }
+
+    checkReadRequestSse(srcSse);
+
+    if (headerMap == null) {
+      headerMap = new HashMap<>();
+    }
+
+    headerMap.put("x-amz-copy-source", S3Escaper.encodePath(srcBucketName + "/" + srcObjectName));
+
+    if (sse != null) {
+      sse.marshal(headerMap);
+    }
+
+    if (srcSse != null) {
+      srcSse.marshal(headerMap);
+    }
+
     if (copyConditions != null) {
       headerMap.putAll(copyConditions.getConditions());
     }
 
-    // Set metadata on the destination of object.
-    if (metadata != null) {
-      headerMap.putAll(metadata);
-    }
-
-    HttpResponse response = executePut(destBucketName, destObjectName, headerMap,
-        null, "", 0);
+    HttpResponse response = executePut(bucketName, objectName, headerMap, null, "", 0);
 
     // For now ignore the copyObjectResult, just read and parse it.
     CopyObjectResult result = new CopyObjectResult();
@@ -3455,7 +3533,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, String fileName)
@@ -3497,7 +3575,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, String fileName, String contentType)
@@ -3539,7 +3617,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, String fileName, ServerSideEncryption sse)
@@ -3672,7 +3750,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream, long size, String contentType)
@@ -3741,7 +3819,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream, Map<String, String> headerMap)
@@ -3815,7 +3893,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream, long size,
@@ -3883,7 +3961,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream, long size,
@@ -3965,7 +4043,7 @@ public class MinioClient {
      * @throws InsufficientDataException   upon getting EOFException while reading given
      * @throws InvalidResponseException    upon a non-xml response from server
      *
-     * @deprecated As of release 6.1
+     * @deprecated As of release 7.0
      */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream,
@@ -4046,7 +4124,7 @@ public class MinioClient {
    * @throws InsufficientDataException   upon getting EOFException while reading given
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream, long size,
@@ -4115,7 +4193,7 @@ public class MinioClient {
    * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
    *
-   * @deprecated As of release 6.1
+   * @deprecated As of release 7.0
    */
   @Deprecated
   public void putObject(String bucketName, String objectName, InputStream stream, String contentType)
@@ -4286,23 +4364,14 @@ public class MinioClient {
     }
 
     if (sse != null) {
-      if (sse.getType() == ServerSideEncryption.Type.SSE_C && !this.baseUrl.isHttps()) {
-        throw new InvalidArgumentException("SSE_C operations must be performed over a secure connection.");
-      } else if (sse.getType() == ServerSideEncryption.Type.SSE_KMS && !this.baseUrl.isHttps()) {
-        throw new InvalidArgumentException("SSE_KMS operations must be performed over a secure connection.");
-      }
-
+      checkWriteRequestSse(sse);
       // The correct approach is see.marshal() needs to accept boolean isHttps and do above checks inside.
       sse.marshal(headerMap);
     }
 
 
     if (size <= MIN_MULTIPART_SIZE) {
-      // Single put object.
-      if (sse != null) {
-        sse.marshal(headerMap);
-      }
-      putObject(bucketName, objectName, data, size.intValue(),headerMap , null, 0);
+      putObject(bucketName, objectName, data, size.intValue(), headerMap, null, 0);
       return;
     }
 

--- a/examples/CopyObject.java
+++ b/examples/CopyObject.java
@@ -70,8 +70,8 @@ public class CopyObject {
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 
-      minioClient.copyObject("my-bucketname", "my-objectname", "my-destbucketname",
-                             "my-objectname-copy");
+      minioClient.copyObject("my-destbucketname", "my-objectname-copy", null, null,
+                             "my-bucketname", "my-objectname", null, null);
       System.out.println("my-objectname-copy copied to my-destbucketname successfully");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);

--- a/examples/CopyObjectEncrypted.java
+++ b/examples/CopyObjectEncrypted.java
@@ -64,8 +64,8 @@ public class CopyObjectEncrypted {
       minioClient.putObject("my-bucketname", "my-objectname", bais, Long.valueOf(bais.available()), null, ssePut, null);
       System.out.println("my-objectname is uploaded successfully");
         
-      minioClient.copyObject("my-bucketname", "my-objectname", sseSource, "my-destbucketname",
-                             "my-objectname-copy", null, sseTarget);
+      minioClient.copyObject("my-destbucketname", "my-objectname-copy", null, sseTarget,
+                             "my-bucketname", "my-objectname", sseSource, null);
 
       bais.close();
 

--- a/examples/CopyObjectEncryptedKms.java
+++ b/examples/CopyObjectEncryptedKms.java
@@ -61,8 +61,8 @@ public class CopyObjectEncryptedKms {
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 
-      minioClient.copyObject("my-bucketname", "my-objectname", null, "my-destbucketname",
-                             "my-objectname-copy", null, sse);
+      minioClient.copyObject("my-destbucketname", "my-objectname-copy", null, sse,
+                             "my-bucketname", "my-objectname", null, null);
       System.out.println("my-objectname-copy copied to my-destbucketname successfully");
         
     } catch (MinioException e) {

--- a/examples/CopyObjectEncryptedS3.java
+++ b/examples/CopyObjectEncryptedS3.java
@@ -55,8 +55,8 @@ public class CopyObjectEncryptedS3 {
       bais.close();
       System.out.println("my-objectname is uploaded successfully");
 
-      minioClient.copyObject("my-bucketname", "my-objectname", null, "my-destbucketname",
-                             "my-objectname-copy", null, sse);
+      minioClient.copyObject("my-destbucketname", "my-objectname-copy", null, sse,
+                             "my-bucketname", "my-objectname", null, null);
       System.out.println("my-objectname-copy copied to my-destbucketname successfully");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);

--- a/examples/CopyObjectMetadata.java
+++ b/examples/CopyObjectMetadata.java
@@ -79,8 +79,8 @@ public class CopyObjectMetadata {
       Map<String, String> metadata = new HashMap<>();
       metadata.put("Content-Type", "application/javascript");
 
-      minioClient.copyObject("my-bucketname", "my-objectname", "my-destbucketname",
-                             "my-objectname-copy", copyConditions, metadata);
+      minioClient.copyObject("my-destbucketname", "my-objectname-copy", metadata, null,
+                             "my-bucketname", "my-objectname", null, copyConditions);
       System.out.println("my-objectname-copy copied to my-destbucketname successfully");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -2010,7 +2010,7 @@ public class FunctionalTest {
 
       String destBucketName = getRandomName();
       client.makeBucket(destBucketName);
-      client.copyObject(bucketName, objectName, destBucketName);
+      client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, null);
       client.getObject(destBucketName, objectName).close();
 
       client.removeObject(bucketName, objectName);
@@ -2048,7 +2048,7 @@ public class FunctionalTest {
       invalidETag.setMatchETag("TestETag");
 
       try {
-        client.copyObject(bucketName, objectName, destBucketName, invalidETag);
+        client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, invalidETag);
       } catch (ErrorResponseException e) {
         if (!e.errorResponse().code().equals("PreconditionFailed")) {
           throw e;
@@ -2094,7 +2094,7 @@ public class FunctionalTest {
       copyConditions.setMatchETag(stat.etag());
 
       // File should be copied as ETag set in copyConditions matches object's ETag.
-      client.copyObject(bucketName, objectName, destBucketName, copyConditions);
+      client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, copyConditions);
       client.getObject(destBucketName, objectName).close();
 
       client.removeObject(bucketName, objectName);
@@ -2136,7 +2136,7 @@ public class FunctionalTest {
 
       // File should be copied as ETag set in copyConditions doesn't match object's
       // ETag.
-      client.copyObject(bucketName, objectName, destBucketName, copyConditions);
+      client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, copyConditions);
       client.getObject(destBucketName, objectName).close();
 
       client.removeObject(bucketName, objectName);
@@ -2179,7 +2179,7 @@ public class FunctionalTest {
       matchingETagNone.setMatchETagNone(stat.etag());
 
       try {
-        client.copyObject(bucketName, objectName, destBucketName, matchingETagNone);
+        client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, matchingETagNone);
       } catch (ErrorResponseException e) {
         // File should not be copied as ETag set in copyConditions matches object's
         // ETag.
@@ -2228,7 +2228,7 @@ public class FunctionalTest {
       modifiedDateCondition.setModified(dateRepresentation);
 
       // File should be copied as object was modified after the set date.
-      client.copyObject(bucketName, objectName, destBucketName, modifiedDateCondition);
+      client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, modifiedDateCondition);
       client.getObject(destBucketName, objectName).close();
 
       client.removeObject(bucketName, objectName);
@@ -2272,7 +2272,7 @@ public class FunctionalTest {
       invalidUnmodifiedCondition.setUnmodified(dateRepresentation);
 
       try {
-        client.copyObject(bucketName, objectName, destBucketName, invalidUnmodifiedCondition);
+        client.copyObject(destBucketName, objectName, null, null, bucketName, null, null, invalidUnmodifiedCondition);
       } catch (ErrorResponseException e) {
         // File should not be copied as object was modified after date set in
         // copyConditions.
@@ -2323,7 +2323,8 @@ public class FunctionalTest {
       Map<String, String> metadata = new HashMap<>();
       metadata.put("Content-Type", customContentType);
 
-      client.copyObject(bucketName, objectName, destBucketName, objectName, copyConditions, metadata);
+      client.copyObject(destBucketName, objectName, metadata, null,
+                        bucketName, objectName, null, copyConditions);
 
       ObjectStat objectStat = client.statObject(destBucketName, objectName);
       if (!customContentType.equals(objectStat.contentType())) {
@@ -2369,7 +2370,8 @@ public class FunctionalTest {
       CopyConditions copyConditions = new CopyConditions();
       copyConditions.setReplaceMetadataDirective();
 
-      client.copyObject(bucketName, objectName, bucketName, objectName, copyConditions, new HashMap<String, String>());
+      client.copyObject(bucketName, objectName, new HashMap<String, String>(), null,
+                        bucketName, objectName, null, copyConditions);
       ObjectStat objectStat = client.statObject(bucketName, objectName);
       if (objectStat.httpHeaders().containsKey("X-Amz-Meta-Test")) {
         throw new Exception("expected user-defined metadata has been removed");
@@ -2422,7 +2424,7 @@ public class FunctionalTest {
       CopyConditions copyConditions = new CopyConditions();
       copyConditions.setReplaceMetadataDirective();
 
-      client.copyObject(bucketName, objectName, sseSource, bucketName, objectName, copyConditions, sseTarget);
+      client.copyObject(bucketName, objectName, null, sseTarget, bucketName, objectName, sseSource, copyConditions);
       ObjectStat objectStat = client.statObject(bucketName, objectName, sseTarget);
 
       client.removeObject(bucketName, objectName);
@@ -2463,7 +2465,7 @@ public class FunctionalTest {
       CopyConditions copyConditions = new CopyConditions();
       copyConditions.setReplaceMetadataDirective();
 
-      client.copyObject(bucketName, objectName, null, bucketName, objectName, copyConditions, sse);
+      client.copyObject(bucketName, objectName, null, sse, bucketName, objectName, null, copyConditions);
       ObjectStat objectStat = client.statObject(bucketName, objectName);
       if (objectStat.httpHeaders().containsKey("X-Amz-Meta-Test")) {
         throw new Exception("expected user-defined metadata has been removed");
@@ -2515,7 +2517,7 @@ public class FunctionalTest {
       CopyConditions copyConditions = new CopyConditions();
       copyConditions.setReplaceMetadataDirective();
 
-      client.copyObject(bucketName, objectName, null, bucketName, objectName, copyConditions, sse);
+      client.copyObject(bucketName, objectName, null, sse, bucketName, objectName, null, copyConditions);
       ObjectStat objectStat = client.statObject(bucketName, objectName);
       if (objectStat.httpHeaders().containsKey("X-Amz-Meta-Test")) {
         throw new Exception("expected user-defined metadata has been removed");


### PR DESCRIPTION
Added new version of copyObject(). Note: this method makes source and
destination argument swapping correctly to denote on which bucket and
object the request is sent.
    
```
public void copyObject(String bucketName, String objectName, Map<String,String> headerMap, ServerSideEncryption sse,
                       String srcBucketName, String srcObjectName, ServerSideEncryption srcSse,
                       CopyConditions copyConditions)
```
