### PR TITLE
[BUG][FIX] fix NPE when try to stat object named "/"

### DIFF
--- a/api/src/main/java/io/minio/ObjectStat.java
+++ b/api/src/main/java/io/minio/ObjectStat.java
@@ -48,7 +48,8 @@ public class ObjectStat {
     this.bucketName = bucketName;
     this.name = name;
     this.contentType = header.contentType();
-    this.createdTime = (Date) header.lastModified().clone();
+    Date lastModified = header.lastModified();
+    this.createdTime = lastModified == null ? new Date(-1L) : (Date) header.lastModified().clone();
     this.length = header.contentLength();
 
     if (header.etag() != null) {


### PR DESCRIPTION
NPE thrown when try to stat object named "/", code to reproduction:

``` java
ObjectStat stat = factory.getClient().statObject("test", "/");
```

exception thrown:
``` java
java.lang.NullPointerException
	at io.minio.ResponseHeader.lastModified(ResponseHeader.java:132)
	at io.minio.ObjectStat.<init>(ObjectStat.java:51)
	at io.minio.MinioClient.statObject(MinioClient.java:1482)
```