### PR TITLE
Add overloaded Listen Bucket Notification method

### DIFF
--- a/api/src/main/java/io/minio/CloseableIterator.java
+++ b/api/src/main/java/io/minio/CloseableIterator.java
@@ -1,0 +1,25 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface CloseableIterator<T> extends Iterator<T>, Closeable {
+}
+

--- a/api/src/main/java/io/minio/Result.java
+++ b/api/src/main/java/io/minio/Result.java
@@ -16,6 +16,8 @@
 
 package io.minio;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -47,7 +49,8 @@ public class Result<T> {
    * Returns given Type if exception is null, else respective exception is thrown.
    */
   public T get()
-    throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException, IOException,
+    throws InvalidBucketNameException, NoSuchAlgorithmException, InsufficientDataException,
+           JsonParseException, JsonMappingException,IOException,
            InvalidKeyException, NoResponseException, XmlPullParserException, ErrorResponseException,
            InternalException {
     if (ex == null) {
@@ -56,22 +59,45 @@ public class Result<T> {
 
     if (ex instanceof InvalidBucketNameException) {
       throw (InvalidBucketNameException) ex;
-    } else if (ex instanceof NoSuchAlgorithmException) {
-      throw (NoSuchAlgorithmException) ex;
-    } else if (ex instanceof InsufficientDataException) {
-      throw (InsufficientDataException) ex;
-    } else if (ex instanceof IOException) {
-      throw (IOException) ex;
-    } else if (ex instanceof InvalidKeyException) {
-      throw (InvalidKeyException) ex;
-    } else if (ex instanceof NoResponseException) {
-      throw (NoResponseException) ex;
-    } else if (ex instanceof XmlPullParserException) {
-      throw (XmlPullParserException) ex;
-    } else if (ex instanceof ErrorResponseException) {
-      throw (ErrorResponseException) ex;
-    } else {
-      throw (InternalException) ex;
     }
+
+    if (ex instanceof NoSuchAlgorithmException) {
+      throw (NoSuchAlgorithmException) ex;
+    }
+
+    if (ex instanceof InsufficientDataException) {
+      throw (InsufficientDataException) ex;
+    }
+
+    if (ex instanceof InvalidKeyException) {
+      throw (InvalidKeyException) ex;
+    }
+
+    if (ex instanceof NoResponseException) {
+      throw (NoResponseException) ex;
+    }
+
+    if (ex instanceof XmlPullParserException) {
+      throw (XmlPullParserException) ex;
+    }
+
+    if (ex instanceof ErrorResponseException) {
+      throw (ErrorResponseException) ex;
+    }
+
+    if (ex instanceof JsonParseException) {
+      throw (JsonParseException) ex;
+    }
+
+    if (ex instanceof JsonMappingException) {
+      throw (JsonMappingException) ex;
+    }
+
+    if (ex instanceof IOException) {
+      throw (IOException) ex;
+    }
+
+    throw (InternalException) ex;
+
   }
 }

--- a/api/src/main/java/io/minio/notification/NotificationInfo.java
+++ b/api/src/main/java/io/minio/notification/NotificationInfo.java
@@ -20,6 +20,7 @@ package io.minio.notification;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
 
 @SuppressFBWarnings("UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -28,5 +29,12 @@ public class NotificationInfo {
   public NotificationEvent[] records;
   @JsonProperty("Err")
   public String err;
+
+
+  @Override
+  public String toString() {
+    return "NotificationInfo{" + "records=" + Arrays.toString(records)
+      + ", err='" + err + '\'' + '}';
+  }
 }
 


### PR DESCRIPTION
There was an infine while loop in `listenBucketNotification` which kept on reading for any event on the  server. 
With this PR, For the functional  test `listenBucketNotification_test1` once the event is received the infinite loop is stopped by calling the method `client.turnOffListening()` .