### PR TITLE
Reset notification string on next()

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -5879,6 +5879,7 @@ public class MinioClient {
             } catch ( IOException e) {
               return new Result<>(null, e);
         } finally {
+          notificationString = null;
           notificationInfo = null;
         }
       }


### PR DESCRIPTION
This change resets the notificationString after parsing its value.
Otherwise hasNext() on the Iterator always returns true after the first occurrence.
This leads to a loop with next() always returning the same event as populate() does not continue scanning.