### PR TITLE
gzip Accept-Encoding nginx fix.

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -957,6 +957,7 @@ public class MinioClient {
           len = 0;
         }
 
+        requestBuilder.header("Accept-Encoding", "identity");
         if (method == Method.POST && queryParamMap != null && queryParamMap.containsKey("delete")) {
           // Fix issue #579: Treat 'Delete Multiple Objects' specially which requires MD5 hash.
           String[] hashes = Digest.sha256Md5Hashes(data, len);


### PR DESCRIPTION
Fixes #820
We need this change to get around the okhttp feature of using gzip by default. As this post by okhttp developers point it out, we need to set the Accept-encoding http header to identity to get around the problem.