### PR TITLE
Use Optionals for some frequently used get methods.

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -2067,6 +2067,179 @@ public class MinioClient {
     }
   }
 
+  /**
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
+   * InputStream must be closed after use else the connection will remain open.
+   *
+   * <p><b>Example:</b>
+   * <pre>{@code
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname");
+   * if(stream.isPresent) {
+   *      InputStream stream = optionalStream.get();
+   *      // ... do something with it...
+   *      stream.close();
+   * }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   *
+   * @return {@link Optional} containing and {@link InputStream} with the object data.
+   *
+   * @see Optional
+   */
+  public Optional<InputStream> getOptionalObject(String bucketName, String objectName) {
+    try {
+      return Optional.ofNullable(getObject(bucketName, objectName));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
+   * InputStream must be closed after use else the connection will remain open.
+   *
+   * <p><b>Example:</b>
+   * <pre>{@code
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname", sse);
+   * if(stream.isPresent) {
+   *      InputStream stream = optionalStream.get();
+   *      // ... do something with it...
+   *      stream.close();
+   * }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   * @param sse
+   *         Encryption metadata only required for SSE-C.
+   *
+   * @return {@link Optional} containing and {@link InputStream} with the object data.
+   *
+   * @see Optional
+   */
+  public Optional<InputStream> getOptionalObject(String bucketName, String objectName, ServerSideEncryption sse) {
+    try {
+      return Optional.ofNullable(getObject(bucketName, objectName, sse));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+
+  /**
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
+   * InputStream must be closed after use else the connection will remain open.
+   *
+   * <p><b>Example:</b>
+   * <pre>{@code
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname", 1024L);
+   * if(stream.isPresent) {
+   *      InputStream stream = optionalStream.get();
+   *      // ... do something with it...
+   *      stream.close();
+   * }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   * @param offset
+   *         Offset to read at.
+   *
+   * @return {@link Optional} containing and {@link InputStream} with the object data.
+   *
+   * @see Optional
+   */
+  public Optional<InputStream> getOptionalObject(String bucketName, String objectName, long offset) {
+    try {
+      return Optional.ofNullable(getObject(bucketName, objectName, offset));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+
+  /**
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
+   * InputStream must be closed after use else the connection will remain open.
+   *
+   * <p><b>Example:</b>
+   * <pre>{@code
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname", 1024L, 4096L);
+   * if(stream.isPresent) {
+   *      InputStream stream = optionalStream.get();
+   *      // ... do something with it...
+   *      stream.close();
+   * }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   * @param offset
+   *         Offset to read at.
+   * @param length
+   *         Length to read.
+   *
+   * @return {@link Optional} containing and {@link InputStream} with the object data.
+   *
+   * @see Optional
+   */
+  public Optional<InputStream> getOptionalObject(String bucketName, String objectName, long offset, Long length) {
+    try {
+      return Optional.ofNullable(getObject(bucketName, objectName, offset, length));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+
+  /**
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
+   * InputStream must be closed after use else the connection will remain open.
+   *
+   * <p><b>Example:</b>
+   * <pre>{@code
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname", 1024L, 4096L, sse);
+   * if(stream.isPresent) {
+   *      InputStream stream = optionalStream.get();
+   *      // ... do something with it...
+   *      stream.close();
+   * }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   * @param offset
+   *         Offset to read at.
+   * @param length
+   *         Length to read.
+   * @param sse
+   *         Server side encryption
+   *
+   * @return {@link Optional} containing and {@link InputStream} with the object data.
+   *
+   * @see Optional
+   */
+  public Optional<InputStream> getOptionalObject(String bucketName, String objectName, long offset, Long length,
+                                                 ServerSideEncryption sse) {
+    try {
+      return Optional.ofNullable(getObject(bucketName, objectName, offset, length, sse));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
 
   /**
    * Copy a source object into a new destination object with same object name.

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -109,6 +109,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -1554,6 +1555,68 @@ public class MinioClient {
     return objectStat;
   }
 
+
+  /**
+   * Returns meta data information of given object in given bucket, if it is present and accessible.
+   *
+   * </p><b>Example:</b><br>
+   * <pre>{@code
+   *      Optional<ObjectStat> objectStat = minioClient.statOptionalObject("my-bucketname", "my-objectname");
+   *      if(objectStat.isPresent()) {
+   *          System.out.println(objectStat.get());
+   *      }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   *
+   * @return Optional containing populated object metadata.
+   *
+   * @see ObjectStat
+   * @see Optional
+   */
+  public Optional<ObjectStat> statOptionalObject(String bucketName, String objectName) {
+    try {
+      return Optional.ofNullable(statObject(bucketName, objectName));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Returns meta data information of given object in given bucket, if it is present and accessible.
+   *
+   * </p><b>Example:</b><br>
+   * <pre>{@code
+   *      Optional<ObjectStat> objectStat = minioClient.statOptionalObject("my-bucketname", "my-objectname");
+   *      if(objectStat.isPresent()) {
+   *          System.out.println(objectStat.get());
+   *      }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   * @param sse
+   *         Encryption metadata only required for SSE-C.
+   *
+   * @return Optional containing populated object metadata.
+   *
+   * @see ObjectStat
+   * @see Optional
+   */
+  public Optional<ObjectStat> statOptionalObject(String bucketName, String objectName, ServerSideEncryption sse) {
+    try {
+      return Optional.ofNullable(statObject(bucketName, objectName,sse));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+
   /**
    * Gets object's URL in given bucket.  The URL is ONLY useful to retrieve the object's data if the object has
    * public read permissions.
@@ -1589,6 +1652,33 @@ public class MinioClient {
         null, null, null, null, 0);
     HttpUrl url = request.url();
     return url.toString();
+  }
+
+  /**
+   * Gets object's URL in given bucket if object is present and accessible. The URL is ONLY useful to retrieve the object's data if the
+   * object has public read permissions.
+   *
+   * <p><b>Example:</b>
+   * <pre>{@code
+   *      Optional<String> url = minioClient.getOptionalObjectUrl("my-bucketname", "my-objectname");
+   *      if(url.isPresent()) {
+   *          System.out.println(url.get());
+   *      }
+   * }</pre>
+   *
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   *
+   * @return Optional of string containing the URL to download the object.
+   */
+  public Optional<String> getOptionalObjectUrl(String bucketName, String objectName) {
+    try {
+      return Optional.ofNullable(getObjectUrl(bucketName, objectName));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
   }
 
   /**
@@ -2675,6 +2765,51 @@ public class MinioClient {
     Request request = createRequest(method, bucketName, objectName, region, null, queryParamMap, null, body, 0);
     HttpUrl url = Signer.presignV4(request, region, accessKey, secretKey, expires);
     return url.toString();
+  }
+
+  /**
+   * <p>Returns a presigned URL string for a specific object in the bucket if the object is present and accessible.</p>
+   *
+   * <p>The url can be presigned with the following values:
+   * <ul>
+   *     <li>given HTTP method</li>
+   *     <li>expiry time</li>
+   *     <li>custom request params</li>
+   * </ul></p>
+   *
+   * </p><b>Example:</b><br>
+   * <pre>{@code
+   * Optional<String> url = minioClient.getOptionalPresignedObjectUrl(Method.DELETE,
+   *                                                                  "my-bucketname",
+   *                                                                  "my-objectname",
+   *                                                                  60 * 60 * 24,
+   *                                                                  reqParams);
+   * if(url.isPresent()) {
+   *      System.out.println(url.get());
+   * }
+   * }</pre>
+   *
+   * @param method
+   *         HTTP {@link Method}.
+   * @param bucketName
+   *         Bucket name.
+   * @param objectName
+   *         Object name in the bucket.
+   * @param expires
+   *         Expiration time in seconds of presigned URL.
+   * @param reqParams
+   *         Override values for set of response headers. Currently supported request parameters are [response-expires,
+   *         response-content-type, response-cache-control, response-content-disposition]
+   *
+   * @return Optional of string containing the URL to download the object.
+   */
+  public Optional<String> getOptionalPresignedObjectUrl(Method method, String bucketName, String objectName, Integer expires,
+                                                        Map<String, String> reqParams) {
+    try {
+      return Optional.ofNullable(getPresignedObjectUrl(method, bucketName, objectName, expires, reqParams));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
   }
 
   /**

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1580,6 +1580,8 @@ public class MinioClient {
   public Optional<ObjectStat> statOptionalObject(String bucketName, String objectName) {
     try {
       return Optional.ofNullable(statObject(bucketName, objectName));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -1611,6 +1613,8 @@ public class MinioClient {
   public Optional<ObjectStat> statOptionalObject(String bucketName, String objectName, ServerSideEncryption sse) {
     try {
       return Optional.ofNullable(statObject(bucketName, objectName,sse));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -1655,8 +1659,8 @@ public class MinioClient {
   }
 
   /**
-   * Gets object's URL in given bucket if object is present and accessible. The URL is ONLY useful to retrieve the object's data if the
-   * object has public read permissions.
+   * Gets object's URL in given bucket if object is present and accessible.
+   * The URL is ONLY useful to retrieve the object's data if the object has public read permissions.
    *
    * <p><b>Example:</b>
    * <pre>{@code
@@ -1676,6 +1680,8 @@ public class MinioClient {
   public Optional<String> getOptionalObjectUrl(String bucketName, String objectName) {
     try {
       return Optional.ofNullable(getObjectUrl(bucketName, objectName));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -2068,8 +2074,8 @@ public class MinioClient {
   }
 
   /**
-   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
-   * InputStream must be closed after use else the connection will remain open.
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket,
+   * if it exists and is accessible. The InputStream must be closed after use else the connection will remain open.
    *
    * <p><b>Example:</b>
    * <pre>{@code
@@ -2093,14 +2099,16 @@ public class MinioClient {
   public Optional<InputStream> getOptionalObject(String bucketName, String objectName) {
     try {
       return Optional.ofNullable(getObject(bucketName, objectName));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
   }
 
   /**
-   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
-   * InputStream must be closed after use else the connection will remain open.
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket,
+   * if it exists and is accessible. The InputStream must be closed after use else the connection will remain open.
    *
    * <p><b>Example:</b>
    * <pre>{@code
@@ -2126,6 +2134,8 @@ public class MinioClient {
   public Optional<InputStream> getOptionalObject(String bucketName, String objectName, ServerSideEncryption sse) {
     try {
       return Optional.ofNullable(getObject(bucketName, objectName, sse));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -2133,8 +2143,8 @@ public class MinioClient {
 
 
   /**
-   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
-   * InputStream must be closed after use else the connection will remain open.
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket,
+   * if it exists and is accessible. The InputStream must be closed after use else the connection will remain open.
    *
    * <p><b>Example:</b>
    * <pre>{@code
@@ -2160,6 +2170,8 @@ public class MinioClient {
   public Optional<InputStream> getOptionalObject(String bucketName, String objectName, long offset) {
     try {
       return Optional.ofNullable(getObject(bucketName, objectName, offset));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -2167,12 +2179,12 @@ public class MinioClient {
 
 
   /**
-   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
-   * InputStream must be closed after use else the connection will remain open.
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket,
+   * if it exists and is accessible. The InputStream must be closed after use else the connection will remain open.
    *
    * <p><b>Example:</b>
    * <pre>{@code
-   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname", 1024L, 4096L);
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucket", "my-object", 1024L, 4096L);
    * if(stream.isPresent) {
    *      InputStream stream = optionalStream.get();
    *      // ... do something with it...
@@ -2196,6 +2208,8 @@ public class MinioClient {
   public Optional<InputStream> getOptionalObject(String bucketName, String objectName, long offset, Long length) {
     try {
       return Optional.ofNullable(getObject(bucketName, objectName, offset, length));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -2203,12 +2217,12 @@ public class MinioClient {
 
 
   /**
-   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket if it exists and is accessible. The
-   * InputStream must be closed after use else the connection will remain open.
+   * Gets an Optional containing the entire object's data as {@link InputStream} in given bucket,
+   * if it exists and is accessible. The InputStream must be closed after use else the connection will remain open.
    *
    * <p><b>Example:</b>
    * <pre>{@code
-   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucketname", "my-objectname", 1024L, 4096L, sse);
+   * Optional<InputStream> optionalStream = minioClient.getOptionalObject("my-bucket", "my-object", 1024L, 4096L, sse);
    * if(stream.isPresent) {
    *      InputStream stream = optionalStream.get();
    *      // ... do something with it...
@@ -2235,6 +2249,8 @@ public class MinioClient {
                                                  ServerSideEncryption sse) {
     try {
       return Optional.ofNullable(getObject(bucketName, objectName, offset, length, sse));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }
@@ -2976,10 +2992,12 @@ public class MinioClient {
    *
    * @return Optional of string containing the URL to download the object.
    */
-  public Optional<String> getOptionalPresignedObjectUrl(Method method, String bucketName, String objectName, Integer expires,
-                                                        Map<String, String> reqParams) {
+  public Optional<String> getOptionalPresignedObjectUrl(Method method, String bucketName, String objectName,
+                                                        Integer expires, Map<String, String> reqParams) {
     try {
       return Optional.ofNullable(getPresignedObjectUrl(method, bucketName, objectName, expires, reqParams));
+    } catch (RuntimeException e) {
+      throw e;
     } catch (Exception e) {
       return Optional.empty();
     }


### PR DESCRIPTION
Frequently used methods like **statObject**, **getObjectUrl**, **getPresignedObjectUrl** and **getObject** logically throw exceptions if said objects cannot be accessed (for whatever reason). 

I implemented convenience methods for the above mentioned methods. Each convenience method **retrieves the result from the primary one**.

**Apart from the RuntimeException, all other exceptions are ignored and an Optional.empty() is returned.**
