### PR TITLE
fix: do not set empty content-encoding

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -970,7 +971,7 @@ public class MinioClient {
       }
     }
 
-    if (contentEncoding != null) {
+    if (!Strings.isNullOrEmpty(contentEncoding)) {
       requestBuilder.header("Content-Encoding", contentEncoding);
     }
 


### PR DESCRIPTION
Recent versions of the SDK sets Content-Encoding to empty string when a PutObject call is made. This PR sets Content-Encoding header only if it is not null or empty.