### PR TITLE
fix windows ci

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,5 +31,7 @@ jobs:
           ./gradlew runFunctionalTest
       - name: Gradle build on ${{ matrix.java-version }}
         if: matrix.os == 'windows-latest'
-        run: gradlew.bat runFunctionalTest
+        run: |
+          $Env:Path += ';.'
+          gradlew.bat runFunctionalTest
 


### PR DESCRIPTION
### fix windows ci

**Problem:**
It seems that `gradlew.bat` is not operable in the original windows-ci.

See a failed check in https://github.com/minio/minio-java/pull/811:
https://github.com/minio/minio-java/pull/811/checks?check_run_id=292192553

https://github.com/minio/minio-java/pull/811 did nothing but improve some docs, but it still failed in windows-ci.
![image](https://user-images.githubusercontent.com/17903517/68455566-a3557e00-0236-11ea-82e2-861da8a9051e.png)

**Fix:**
Include current folder in `Path`. 
P.S. I don't understand why windows-ci was ok before but failed recently.

**How to Test:**
See https://github.com/minio/minio-java/pull/814 which is just https://github.com/minio/minio-java/pull/811 with current folder in `Path` ==> ci passed.

**Ref:** 
https://stackoverflow.com/a/9046942/5898846