### PR TITLE
Refactor builder framework

### DIFF
--- a/api/src/main/java/io/minio/BaseArgs.java
+++ b/api/src/main/java/io/minio/BaseArgs.java
@@ -1,0 +1,49 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public abstract class BaseArgs {
+  public abstract static class BaseBuilder<T extends BaseBuilder<T, B>, B extends BaseArgs> {
+    protected List<Consumer<B>> operations;
+
+    public BaseBuilder() {
+      this.operations = new ArrayList<>();
+    }
+
+    protected B build(Class<B> clazz) throws IllegalArgumentException {
+      try {
+        B args = clazz.getDeclaredConstructor().newInstance();
+        operations.forEach(operation -> operation.accept(args));
+        return args;
+      } catch (InstantiationException
+          | IllegalAccessException
+          | InvocationTargetException
+          | NoSuchMethodException
+          | SecurityException e) {
+        // This should never happen as we'll always be
+        // sending a proper class as argument to build()
+        e.printStackTrace();
+        return null;
+      }
+    }
+  }
+}

--- a/api/src/main/java/io/minio/BucketArgs.java
+++ b/api/src/main/java/io/minio/BucketArgs.java
@@ -17,14 +17,9 @@
 package io.minio;
 
 /** Base argument class holds bucket name and region */
-public abstract class BucketArgs {
-  private final String name;
-  private final String region;
-
-  BucketArgs(Builder<?> builder) {
-    this.name = builder.name;
-    this.region = builder.region;
-  }
+public abstract class BucketArgs extends BaseArgs {
+  protected String name;
+  protected String region;
 
   /** Returns bucket name */
   public String bucketName() {
@@ -37,27 +32,9 @@ public abstract class BucketArgs {
   }
 
   /** Base argument builder class. */
-  public abstract static class Builder<T extends Builder<T>> {
-    public String name;
-    public String region;
-
-    public Builder() {}
-
-    @SuppressWarnings("unchecked") // Its safe to type cast to T as T is inherited by this class
-    public T bucket(String name) {
-      validateName(name);
-      this.name = name;
-      return (T) this;
-    }
-
-    @SuppressWarnings("unchecked") // Its safe to type cast to T as T is inherited by this class
-    public T region(String region) {
-      this.region = region;
-      return (T) this;
-    }
-
-    /** Validate the name of the bucket */
-    public static void validateName(String name) {
+  public abstract static class Builder<T extends Builder<T, B>, B extends BucketArgs>
+      extends BaseArgs.BaseBuilder<Builder<T, B>, B> {
+    protected void validateName(String name) {
       if (name == null) {
         throw new IllegalArgumentException("null bucket name");
       }
@@ -81,6 +58,19 @@ public abstract class BucketArgs {
                 + "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html";
         throw new IllegalArgumentException(name + " : " + msg);
       }
+    }
+
+    @SuppressWarnings("unchecked") // Its safe to type cast to T as T is inherited by this class
+    public T bucket(String name) {
+      validateName(name);
+      operations.add(args -> args.name = name);
+      return (T) this;
+    }
+
+    @SuppressWarnings("unchecked") // Its safe to type cast to T as T is inherited by this class
+    public T region(String region) {
+      operations.add(args -> args.region = region);
+      return (T) this;
     }
   }
 }

--- a/api/src/main/java/io/minio/MakeBucketArgs.java
+++ b/api/src/main/java/io/minio/MakeBucketArgs.java
@@ -18,12 +18,7 @@ package io.minio;
 
 /** Argument class of @see #makeBucket(MakeBucketArgs args). */
 public class MakeBucketArgs extends BucketArgs {
-  private final boolean objectLock;
-
-  private MakeBucketArgs(Builder builder) {
-    super(builder);
-    this.objectLock = builder.objectLock;
-  }
+  private boolean objectLock;
 
   /** Returns object lock flag. */
   public boolean objectLock() {
@@ -35,18 +30,14 @@ public class MakeBucketArgs extends BucketArgs {
   }
 
   /** Argument builder of @see #makeBucket(MakeBucketArgs args). */
-  public static final class Builder extends BucketArgs.Builder<Builder> {
-    private boolean objectLock;
-
-    public Builder() {}
-
+  public static final class Builder extends BucketArgs.Builder<Builder, MakeBucketArgs> {
     public Builder objectLock(boolean objectLock) {
-      this.objectLock = objectLock;
+      operations.add(args -> args.objectLock = objectLock);
       return this;
     }
 
     public MakeBucketArgs build() throws IllegalArgumentException {
-      return new MakeBucketArgs(this);
+      return build(MakeBucketArgs.class);
     }
   }
 }


### PR DESCRIPTION
One issue with the regular implementation of the builder pattern is the
duplication of same variables across the actual class being built (e.g.
MakeBucketArgs) and the corresponding builder (MakeBucketArgs.Builder)

This can be avoided by making use of Java's `Consumer` functional
interface. Instead of keeping all the builder data in its instance
variables, we can rather keep lambda expressions for setting the data in
the object being built. Coupled with some use of generics, the logic of
executing all the stored lambda expressions can be then pushed to a
parent class.

Benefits:
 - No need to add constructors in both args and builder classes.
 - No need to define any instance variables in any of the concrete
 builder classes

New class hierarchy:

 - BaseArgs (abstract base class - no common logic as of now)
   - BucketBaseArgs (abstract - bucket specific common logic)
     - MakeBucketArgs (concrete implementation of make-bucket args)
 - BaseArgs.Builder (common logic related to building args)
   - BucketArgs.Builder (fluent setters for bucket common data)
     - MakeBucketArgs.Builder (fluent method for objectLock arg and the
     simple one-line `build()` method

With this approach, the only boilerplate code in concrete args classes
will be:
 - one-line `builder()` method inside the concrete args class
 - one-line `build()`  method inside the concrete builder class