### PR TITLE
Add success action status to PresignedPostPolicy

### DIFF
--- a/api/src/main/java/io/minio/PostPolicy.java
+++ b/api/src/main/java/io/minio/PostPolicy.java
@@ -31,6 +31,7 @@ import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 
 import io.minio.errors.InvalidArgumentException;
+import io.minio.SuccessActionStatus;
 
 
 /**
@@ -44,6 +45,7 @@ public class PostPolicy {
   private final boolean startsWith;
   private final DateTime expirationDate;
   private String contentType;
+  private int successActionStatus;
   private String contentEncoding;
   private long contentRangeStart;
   private long contentRangeEnd;
@@ -91,6 +93,18 @@ public class PostPolicy {
     this.contentType = contentType;
   }
 
+  /**
+   * Sets success action status.
+   */
+  public void setSuccessActionStatus(int successActionStatus) throws InvalidArgumentException {
+    if (!(successActionStatus ==  SuccessActionStatus.SuccessActionStatus200.getValue()
+        || successActionStatus == SuccessActionStatus.SuccessActionStatus201.getValue()
+        || successActionStatus == SuccessActionStatus.SuccessActionStatus204.getValue())) {
+      throw new InvalidArgumentException("Invalid action status, acceptable values are 200, 201, or 204");
+    }
+
+    this.successActionStatus = successActionStatus;
+  }
 
   /**
    * Sets content encoding.
@@ -209,6 +223,11 @@ public class PostPolicy {
     if (this.contentEncoding != null) {
       conditions.add(new String[]{"eq", "$Content-Encoding", this.contentEncoding});
       formData.put("Content-Encoding", this.contentEncoding);
+    }
+
+    if (this.successActionStatus > 0) {
+      conditions.add(new String[]{"eq", "success_action_status", Integer.toString(this.successActionStatus)});
+      formData.put("success_action_status", Integer.toString(this.successActionStatus));
     }
 
     if (this.contentRangeStart > 0 && this.contentRangeEnd > 0) {

--- a/api/src/main/java/io/minio/SuccessActionStatus.java
+++ b/api/src/main/java/io/minio/SuccessActionStatus.java
@@ -1,0 +1,33 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+public enum SuccessActionStatus {
+
+  SuccessActionStatus201(201), SuccessActionStatus200(200), SuccessActionStatus204(204);
+
+  private final int value;
+
+  private SuccessActionStatus(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -2992,7 +2992,7 @@ try {
 
 `public Map<String,String> presignedPostPolicy(PostPolicy policy)`
 
-Allows setting policy conditions to a presigned URL for POST operations. Policies such as bucket name to receive object uploads, key name prefixes, expiry policy may be set.
+Allows setting policy conditions to a presigned URL for POST operations. Policies such as bucket name to receive object uploads, key name prefixes, expiry policy may be set. The client receives HTTP status code under key success_action_status, when the file is uploaded successfully. If its value is set to 201, the client notifies with a XML document containing the key where the file was uploaded to.
 
 [View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#presignedPostPolicy-io.minio.PostPolicy-)
 
@@ -3022,10 +3022,13 @@ __Example__
 
 ```java
 try {
-	PostPolicy policy = new PostPolicy("mybucket", "myobject",
-  DateTime.now().plusDays(7));
+	PostPolicy policy = new PostPolicy("mybucket", "myobject", DateTime.now().plusDays(7));
+	// 'my-objectname' should be 'image/png' content type
 	policy.setContentType("image/png");
+	// set success action status to 201 to receive XML document
+	policy.setSuccessActionStatus(201);
 	Map<String,String> formData = minioClient.presignedPostPolicy(policy);
+	// Print a curl command that can be executable with the file /tmp/userpic.png and the file will be uploaded.
 	System.out.print("curl -X POST ");
 	for (Map.Entry<String,String> entry : formData.entrySet()) {
     System.out.print(" -F " + entry.getKey() + "=" + entry.getValue());

--- a/examples/PresignedPostPolicy.java
+++ b/examples/PresignedPostPolicy.java
@@ -45,6 +45,10 @@ public class PresignedPostPolicy {
       PostPolicy policy = new PostPolicy("my-bucketname", "my-objectname", DateTime.now().plusDays(7));
       // 'my-objectname' should be 'image/png' content type
       policy.setContentType("image/png");
+      // set success action status to 201 because we want the client to notify us with the S3 key
+      // where the file was uploaded to.
+      policy.setSuccessActionStatus(201);
+
       Map<String,String> formData = minioClient.presignedPostPolicy(policy);
 
       // Print a curl command that can be executable with the file /tmp/userpic.png and the file will be uploaded.


### PR DESCRIPTION
Parameter added to set `success-action-status` for making PresignedPostPolicy request.

The generated curl command : 
``` 
curl -X POST  -F bucket=testbucket -F x-amz-date=20190804T172411Z -F success_action_status=201 -F x-amz-signature=c9358c3dc8c5e23b451c1a248f6523e44daeb1a01bd63999b3f389e6a8345fc4 -F key=my-objectname -F x-amz-algorithm=AWS4-HMAC-SHA256 -F Content-Type=image/png -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20190804/us-east-1/s3/aws4_request -F policy=eyJleHBpcmF0aW9uIjoiMjAxOS0wOC0xMVQxNzoyNDoxMC4xNzNaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwidGVzdGJ1Y2tldCJdLFsiZXEiLCIka2V5IiwibXktb2JqZWN0bmFtZSJdLFsiZXEiLCIkQ29udGVudC1UeXBlIiwiaW1hZ2UvcG5nIl0sWyJlcSIsInN1Y2Nlc3NfYWN0aW9uX3N0YXR1cyIsIjIwMCJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTkwODA0L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXSxbImVxIiwiJHgtYW16LWRhdGUiLCIyMDE5MDgwNFQxNzI0MTFaIl1dfQ== -F file=/home/ashish/Pictures/test.png https://play.min.io:9000/testbucket 
```
The XML received :
```
<?xml version="1.0" encoding="UTF-8"?>
<PostResponse><Bucket>testbucket</Bucket><Key>my-objectname</Key><ETag>&#34;d1237fb44ada3718026aeafc725e8402&#34;</ETag><Location>https://play.min.io:9000/testbucket/my-objectname</Location></PostResponse>
```

Closes #782 

