### PR TITLE
Throw InvalidResponseException instead of casting it to InternalException

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -4475,7 +4475,7 @@ public class MinioClient {
           private synchronized long getAggregatedPartSize(String objectName, String uploadId)
               throws InvalidBucketNameException, IllegalArgumentException, NoSuchAlgorithmException,
                   InsufficientDataException, IOException, InvalidKeyException, XmlParserException,
-                  ErrorResponseException, InternalException {
+                  ErrorResponseException, InternalException, InvalidResponseException {
             long aggregatedPartSize = 0;
 
             for (Result<Part> result : listObjectParts(bucketName, objectName, uploadId)) {
@@ -4555,7 +4555,8 @@ public class MinioClient {
                     | XmlParserException
                     | ErrorResponseException
                     | InternalException
-                    | IllegalArgumentException e) {
+                    | IllegalArgumentException
+                    | InvalidResponseException e) {
                   // special case: ignore the error as we can't propagate the exception in next()
                   aggregatedPartSize = -1;
                 }

--- a/api/src/main/java/io/minio/Result.java
+++ b/api/src/main/java/io/minio/Result.java
@@ -22,6 +22,7 @@ import io.minio.errors.ErrorResponseException;
 import io.minio.errors.InsufficientDataException;
 import io.minio.errors.InternalException;
 import io.minio.errors.InvalidBucketNameException;
+import io.minio.errors.InvalidResponseException;
 import io.minio.errors.XmlParserException;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -46,7 +47,8 @@ public class Result<T> {
   public T get()
       throws InvalidBucketNameException, IllegalArgumentException, NoSuchAlgorithmException,
           InsufficientDataException, JsonParseException, JsonMappingException, IOException,
-          InvalidKeyException, XmlParserException, ErrorResponseException, InternalException {
+          InvalidKeyException, XmlParserException, ErrorResponseException, InternalException,
+          InvalidResponseException {
     if (ex == null) {
       return type;
     }
@@ -89,6 +91,10 @@ public class Result<T> {
 
     if (ex instanceof IOException) {
       throw (IOException) ex;
+    }
+
+    if (ex instanceof InvalidResponseException) {
+      throw (InvalidResponseException) ex;
     }
 
     throw (InternalException) ex;


### PR DESCRIPTION
This prevents:
java.lang.ClassCastException: io.minio.errors.InvalidResponseException cannot be cast to io.minio.errors.InternalException
	at io.minio.Result.get(Result.java:100)
