### PR TITLE
Docs and examples added for Object Lock

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -3513,8 +3513,6 @@ public class MinioClient {
    * @param bucketName Bucket name.
    *
    * @throws InvalidBucketNameException  upon invalid bucket name is given
-   * @throws RegionConflictException     upon  passed region conflicts with the one
-   *                                     previously specified.
    * @throws NoSuchAlgorithmException
    *           upon requested algorithm was not found during signature calculation
    * @throws IOException                 upon connection error
@@ -3529,7 +3527,7 @@ public class MinioClient {
    * @throws InvalidResponseException    upon a non-xml response from serve
    */
   public void enableVersioning(String bucketName)
-    throws InvalidBucketNameException, RegionConflictException, NoSuchAlgorithmException, InsufficientDataException,
+    throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
                 IOException, InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
                 InternalException, InvalidResponseException {
     Map<String, String> queryParamMap = new HashMap<>();
@@ -3551,8 +3549,6 @@ public class MinioClient {
    * @param bucketName Bucket name.
    *
    * @throws InvalidBucketNameException  upon invalid bucket name is given
-   * @throws RegionConflictException     upon  passed region conflicts with the one
-   *                                     previously specified.
    * @throws NoSuchAlgorithmException
    *           upon requested algorithm was not found during signature calculation
    * @throws IOException                 upon connection error
@@ -3567,7 +3563,7 @@ public class MinioClient {
    * @throws InvalidResponseException    upon a non-xml response from serve
    */
   public void disableVersioning(String bucketName)
-    throws InvalidBucketNameException, RegionConflictException, NoSuchAlgorithmException, InsufficientDataException,
+    throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
                 IOException, InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
                 InternalException, InvalidResponseException {
     Map<String, String> queryParamMap = new HashMap<>();
@@ -3601,13 +3597,12 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws ErrorResponseException      upon unsuccessful execution
    * @throws InternalException           upon internal library error
-   * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
    */
   public void setDefaultRetention(String bucketName, ObjectLockConfiguration config)
     throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
-           InternalException, InvalidArgumentException, InvalidResponseException {
+           InternalException, InvalidResponseException {
     Map<String, String> queryParamMap = new HashMap<>();
     queryParamMap.put("object-lock", "");
 
@@ -3636,13 +3631,12 @@ public class MinioClient {
    * @throws XmlPullParserException      upon parsing response xml
    * @throws ErrorResponseException      upon unsuccessful execution
    * @throws InternalException           upon internal library error
-   * @throws InvalidArgumentException    upon invalid value is passed to a method.
    * @throws InvalidResponseException    upon a non-xml response from server
    */
   public ObjectLockConfiguration getDefaultRetention(String bucketName)
     throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
-           InternalException, InvalidArgumentException, InvalidResponseException {
+           InternalException, InvalidResponseException {
     Map<String, String> queryParamMap = new HashMap<>();
     queryParamMap.put("object-lock", "");
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,6 +26,10 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSK
 | [`listenBucketNotification`](#listenBucketNotification) |  |   |   |
 | [`setBucketNotification`](#setBucketNotification) |  |   |   |
 | [`getBucketNotification`](#getBucketNotification) |  |   |   |
+| [`enableVersioning`](#enableVersioning) |  |   |   |
+| [`disableVersioning`](#disableVersioning) |  |   |   |
+| [`setDefaultRetention`](#setDefaultRetention) |  |   |   |
+| [`getDefaultRetention`](#getDefaultRetention) |  |   |   |
 
 ## 1. Constructors
 
@@ -317,6 +321,59 @@ try {
     // Create bucket 'my-bucketname'.
     minioClient.makeBucket("mybucket","us-east-1");
     System.out.println("mybucket is created successfully");
+  }
+} catch (MinioException e) {
+  System.out.println("Error occurred: " + e);
+}
+```
+
+<a name="makeBucket"></a>
+### makeBucket(String bucketName, String region, boolean objectLock)
+`public void makeBucket(String bucketName, String region, boolean objectLock)`
+
+Creates a new bucket with object lock functionality enabled.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#makeBucket-java.lang.String-java.lang.String-boolean-)
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_ | Name of the bucket.  |
+| ``region``  | _String_ | Region in which the bucket will be created.  |
+| ``objectLock``  | _bool_ | When true, enables object lock functionality  |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+| ``None``  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        |  ``RegionConflictException`` : upon  passed region conflicts with the one previously specified. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidResponseException`` : upon a non-xml response from server.        |
+
+
+
+__Example__
+
+
+```java
+try {
+  // Create bucket if it doesn't exist.
+  boolean found = minioClient.bucketExists("mybucket");
+  if (found) {
+    System.out.println("mybucket already exists");
+  } else {
+    // Create bucket 'my-bucketname' with object lock functionality enabled
+    minioClient.makeBucket("mybucket","us-east-1", true);
+    System.out.println("mybucket is created successfully with object lock functionality enabled.");
   }
 } catch (MinioException e) {
   System.out.println("Error occurred: " + e);
@@ -949,6 +1006,213 @@ __Example__
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);
     }
+```
+
+<a name="enableVersioning"></a>
+### enableVersioning(String bucketName)
+`public void enableVersioning(String bucketName)`
+
+Object versioning is enabled in bucketName.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#enableVersioning-java.lang.String-)
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_ | Name of the bucket.  |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+| ``None``  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidResponseException`` : upon a non-xml response from server.        |
+
+__Example__
+
+
+```java
+try {
+    // Object versioning is enabled in my-bucketname
+    minioClient.enableVersioning("my-bucketname");
+    System.out.println("Object versioning is enabled in my-bucketname.");
+  }
+} catch (MinioException e) {
+  System.out.println("Error occurred: " + e);
+}
+```
+
+
+<a name="disableVersioning"></a>
+### disableVersioning(String bucketName)
+`public void disableVersioning(String bucketName)`
+
+Object versioning is disabled in bucketName.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#disableVersioning-java.lang.String-)
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_ | Name of the bucket.  |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+| ``None``  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidResponseException`` : upon a non-xml response from server.        |
+
+__Example__
+
+
+```java
+try {
+    // Object versioning is disabled in my-bucketname
+    minioClient.disableVersioning("my-bucketname");
+    System.out.println("Object versioning is disabled in my-bucketname.");
+  }
+} catch (MinioException e) {
+  System.out.println("Error occurred: " + e);
+}
+```
+
+<a name="setDefaultRetention"></a>
+### setDefaultRetention(String bucketName, ObjectLockConfiguration config)
+`public void setDefaultRetention(String bucketName, ObjectLockConfiguration config)`
+
+Set default retention on bucket.
+
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#setDefaultRetention-java.lang.String-io.minio.messages.ObjectLockConfiguration- )
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_ | Name of the bucket.  |
+| ``config``  | _ObjectLockConfiguration_ | Object lock Configuration  |
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+| ``None``  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidResponseException`` : upon a non-xml response from server.        |
+
+__Example__
+
+
+```java
+try {
+      // Create bucket if it doesn't exist.
+      boolean found = s3Client.bucketExists("my-bucketname");
+      if (found) {
+           System.out.println("my-bucketname already exists");
+         } else {
+           // Create bucket 'my-bucketname' with object lock functionality enabled
+           s3Client.makeBucket("my-bucketname", null, true);
+           System.out.println("my-bucketname is created successfully with object lock functionality enabled.");
+         }
+   
+         // Declaring config with Retention mode as Compliance and
+         // duration as 100 days
+         ObjectLockConfiguration setConfig = new ObjectLockConfiguration(RetentionMode.COMPLIANCE,100 , DurationUnit.DAYS);
+   
+         // Set object lock configuration
+         s3Client.setDefaultRetention("my-bucketname",config);
+  
+} catch (MinioException e) {
+  System.out.println("Error occurred: " + e);
+}
+```
+
+
+<a name="getDefaultRetention"></a>
+### getDefaultRetention(String bucketName)
+`public void getDefaultRetention(String bucketName)`
+
+Get default retention of bucket.
+   
+[View Javadoc](http://minio.github.io/minio-java/io/minio/MinioClient.html#getDefaultRetention-java.lang.String- )
+
+__Parameters__
+
+|Param   | Type	  | Description  |
+|:--- |:--- |:--- |
+| ``bucketName``  | _String_ | Name of the bucket.  |
+
+
+
+| Return Type	  | Exceptions	  |
+|:--- |:--- |
+| ``None``  | Listed Exceptions: |
+|        |  ``InvalidBucketNameException`` : upon invalid bucket name. |
+|        | ``NoSuchAlgorithmException`` : upon requested algorithm was not found during signature calculation.           |
+|        | ``InsufficientDataException`` : Thrown to indicate that reading given InputStream gets EOFException before reading given length. |
+|        | ``IOException`` : upon connection error.            |
+|        | ``InvalidKeyException`` : upon an invalid access key or secret key.           |
+|        | ``NoResponseException`` : upon no response from server.            |
+|        | ``org.xmlpull.v1.XmlPullParserException`` : upon parsing response XML.            |
+|        | ``ErrorResponseException`` : upon unsuccessful execution.            |
+|        | ``InternalException`` : upon internal library error.        |
+|        | ``InvalidResponseException`` : upon a non-xml response from server.        |
+
+__Example__
+
+
+```java
+try {
+      // Create bucket if it doesn't exist.
+      boolean found = s3Client.bucketExists("my-bucketname");
+      if (found) {
+           System.out.println("my-bucketname already exists");
+         } else {
+           // Create bucket 'my-bucketname' with object lock functionality enabled
+           s3Client.makeBucket("my-bucketname", null, true);
+           System.out.println("my-bucketname is created successfully with object lock functionality enabled.");
+         }
+   
+         // Declaring config with Retention mode as Compliance and
+         // duration as 100 days
+         ObjectLockConfiguration setConfig = new ObjectLockConfiguration(RetentionMode.COMPLIANCE,100 , DurationUnit.DAYS);
+   
+         // Set object lock configuration
+         s3Client.setDefaultRetention("my-bucketname",config);
+         
+      // Get object lock configuration
+      ObjectLockConfiguration getConfig = s3Client.getDefaultRetention("my-bucketname");
+        
+      System.out.println(" Lock Configuration : " + getConfig)
+  
+} catch (MinioException e) {
+  System.out.println("Error occurred: " + e);
+}
 ```
 
 

--- a/examples/MakeBucketWithLock.java
+++ b/examples/MakeBucketWithLock.java
@@ -1,0 +1,51 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import io.minio.MinioClient;
+import io.minio.errors.MinioException;
+
+public class MakeBucketWithLock {
+  /**
+   * MinioClient.makeBucket() example.
+   */
+  public static void main(String[] args)
+    throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
+    try {
+
+      /* Amazon S3: */
+      MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSKEYID",
+                                               "YOUR-SECRETACCESSKEY");
+
+      // Create bucket if it doesn't exist.
+      boolean found = s3Client.bucketExists("my-bucketname");
+      if (found) {
+        System.out.println("my-bucketname already exists");
+      } else {
+        // Create bucket 'my-bucketname' with object lock functionality enabled
+        s3Client.makeBucket("my-bucketname", null, true);
+        System.out.println("my-bucketname is created successfully with object lock functionality enabled.");
+      }
+    } catch (MinioException e) {
+      System.out.println("Error occurred: " + e);
+    }
+  }
+}

--- a/examples/SetGetBucketObjectLockConfig.java
+++ b/examples/SetGetBucketObjectLockConfig.java
@@ -1,0 +1,68 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+import io.minio.MinioClient;
+import io.minio.messages.DurationUnit;
+import io.minio.messages.ObjectLockConfiguration;
+import io.minio.messages.RetentionMode;
+import io.minio.errors.MinioException;
+
+public class SetGetBucketObjectLockConfig {
+  /**
+   * MinioClient.makeBucket() example.
+   */
+  public static void main(String[] args)
+    throws IOException, NoSuchAlgorithmException, InvalidKeyException, XmlPullParserException {
+    try {
+
+      /* Amazon S3: */
+      MinioClient s3Client = new MinioClient("https://s3.amazonaws.com", "YOUR-ACCESSKEYID",
+                                                 "YOUR-SECRETACCESSKEY");
+
+      // Create bucket if it doesn't exist.
+      boolean found = s3Client.bucketExists("my-bucketname");
+      if (found) {
+        System.out.println("my-bucketname already exists");
+      } else {
+        // Create bucket 'my-bucketname' with object lock functionality enabled
+        s3Client.makeBucket("my-bucketname", null, true);
+        System.out.println("my-bucketname is created successfully with object lock functionality enabled.");
+      }
+
+      // Declaring config with Retention mode as Compliance and
+      // duration as 100 days
+      ObjectLockConfiguration config = new ObjectLockConfiguration(RetentionMode.COMPLIANCE,100 , DurationUnit.DAYS);
+
+      // Set object lock configuration
+      s3Client.setDefaultRetention("my-bucketname" , config);
+
+      // Get object lock configuration
+      ObjectLockConfiguration bucketConfig = s3Client.getDefaultRetention("my-bucketname");
+
+      System.out.println(" Lock Configuration : " + bucketConfig);
+
+
+    } catch (MinioException e) {
+      System.out.println("Error occurred: " + e);
+    }
+  }
+}


### PR DESCRIPTION
Docs updated with below api:
public void makeBucket(String bucketName, String region, boolean objectLock)
public void enableVersioning(String bucketName)
public void disableVersioning(String bucketName)
public void setDefaultRetention(String bucketName, ObjectLockConfiguration config)
public ObjectLockConfiguration getDefaultRetention(String bucketName)

Examples added for make bucket with lock and set/get object lock configuration.