### PR TITLE
Implement Args builder for listObjects API

### DIFF
--- a/api/src/main/java/io/minio/ListObjectsArgs.java
+++ b/api/src/main/java/io/minio/ListObjectsArgs.java
@@ -1,0 +1,128 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+/** Argument class of @see #listObjects(ListObjectsArgs args). */
+public class ListObjectsArgs extends BucketArgs {
+  private String continuationToken;
+  private String delimiter;
+  private boolean fetchOwner;
+  private Integer maxKeys;
+  private String prefix;
+  private String startAfter;
+  private boolean includeUserMetadata;
+  private String marker;
+  private boolean recursive;
+  private boolean useVersion1;
+
+  public String continuationToken() {
+    return continuationToken;
+  }
+
+  public boolean includeUserMetadata() {
+    return includeUserMetadata;
+  }
+
+  public String startAfter() {
+    return startAfter;
+  }
+
+  public String prefix() {
+    return prefix;
+  }
+
+  public Integer maxKeys() {
+    return maxKeys;
+  }
+
+  public boolean fetchOwner() {
+    return fetchOwner;
+  }
+
+  public String delimiter() {
+    return delimiter;
+  }
+
+  public String marker() {
+    return marker;
+  }
+
+  public boolean recursive() {
+    return recursive;
+  }
+
+  public boolean useVersion1() {
+    return useVersion1;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Argument builder of @see MinioClient#listObjects(ListObjectArgs args). */
+  public static final class Builder extends BucketArgs.Builder<Builder, ListObjectsArgs> {
+    public Builder continuationToken(String continuationToken) {
+      operations.add(args -> args.continuationToken = continuationToken);
+      return this;
+    }
+
+    public Builder includeUserMetadata(boolean includeUserMetadata) {
+      operations.add(args -> args.includeUserMetadata = includeUserMetadata);
+      return this;
+    }
+
+    public Builder startAfter(String startAfter) {
+      operations.add(args -> args.startAfter = startAfter);
+      return this;
+    }
+
+    public Builder prefix(String prefix) {
+      operations.add(args -> args.prefix = prefix);
+      return this;
+    }
+
+    public Builder maxKeys(Integer maxKeys) {
+      operations.add(args -> args.maxKeys = maxKeys);
+      return this;
+    }
+
+    public Builder fetchOwner(boolean fetchOwner) {
+      operations.add(args -> args.fetchOwner = fetchOwner);
+      return this;
+    }
+
+    public Builder delimiter(String delimiter) {
+      operations.add(args -> args.delimiter = delimiter);
+      return this;
+    }
+
+    public Builder marker(String marker) {
+      operations.add(args -> args.marker = marker);
+      return this;
+    }
+
+    public Builder recursive(boolean recursive) {
+      operations.add(args -> args.recursive = recursive);
+      return this;
+    }
+
+    public Builder useVersion1(boolean useVersion1) {
+      operations.add(args -> args.useVersion1 = useVersion1);
+      return this;
+    }
+  }
+}

--- a/api/src/main/java/io/minio/ListObjectsArgs.java
+++ b/api/src/main/java/io/minio/ListObjectsArgs.java
@@ -25,7 +25,6 @@ public class ListObjectsArgs extends BucketArgs {
   private String prefix;
   private String startAfter;
   private boolean includeUserMetadata;
-  private String marker;
   private boolean recursive;
   private boolean useVersion1;
 
@@ -55,10 +54,6 @@ public class ListObjectsArgs extends BucketArgs {
 
   public String delimiter() {
     return delimiter;
-  }
-
-  public String marker() {
-    return marker;
   }
 
   public boolean recursive() {
@@ -107,11 +102,6 @@ public class ListObjectsArgs extends BucketArgs {
 
     public Builder delimiter(String delimiter) {
       operations.add(args -> args.delimiter = delimiter);
-      return this;
-    }
-
-    public Builder marker(String marker) {
-      operations.add(args -> args.marker = marker);
       return this;
     }
 

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -58,6 +58,7 @@ import io.minio.messages.LegalHold;
 import io.minio.messages.ListAllMyBucketsResult;
 import io.minio.messages.ListBucketResult;
 import io.minio.messages.ListBucketResultV1;
+import io.minio.messages.ListBucketResultV2;
 import io.minio.messages.ListMultipartUploadsResult;
 import io.minio.messages.ListPartsResult;
 import io.minio.messages.LocationConstraint;
@@ -2764,6 +2765,7 @@ public class MinioClient {
    * @param bucketName Name of the bucket.
    * @return Iterable&ltResult&ltItem&gt&gt - Lazy iterator contains object information.
    * @throws XmlParserException upon parsing response xml
+   * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
   public Iterable<Result<Item>> listObjects(final String bucketName) throws XmlParserException {
     return listObjects(bucketName, null);
@@ -2785,6 +2787,7 @@ public class MinioClient {
    * @param prefix Object name starts with prefix.
    * @return Iterable&ltResult&ltItem&gt&gt - Lazy iterator contains object information.
    * @throws XmlParserException upon parsing response xml
+   * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
   public Iterable<Result<Item>> listObjects(final String bucketName, final String prefix)
       throws XmlParserException {
@@ -2812,6 +2815,7 @@ public class MinioClient {
    * @see #listObjects(String bucketName)
    * @see #listObjects(String bucketName, String prefix)
    * @see #listObjects(String bucketName, String prefix, boolean recursive, boolean useVersion1)
+   * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
   public Iterable<Result<Item>> listObjects(
       final String bucketName, final String prefix, final boolean recursive) {
@@ -2839,6 +2843,7 @@ public class MinioClient {
    * @see #listObjects(String bucketName)
    * @see #listObjects(String bucketName, String prefix)
    * @see #listObjects(String bucketName, String prefix, boolean recursive)
+   * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
   public Iterable<Result<Item>> listObjects(
       final String bucketName,
@@ -2850,7 +2855,7 @@ public class MinioClient {
 
   /**
    * Lists object information with user metadata of a bucket for prefix recursively using S3 API
-   * version 1.
+   * version 2.
    *
    * <pre>Example:{@code
    * Iterable<Result<Item>> results =
@@ -2872,6 +2877,7 @@ public class MinioClient {
    * @see #listObjects(String bucketName)
    * @see #listObjects(String bucketName, String prefix)
    * @see #listObjects(String bucketName, String prefix, boolean recursive)
+   * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
   public Iterable<Result<Item>> listObjects(
       final String bucketName,
@@ -2879,36 +2885,178 @@ public class MinioClient {
       final boolean recursive,
       final boolean includeUserMetadata,
       final boolean useVersion1) {
-    if (useVersion1) {
-      if (includeUserMetadata) {
+    return listObjects(
+        ListObjectsArgs.builder()
+            .bucket(bucketName)
+            .prefix(prefix)
+            .recursive(recursive)
+            .includeUserMetadata(includeUserMetadata)
+            .build());
+  }
+
+  /**
+   * Lists objects information of a bucket. Supports both the versions 1 and 2 of the S3 API. By
+   * default, the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">
+   * version 2</a> API is used. <br>
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">version 1</a>
+   * can be used by passing the optional argument `useVersion1` as `true`.
+   *
+   * <pre>Example:{@code
+   * Iterable<Result<Item>> results = minioClient.listObjects(
+   *   ListObjectsArgs.builder().
+   *   bucket("my-bucketname").
+   *   includeUserMetadata(true).
+   *   startAfter("start-after-entry").
+   *   prefix("my-obj").
+   *   maxKeys(100).
+   *   fetchOwner(true)
+   * );
+   * for (Result<Item> result : results) {
+   *   Item item = result.get();
+   *   System.out.println(
+   *       item.lastModified() + ", " + item.size() + ", " + item.objectName());
+   * }
+   * }</pre>
+   *
+   * @param args Instance of {@link ListObjectsArgs} built using the builder
+   * @return Iterable&ltResult&ltItem&gt&gt - Lazy iterator contains object information.
+   * @throws XmlParserException upon parsing response xml
+   */
+  public Iterable<Result<Item>> listObjects(ListObjectsArgs args) {
+    if (args.useVersion1()) {
+      if (args.includeUserMetadata()) {
         throw new IllegalArgumentException(
             "include user metadata flag is not supported in version 1");
       }
-
-      return listObjectsV1(bucketName, prefix, recursive);
+      return listObjectsV1(args);
+    } else {
+      return listObjectsV2(args);
     }
-
-    return listObjectsV2(bucketName, prefix, recursive, includeUserMetadata);
   }
 
-  private Iterable<Result<Item>> listObjectsV2(
-      final String bucketName,
-      final String prefix,
-      final boolean recursive,
-      final boolean includeUserMetadata) {
+  private abstract class ObjectIterator implements Iterator<Result<Item>> {
+    protected Result<Item> error;
+    protected Iterator<Item> itemIterator;
+    protected Iterator<Prefix> prefixIterator;
+    protected boolean completed = false;
+    protected ListBucketResult listBucketResult;
+    protected String lastObjectName;
+
+    protected abstract void populateResult()
+        throws InvalidKeyException, InvalidBucketNameException, IllegalArgumentException,
+            NoSuchAlgorithmException, InsufficientDataException, XmlParserException,
+            ErrorResponseException, InternalException, InvalidResponseException, IOException;
+
+    protected synchronized void populate() {
+      try {
+        populateResult();
+      } catch (ErrorResponseException
+          | IllegalArgumentException
+          | InsufficientDataException
+          | InternalException
+          | InvalidBucketNameException
+          | InvalidKeyException
+          | InvalidResponseException
+          | IOException
+          | NoSuchAlgorithmException
+          | XmlParserException e) {
+        this.error = new Result<>(e);
+      } finally {
+        if (this.listBucketResult != null) {
+          this.itemIterator = this.listBucketResult.contents().iterator();
+          this.prefixIterator = this.listBucketResult.commonPrefixes().iterator();
+        } else {
+          this.itemIterator = new LinkedList<Item>().iterator();
+          this.prefixIterator = new LinkedList<Prefix>().iterator();
+        }
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (this.completed) {
+        return false;
+      }
+
+      if (this.error == null && this.itemIterator == null && this.prefixIterator == null) {
+        populate();
+      }
+
+      if (this.error == null
+          && !this.itemIterator.hasNext()
+          && !this.prefixIterator.hasNext()
+          && this.listBucketResult.isTruncated()) {
+        populate();
+      }
+
+      if (this.error != null) {
+        return true;
+      }
+
+      if (this.itemIterator.hasNext()) {
+        return true;
+      }
+
+      if (this.prefixIterator.hasNext()) {
+        return true;
+      }
+
+      this.completed = true;
+      return false;
+    }
+
+    @Override
+    public Result<Item> next() {
+      if (this.completed) {
+        throw new NoSuchElementException();
+      }
+
+      if (this.error == null && this.itemIterator == null && this.prefixIterator == null) {
+        populate();
+      }
+
+      if (this.error == null
+          && !this.itemIterator.hasNext()
+          && !this.prefixIterator.hasNext()
+          && this.listBucketResult.isTruncated()) {
+        populate();
+      }
+
+      if (this.error != null) {
+        this.completed = true;
+        return this.error;
+      }
+
+      if (this.itemIterator.hasNext()) {
+        Item item = this.itemIterator.next();
+        this.lastObjectName = item.objectName();
+        return new Result<>(item);
+      }
+      if (this.prefixIterator.hasNext()) {
+        return new Result<>(this.prefixIterator.next().toItem());
+      }
+
+      this.completed = true;
+      throw new NoSuchElementException();
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private Iterable<Result<Item>> listObjectsV2(ListObjectsArgs args) {
     return new Iterable<Result<Item>>() {
       @Override
       public Iterator<Result<Item>> iterator() {
-        return new Iterator<Result<Item>>() {
-          private ListBucketResult listBucketResult;
-          private Result<Item> error;
-          private Iterator<Item> itemIterator;
-          private Iterator<Prefix> prefixIterator;
-          private boolean completed = false;
-
-          private synchronized void populate() {
+        return new ObjectIterator() {
+          protected void populateResult()
+              throws InvalidKeyException, InvalidBucketNameException, IllegalArgumentException,
+                  NoSuchAlgorithmException, InsufficientDataException, XmlParserException,
+                  ErrorResponseException, InternalException, InvalidResponseException, IOException {
             String delimiter = "/";
-            if (recursive) {
+            if (args.recursive()) {
               delimiter = null;
             }
 
@@ -2921,141 +3069,43 @@ public class MinioClient {
             this.itemIterator = null;
             this.prefixIterator = null;
 
-            try {
-              this.listBucketResult =
-                  listObjectsV2(
-                      bucketName,
-                      continuationToken,
-                      delimiter,
-                      false,
-                      null,
-                      prefix,
-                      null,
-                      includeUserMetadata);
-            } catch (ErrorResponseException
-                | IllegalArgumentException
-                | InsufficientDataException
-                | InternalException
-                | InvalidBucketNameException
-                | InvalidKeyException
-                | InvalidResponseException
-                | IOException
-                | NoSuchAlgorithmException
-                | XmlParserException e) {
-              this.error = new Result<>(e);
-            } finally {
-              if (this.listBucketResult != null) {
-                this.itemIterator = this.listBucketResult.contents().iterator();
-                this.prefixIterator = this.listBucketResult.commonPrefixes().iterator();
-              } else {
-                this.itemIterator = new LinkedList<Item>().iterator();
-                this.prefixIterator = new LinkedList<Prefix>().iterator();
-              }
-            }
-          }
-
-          @Override
-          public boolean hasNext() {
-            if (this.completed) {
-              return false;
-            }
-
-            if (this.error == null && this.itemIterator == null && this.prefixIterator == null) {
-              populate();
-            }
-
-            if (this.error == null
-                && !this.itemIterator.hasNext()
-                && !this.prefixIterator.hasNext()
-                && this.listBucketResult.isTruncated()) {
-              populate();
-            }
-
-            if (this.error != null) {
-              return true;
-            }
-
-            if (this.itemIterator.hasNext()) {
-              return true;
-            }
-
-            if (this.prefixIterator.hasNext()) {
-              return true;
-            }
-
-            this.completed = true;
-            return false;
-          }
-
-          @Override
-          public Result<Item> next() {
-            if (this.completed) {
-              throw new NoSuchElementException();
-            }
-
-            if (this.error == null && this.itemIterator == null && this.prefixIterator == null) {
-              populate();
-            }
-
-            if (this.error == null
-                && !this.itemIterator.hasNext()
-                && !this.prefixIterator.hasNext()
-                && this.listBucketResult.isTruncated()) {
-              populate();
-            }
-
-            if (this.error != null) {
-              this.completed = true;
-              return this.error;
-            }
-
-            if (this.itemIterator.hasNext()) {
-              Item item = this.itemIterator.next();
-              return new Result<>(item);
-            }
-
-            if (this.prefixIterator.hasNext()) {
-              return new Result<>(this.prefixIterator.next().toItem());
-            }
-
-            this.completed = true;
-            throw new NoSuchElementException();
-          }
-
-          @Override
-          public void remove() {
-            throw new UnsupportedOperationException();
+            this.listBucketResult =
+                invokeListObjectsV2(
+                    ListObjectsArgs.builder()
+                        .bucket(args.bucketName())
+                        .continuationToken(continuationToken)
+                        .delimiter(delimiter)
+                        .fetchOwner(args.fetchOwner())
+                        .prefix(args.prefix())
+                        .includeUserMetadata(args.includeUserMetadata())
+                        .build());
           }
         };
       }
     };
   }
 
-  private Iterable<Result<Item>> listObjectsV1(
-      final String bucketName, final String prefix, final boolean recursive) {
+  private Iterable<Result<Item>> listObjectsV1(ListObjectsArgs args) {
     return new Iterable<Result<Item>>() {
       @Override
       public Iterator<Result<Item>> iterator() {
-        return new Iterator<Result<Item>>() {
-          private String lastObjectName;
-          private ListBucketResultV1 listBucketResult;
-          private Result<Item> error;
-          private Iterator<Item> itemIterator;
-          private Iterator<Prefix> prefixIterator;
-          private boolean completed = false;
-
-          private synchronized void populate() {
+        return new ObjectIterator() {
+          @Override
+          protected void populateResult()
+              throws InvalidKeyException, InvalidBucketNameException, IllegalArgumentException,
+                  NoSuchAlgorithmException, InsufficientDataException, XmlParserException,
+                  ErrorResponseException, InternalException, InvalidResponseException, IOException {
             String delimiter = "/";
-            if (recursive) {
+            if (args.recursive()) {
               delimiter = null;
             }
 
-            String marker = null;
+            String continuationToken = null;
             if (this.listBucketResult != null) {
               if (delimiter != null) {
-                marker = listBucketResult.nextMarker();
+                continuationToken = listBucketResult.nextContinuationToken();
               } else {
-                marker = this.lastObjectName;
+                continuationToken = this.lastObjectName;
               }
             }
 
@@ -3063,102 +3113,14 @@ public class MinioClient {
             this.itemIterator = null;
             this.prefixIterator = null;
 
-            try {
-              this.listBucketResult = listObjectsV1(bucketName, delimiter, marker, null, prefix);
-            } catch (ErrorResponseException
-                | IllegalArgumentException
-                | InsufficientDataException
-                | InternalException
-                | InvalidBucketNameException
-                | InvalidKeyException
-                | InvalidResponseException
-                | IOException
-                | NoSuchAlgorithmException
-                | XmlParserException e) {
-              this.error = new Result<>(e);
-            } finally {
-              if (this.listBucketResult != null) {
-                this.itemIterator = this.listBucketResult.contents().iterator();
-                this.prefixIterator = this.listBucketResult.commonPrefixes().iterator();
-              } else {
-                this.itemIterator = new LinkedList<Item>().iterator();
-                this.prefixIterator = new LinkedList<Prefix>().iterator();
-              }
-            }
-          }
-
-          @Override
-          public boolean hasNext() {
-            if (this.completed) {
-              return false;
-            }
-
-            if (this.error == null && this.itemIterator == null && this.prefixIterator == null) {
-              populate();
-            }
-
-            if (this.error == null
-                && !this.itemIterator.hasNext()
-                && !this.prefixIterator.hasNext()
-                && this.listBucketResult.isTruncated()) {
-              populate();
-            }
-
-            if (this.error != null) {
-              return true;
-            }
-
-            if (this.itemIterator.hasNext()) {
-              return true;
-            }
-
-            if (this.prefixIterator.hasNext()) {
-              return true;
-            }
-
-            this.completed = true;
-            return false;
-          }
-
-          @Override
-          public Result<Item> next() {
-            if (this.completed) {
-              throw new NoSuchElementException();
-            }
-
-            if (this.error == null && this.itemIterator == null && this.prefixIterator == null) {
-              populate();
-            }
-
-            if (this.error == null
-                && !this.itemIterator.hasNext()
-                && !this.prefixIterator.hasNext()
-                && this.listBucketResult.isTruncated()) {
-              populate();
-            }
-
-            if (this.error != null) {
-              this.completed = true;
-              return this.error;
-            }
-
-            if (this.itemIterator.hasNext()) {
-              Item item = this.itemIterator.next();
-              this.lastObjectName = item.objectName();
-              return new Result<>(item);
-            }
-
-            if (this.prefixIterator.hasNext()) {
-              return new Result<>(this.prefixIterator.next().toItem());
-            }
-
-            this.completed = true;
-            throw new NoSuchElementException();
-          }
-
-          @Override
-          public void remove() {
-            throw new UnsupportedOperationException();
+            this.listBucketResult =
+                invokeListObjectsV1(
+                    ListObjectsArgs.builder()
+                        .bucket(args.bucketName())
+                        .delimiter(args.delimiter())
+                        .marker(continuationToken)
+                        .prefix(args.prefix())
+                        .build());
           }
         };
       }
@@ -5274,136 +5236,69 @@ public class MinioClient {
     return Xml.unmarshal(DeleteResult.class, bodyContent);
   }
 
-  /**
-   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjects
-   * version 2 S3 API</a>.
-   *
-   * @param bucketName Name of the bucket.
-   * @param continuationToken Continuation token.
-   * @param delimiter Delimiter.
-   * @param fetchOwner Flage to fetch owner information of objects.
-   * @param maxKeys Maximum object information to fetch.
-   * @param prefix Prefix.
-   * @param startAfter Fetch object information after this entry.
-   * @param includeUserMetadata Flag to include user metadata in object information. This is MinIO
-   *     extension works with MinIO server only.
-   * @return {@link ListBucketResultV1} - Contains object information.
-   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
-   * @throws IllegalArgumentException throws to indicate invalid argument passed.
-   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
-   * @throws InternalException thrown to indicate internal library error.
-   * @throws InvalidBucketNameException thrown to indicate invalid bucket name passed.
-   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
-   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
-   *     response.
-   * @throws IOException thrown to indicate I/O error on S3 operation.
-   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
-   * @throws XmlParserException thrown to indicate XML parsing error.
-   */
-  protected ListBucketResult listObjectsV2(
-      String bucketName,
-      String continuationToken,
-      String delimiter,
-      boolean fetchOwner,
-      Integer maxKeys,
-      String prefix,
-      String startAfter,
-      boolean includeUserMetadata)
-      throws InvalidBucketNameException, IllegalArgumentException, NoSuchAlgorithmException,
-          InsufficientDataException, IOException, InvalidKeyException, XmlParserException,
-          ErrorResponseException, InternalException, InvalidResponseException {
+  private Map<String, String> getCommonListObjectsQueryParams(ListObjectsArgs args) {
     Map<String, String> queryParamMap = new HashMap<>();
-    queryParamMap.put("list-type", "2");
 
-    if (continuationToken != null) {
-      queryParamMap.put("continuation-token", continuationToken);
-    }
-
-    if (delimiter != null) {
-      queryParamMap.put("delimiter", delimiter);
+    if (args.delimiter() != null) {
+      queryParamMap.put("delimiter", args.delimiter());
     } else {
       queryParamMap.put("delimiter", "");
     }
 
-    if (fetchOwner) {
+    if (args.maxKeys() != null) {
+      queryParamMap.put("max-keys", args.maxKeys().toString());
+    }
+
+    if (args.prefix() != null) {
+      queryParamMap.put("prefix", args.prefix());
+    } else {
+      queryParamMap.put("prefix", "");
+    }
+
+    return queryParamMap;
+  }
+
+  private ListBucketResultV2 invokeListObjectsV2(ListObjectsArgs args)
+      throws InvalidKeyException, InvalidBucketNameException, IllegalArgumentException,
+          NoSuchAlgorithmException, InsufficientDataException, XmlParserException,
+          ErrorResponseException, InternalException, InvalidResponseException, IOException {
+    Map<String, String> queryParamMap = getCommonListObjectsQueryParams(args);
+    queryParamMap.put("list-type", "2");
+
+    if (args.continuationToken() != null) {
+      queryParamMap.put("continuation-token", args.continuationToken());
+    }
+
+    if (args.fetchOwner()) {
       queryParamMap.put("fetch-owner", "true");
     }
 
-    if (maxKeys != null) {
-      queryParamMap.put("max-keys", maxKeys.toString());
+    if (args.startAfter() != null) {
+      queryParamMap.put("start-after", args.startAfter());
     }
 
-    if (prefix != null) {
-      queryParamMap.put("prefix", prefix);
-    } else {
-      queryParamMap.put("prefix", "");
-    }
-
-    if (startAfter != null) {
-      queryParamMap.put("start-after", startAfter);
-    }
-
-    if (includeUserMetadata) {
+    if (args.includeUserMetadata()) {
       queryParamMap.put("metadata", "true");
     }
 
-    Response response = executeGet(bucketName, null, null, queryParamMap);
+    Response response = executeGet(args.bucketName(), null, null, queryParamMap);
 
     try (ResponseBody body = response.body()) {
-      return Xml.unmarshal(ListBucketResult.class, body.charStream());
+      return Xml.unmarshal(ListBucketResultV2.class, body.charStream());
     }
   }
 
-  /**
-   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects
-   * version 1 S3 API</a>.
-   *
-   * @param bucketName Name of the bucket.
-   * @param delimiter Delimiter.
-   * @param marker Marker.
-   * @param maxKeys Maximum object information to fetch.
-   * @param prefix Prefix.
-   * @return {@link ListBucketResultV1} - Contains object information.
-   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
-   * @throws IllegalArgumentException throws to indicate invalid argument passed.
-   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
-   * @throws InternalException thrown to indicate internal library error.
-   * @throws InvalidBucketNameException thrown to indicate invalid bucket name passed.
-   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
-   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
-   *     response.
-   * @throws IOException thrown to indicate I/O error on S3 operation.
-   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
-   * @throws XmlParserException thrown to indicate XML parsing error.
-   */
-  protected ListBucketResultV1 listObjectsV1(
-      String bucketName, String delimiter, String marker, Integer maxKeys, String prefix)
+  private ListBucketResultV1 invokeListObjectsV1(ListObjectsArgs args)
       throws InvalidBucketNameException, IllegalArgumentException, NoSuchAlgorithmException,
           InsufficientDataException, IOException, InvalidKeyException, XmlParserException,
           ErrorResponseException, InternalException, InvalidResponseException {
-    Map<String, String> queryParamMap = new HashMap<>();
+    Map<String, String> queryParamMap = getCommonListObjectsQueryParams(args);
 
-    if (delimiter != null) {
-      queryParamMap.put("delimiter", delimiter);
-    } else {
-      queryParamMap.put("delimiter", "");
+    if (args.marker() != null) {
+      queryParamMap.put("marker", args.marker());
     }
 
-    if (marker != null) {
-      queryParamMap.put("marker", marker);
-    }
-
-    if (maxKeys != null) {
-      queryParamMap.put("max-keys", maxKeys.toString());
-    }
-
-    if (prefix != null) {
-      queryParamMap.put("prefix", prefix);
-    } else {
-      queryParamMap.put("prefix", "");
-    }
-
-    Response response = executeGet(bucketName, null, null, queryParamMap);
+    Response response = executeGet(args.bucketName(), null, null, queryParamMap);
 
     try (ResponseBody body = response.body()) {
       return Xml.unmarshal(ListBucketResultV1.class, body.charStream());

--- a/api/src/main/java/io/minio/messages/ListBucketResult.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResult.java
@@ -21,28 +21,13 @@ import java.util.LinkedList;
 import java.util.List;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
-import org.simpleframework.xml.Namespace;
-import org.simpleframework.xml.Root;
 
-/**
- * Object representation of response XML of <a
- * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2
- * API</a>.
- */
-@Root(name = "ListBucketResult", strict = false)
-@Namespace(reference = "http://s3.amazonaws.com/doc/2006-03-01/")
-public class ListBucketResult {
+public abstract class ListBucketResult {
   @Element(name = "Name")
   private String name;
 
   @Element(name = "Prefix", required = false)
   private String prefix;
-
-  @Element(name = "ContinuationToken", required = false)
-  private String continuationToken;
-
-  @Element(name = "NextContinuationToken", required = false)
-  private String nextContinuationToken;
 
   @Element(name = "StartAfter", required = false)
   private String startAfter;
@@ -75,16 +60,6 @@ public class ListBucketResult {
   /** Returns prefix. */
   public String prefix() {
     return prefix;
-  }
-
-  /** Returns continuation token. */
-  public String continuationToken() {
-    return continuationToken;
-  }
-
-  /** Returns next continuation token. */
-  public String nextContinuationToken() {
-    return nextContinuationToken;
   }
 
   /** Returns start after. */
@@ -129,4 +104,9 @@ public class ListBucketResult {
 
     return Collections.unmodifiableList(commonPrefixes);
   }
+
+  /** Returns continuation token. */
+  public abstract String continuationToken();
+
+  public abstract String nextContinuationToken();
 }

--- a/api/src/main/java/io/minio/messages/ListBucketResultV2.java
+++ b/api/src/main/java/io/minio/messages/ListBucketResultV2.java
@@ -22,26 +22,27 @@ import org.simpleframework.xml.Root;
 
 /**
  * Object representation of response XML of <a
- * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects API</a>.
+ * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2
+ * API</a>.
  */
 @Root(name = "ListBucketResult", strict = false)
 @Namespace(reference = "http://s3.amazonaws.com/doc/2006-03-01/")
-public class ListBucketResultV1 extends ListBucketResult {
-  @Element(name = "Marker", required = false)
-  private String marker;
+public class ListBucketResultV2 extends ListBucketResult {
+  @Element(name = "ContinuationToken", required = false)
+  private String continuationToken;
 
-  @Element(name = "NextMarker", required = false)
-  private String nextMarker;
+  @Element(name = "NextContinuationToken", required = false)
+  private String nextContinuationToken;
 
   /** Returns continuation token. */
   @Override
   public String continuationToken() {
-    return marker;
+    return continuationToken;
   }
 
   /** Returns next continuation token. */
   @Override
   public String nextContinuationToken() {
-    return nextMarker;
+    return nextContinuationToken;
   }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -544,15 +544,15 @@ for (Result<Upload> result : results) {
 ```
 
 <a name="listObjects"></a>
-### listObjects(String bucketName)
-`public Iterable<Result<Item>> listObjects(String bucketName)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#listObjects-java.lang.String-)_
+### listObjects(ListObjectsArgs args)
+`public Iterable<Result<Item>> listObjects(ListObjectsArgs args)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#listObjects-io.minio.ListObjectsArgs-)_
 
 Lists object information of a bucket.
 
 __Parameters__
 | Parameter      | Type     | Description         |
 |:---------------|:---------|:--------------------|
-| ``bucketName`` | _String_ | Name of the bucket. |
+| ``args`` | _[ListObjectsArgs]_ | Arguments to list objects |
 
 | Returns                                                                   |
 |:--------------------------------------------------------------------------|
@@ -560,85 +560,15 @@ __Parameters__
 
 __Example__
 ```java
-Iterable<Result<Item>> results = minioClient.listObjects("my-bucketname");
-for (Result<Item> result : results) {
-  Item item = result.get();
-  System.out.println(item.lastModified() + ", " + item.size() + ", " + item.objectName());
-}
-```
-
-<a name="listObjects"></a>
-### listObjects(String bucketName, String prefix)
-`public Iterable<Result<Item>> listObjects(String bucketName, String prefix))` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#listObjects-java.lang.String-java.lang.String-)_
-
-Lists object information of a bucket for prefix.
-
-__Parameters__
-| Parameter      | Type     | Description                     |
-|:---------------|:---------|:--------------------------------|
-| ``bucketName`` | _String_ | Name of the bucket.             |
-| ``prefix``     | _String_ | Object name starts with prefix. |
-
-| Returns                                                                   |
-|:--------------------------------------------------------------------------|
-| _Iterable<[Result]<[Item]>>_ - Lazy iterator contains object information. |
-
-__Example__
-```java
-Iterable<Result<Item>> results = minioClient.listObjects("my-bucketname", "my-obj");
-for (Result<Item> result : results) {
-  Item item = result.get();
-  System.out.println(item.lastModified() + ", " + item.size() + ", " + item.objectName());
-}
-```
-
-<a name="listObjects"></a>
-### listObjects(String bucketName, String prefix, boolean recursive)
-`public Iterable<Result<Item>> listObjects(String bucketName, String prefix, boolean recursive)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#listObjects-java.lang.String-java.lang.String-boolean-)_
-
-Lists object information of a bucket for prefix recursively.
-
-__Parameters__
-| Parameter      | Type      | Description                                          |
-|:---------------|:----------|:-----------------------------------------------------|
-| ``bucketName`` | _String_  | Name of the bucket.                                  |
-| ``prefix``     | _String_  | Object name starts with prefix.                      |
-| ``recursive``  | _boolean_ | List recursively than directory structure emulation. |
-
-| Returns                                                                   |
-|:--------------------------------------------------------------------------|
-| _Iterable<[Result]<[Item]>>_ - Lazy iterator contains object information. |
-
-__Example__
-```java
-Iterable<Result<Item>> results = minioClient.listObjects("my-bucketname", "my-obj", true);
-for (Result<Item> result : results) {
-  Item item = result.get();
-  System.out.println(item.lastModified() + ", " + item.size() + ", " + item.objectName());
-}
-```
-
-<a name="listObjects"></a>
-### listObjects(String bucketName, String prefix, boolean recursive, boolean useVersion1)
-`public Iterable<Result<Item>> listObjects(String bucketName, String prefix, boolean recursive, boolean useVersion1)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#listObjects-java.lang.String-java.lang.String-boolean-boolean-)_
-
-Lists object information of a bucket for prefix recursively using S3 API version 1.
-
-__Parameters__
-| Parameter       | Type      | Description                                          |
-|:----------------|:----------|:-----------------------------------------------------|
-| ``bucketName``  | _String_  | Name of the bucket.                                  |
-| ``prefix``      | _String_  | Object name starts with prefix.                      |
-| ``recursive``   | _boolean_ | List recursively than directory structure emulation. |
-| ``useVersion1`` | _boolean_ | when true, version 1 of REST API is used.            |
-
-| Returns                                                                   |
-|:--------------------------------------------------------------------------|
-| _Iterable<[Result]<[Item]>>_ - Lazy iterator contains object information. |
-
-__Example__
-```java
-Iterable<Result<Item>> results = minioClient.listObjects("my-bucketname", "my-obj", true, true);
+Iterable<Result<Item>> results = minioClient.listObjects(
+  ListObjectsArgs.builder()
+    .bucket("my-bucketname")
+    .includeUserMetadata(true)
+    .startAfter("start-after-entry")
+    .prefix("my-obj")
+    .maxKeys(100)
+    .fetchOwner(true)
+);
 for (Result<Item> result : results) {
   Item item = result.get();
   System.out.println(item.lastModified() + ", " + item.size() + ", " + item.objectName());
@@ -1599,4 +1529,5 @@ ObjectStat objectStat = minioClient.statObject("my-bucketname", "my-objectname",
 [DeleteError]: http://minio.github.io/minio-java/io/minio/messages/DeleteError.html
 [SelectResponseStream]: http://minio.github.io/minio-java/io/minio/SelectResponseStream.html
 [MakeBucketArgs]: http://minio.github.io/minio-java/io/minio/MakeBucketArgs.html
+[ListObjectsArgs]: http://minio.github.io/minio-java/io/minio/ListObjectsArgs.html
 [Method]: http://minio.github.io/minio-java/io/minio/http/Method.html

--- a/examples/ListObjects.java
+++ b/examples/ListObjects.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import io.minio.ListObjectsArgs;
 import io.minio.MinioClient;
 import io.minio.Result;
 import io.minio.errors.MinioException;
@@ -42,7 +43,8 @@ public class ListObjects {
       boolean found = minioClient.bucketExists("my-bucketname");
       if (found) {
         // List objects from 'my-bucketname'
-        Iterable<Result<Item>> myObjects = minioClient.listObjects("my-bucketname");
+        Iterable<Result<Item>> myObjects =
+            minioClient.listObjects(ListObjectsArgs.builder().bucket("my-bucketname").build());
         for (Result<Item> result : myObjects) {
           Item item = result.get();
           System.out.println(item.lastModified() + ", " + item.size() + ", " + item.objectName());


### PR DESCRIPTION
Added the new args class `ListObjectsArgs` to be used with the
listObjects API. Example usage:

```
Iterable<Result<Item>> results = minioClient.listObjects(
  ListObjectsArgs.builder().
    bucket("my-bucketname").
    includeUserMetadata(true).
    startAfter("start-after-entry").
    prefix("my-obj").
    maxKeys(100).
    fetchOwner(true)
  );
```

Also refactored some of the existing code to reduce duplication of code:

- Extract common part of the result of both V1 and V2 API into
`ListBucketResult`, and made the two specific classes
(`ListBucketResultV1` and `ListBucketResultV2`) extend from it. The main
difference between the two is the naming of the continuation token
(`continuationToken` in V2 vs `marker` in V1). Since this is only a
naming difference, both results can be treated the same way by
abstracting out the methods related to these result fields.

- Similarly, most of the logic of the iterators for the response of V1
and V2 was also common. Extracted it out into a new abstract class
called `ObjectIterator`.