### PR TITLE
Implement Args builder for getObject API

### DIFF
--- a/api/src/main/java/io/minio/ComposeSource.java
+++ b/api/src/main/java/io/minio/ComposeSource.java
@@ -29,7 +29,7 @@ public class ComposeSource {
   private Long length;
   private Map<String, String> headerMap;
   private CopyConditions copyConditions;
-  private ServerSideEncryption sse;
+  private ServerSideEncryptionCustomerKey ssec;
   private long objectSize;
   private Map<String, String> headers;
 
@@ -79,7 +79,7 @@ public class ComposeSource {
       Long length,
       Map<String, String> headerMap,
       CopyConditions copyConditions,
-      ServerSideEncryption sse)
+      ServerSideEncryptionCustomerKey ssec)
       throws IllegalArgumentException {
     if (bucketName == null) {
       throw new IllegalArgumentException("Source bucket name cannot be empty");
@@ -111,7 +111,7 @@ public class ComposeSource {
       this.headerMap = null;
     }
     this.copyConditions = copyConditions;
-    this.sse = sse;
+    this.ssec = ssec;
   }
 
   /** Constructs header . */
@@ -166,8 +166,8 @@ public class ComposeSource {
       headers.putAll(copyConditions.getConditions());
     }
 
-    if (sse != null) {
-      headers.putAll(sse.copySourceHeaders());
+    if (ssec != null) {
+      headers.putAll(ssec.copySourceHeaders());
     }
 
     this.objectSize = objectSize;
@@ -194,8 +194,8 @@ public class ComposeSource {
     return copyConditions;
   }
 
-  public ServerSideEncryption sse() {
-    return sse;
+  public ServerSideEncryptionCustomerKey ssec() {
+    return ssec;
   }
 
   public Map<String, String> headers() {

--- a/api/src/main/java/io/minio/DownloadObjectArgs.java
+++ b/api/src/main/java/io/minio/DownloadObjectArgs.java
@@ -1,0 +1,58 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class DownloadObjectArgs extends SsecObjectArgs {
+  private String fileName;
+
+  public String fileName() {
+    return fileName;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends SsecObjectArgs.Builder<Builder, DownloadObjectArgs> {
+    public Builder fileName(String fileName) {
+      validateFileName(fileName);
+      operations.add(args -> args.fileName = fileName);
+      return this;
+    }
+
+    private void validateFileName(String fileName) {
+      if (fileName == null) {
+        return;
+      }
+
+      if (fileName.isEmpty()) {
+        throw new IllegalArgumentException("filename should be either null or non-empty");
+      }
+
+      Path filePath = Paths.get(fileName);
+      boolean fileExists = Files.exists(filePath);
+
+      if (fileExists && !Files.isRegularFile(filePath)) {
+        throw new IllegalArgumentException(fileName + ": not a regular file");
+      }
+    }
+  }
+}

--- a/api/src/main/java/io/minio/GetObjectArgs.java
+++ b/api/src/main/java/io/minio/GetObjectArgs.java
@@ -1,0 +1,60 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+public class GetObjectArgs extends SsecObjectArgs {
+  private Long offset;
+  private Long length;
+
+  public Long length() {
+    return length;
+  }
+
+  public Long offset() {
+    return offset;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder extends SsecObjectArgs.Builder<Builder, GetObjectArgs> {
+    public Builder offset(Long offset) {
+      validateOffset(offset);
+      operations.add(args -> args.offset = offset);
+      return this;
+    }
+
+    public Builder length(Long length) {
+      validateLength(length);
+      operations.add(args -> args.length = length);
+      return this;
+    }
+
+    private void validateLength(Long length) {
+      if (length != null && length <= 0) {
+        throw new IllegalArgumentException("length should be greater than zero");
+      }
+    }
+
+    private void validateOffset(Long offset) {
+      if (offset != null && offset < 0) {
+        throw new IllegalArgumentException("offset should be zero or greater");
+      }
+    }
+  }
+}

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1626,7 +1626,7 @@ public class MinioClient {
    *
    * <pre>Example:{@code
    * ObjectStat objectStat =
-   *     minioClient.statObject("my-bucketname", "my-objectname", ssec);
+   *     minioClient.statObject("my-bucketname", "my-objectname", sse);
    * }</pre>
    *
    * @param bucketName Name of the bucket.
@@ -1647,12 +1647,13 @@ public class MinioClient {
    * @see ObjectStat
    */
   @Deprecated
-  public ObjectStat statObject(String bucketName, String objectName, ServerSideEncryption sse)
+  public ObjectStat statObject(
+      String bucketName, String objectName, ServerSideEncryptionCustomerKey ssec)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
     return statObject(
-        StatObjectArgs.builder().bucket(bucketName).object(objectName).ssec(sse).build());
+        StatObjectArgs.builder().bucket(bucketName).object(objectName).ssec(ssec).build());
   }
 
   /**
@@ -1713,7 +1714,7 @@ public class MinioClient {
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
     checkArgs(args);
-    checkReadRequestSse(args.ssec());
+    args.validateSsec(baseUrl);
 
     Multimap<String, String> headers = HashMultimap.create();
     headers.putAll(args.extraHeaders());
@@ -1788,12 +1789,14 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
    */
+  @Deprecated
   public InputStream getObject(String bucketName, String objectName)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    return getObject(bucketName, objectName, null, null, null);
+    return getObject(GetObjectArgs.builder().bucket(bucketName).object(objectName).build());
   }
 
   /**
@@ -1809,7 +1812,7 @@ public class MinioClient {
    *
    * @param bucketName Name of the bucket.
    * @param objectName Object name in the bucket.
-   * @param sse SSE-C type server-side encryption.
+   * @param ssec SSE-C type server-side encryption.
    * @return {@link InputStream} - Contains object data.
    * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
    * @throws IllegalArgumentException throws to indicate invalid argument passed.
@@ -1822,12 +1825,16 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
    */
-  public InputStream getObject(String bucketName, String objectName, ServerSideEncryption sse)
+  @Deprecated
+  public InputStream getObject(
+      String bucketName, String objectName, ServerSideEncryptionCustomerKey ssec)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    return getObject(bucketName, objectName, null, null, sse);
+    return getObject(
+        GetObjectArgs.builder().bucket(bucketName).object(objectName).ssec(ssec).build());
   }
 
   /**
@@ -1856,12 +1863,15 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
    */
+  @Deprecated
   public InputStream getObject(String bucketName, String objectName, long offset)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    return getObject(bucketName, objectName, offset, null, null);
+    return getObject(
+        GetObjectArgs.builder().bucket(bucketName).object(objectName).offset(offset).build());
   }
 
   /**
@@ -1891,12 +1901,20 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
    */
+  @Deprecated
   public InputStream getObject(String bucketName, String objectName, long offset, Long length)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    return getObject(bucketName, objectName, offset, length, null);
+    return getObject(
+        GetObjectArgs.builder()
+            .bucket(bucketName)
+            .object(objectName)
+            .offset(offset)
+            .length(length)
+            .build());
   }
 
   /**
@@ -1914,7 +1932,7 @@ public class MinioClient {
    * @param objectName Object name in the bucket.
    * @param offset Start byte position of object data.
    * @param length Number of bytes of object data from offset.
-   * @param sse SSE-C type server-side encryption.
+   * @param ssec SSE-C type server-side encryption.
    * @return {@link InputStream} - Contains object data.
    * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
    * @throws IllegalArgumentException throws to indicate invalid argument passed.
@@ -1927,34 +1945,75 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
    */
+  @Deprecated
   public InputStream getObject(
-      String bucketName, String objectName, Long offset, Long length, ServerSideEncryption sse)
+      String bucketName,
+      String objectName,
+      Long offset,
+      Long length,
+      ServerSideEncryptionCustomerKey ssec)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    if ((bucketName == null) || (bucketName.isEmpty())) {
-      throw new IllegalArgumentException("bucket name cannot be empty");
-    }
+    return getObject(
+        GetObjectArgs.builder()
+            .bucket(bucketName)
+            .object(objectName)
+            .offset(offset)
+            .length(length)
+            .ssec(ssec)
+            .build());
+  }
 
-    checkObjectName(objectName);
-
-    if (offset != null && offset < 0) {
-      throw new IllegalArgumentException("offset should be zero or greater");
-    }
-
-    if (length != null && length <= 0) {
-      throw new IllegalArgumentException("length should be greater than zero");
-    }
-
-    checkReadRequestSse(sse);
+  /**
+   * Gets data from offset to length of a SSE-C encrypted object. Returned {@link InputStream} must
+   * be closed after use to release network resources.
+   *
+   * <pre>Example:{@code
+   * try (InputStream stream =
+   *     minioClient.getObject(
+   *   GetObjectArgs.builder()
+   *     .bucket("my-bucketname")
+   *     .object("my-objectname")
+   *     .offset(offset)
+   *     .length(len)
+   *     .ssec(ssec)
+   *     .build()
+   * ) {
+   *   // Read data from stream
+   * }
+   * }</pre>
+   *
+   * @param args Object of {@link GetObjectArgs}
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws IllegalArgumentException throws to indicate invalid argument passed.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidBucketNameException thrown to indicate invalid bucket name passed.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public InputStream getObject(GetObjectArgs args)
+      throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
+          InternalException, InvalidBucketNameException, InvalidKeyException,
+          InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
+    Long offset = args.offset();
+    Long length = args.length();
+    ServerSideEncryptionCustomerKey ssec = args.ssec();
+    args.validateSsec(this.baseUrl);
 
     if (length != null && offset == null) {
       offset = 0L;
     }
 
     Map<String, String> headerMap = null;
-    if (offset != null || length != null || sse != null) {
+    if (offset != null || length != null || ssec != null) {
       headerMap = new HashMap<>();
     }
 
@@ -1964,11 +2023,11 @@ public class MinioClient {
       headerMap.put("Range", "bytes=" + offset + "-");
     }
 
-    if (sse != null) {
-      headerMap.putAll(sse.headers());
+    if (ssec != null) {
+      headerMap.putAll(ssec.headers());
     }
 
-    Response response = executeGet(bucketName, objectName, headerMap, null);
+    Response response = executeGet(args.bucket(), args.object(), headerMap, null);
     return response.body().byteStream();
   }
 
@@ -1993,12 +2052,19 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
    */
+  @Deprecated
   public void getObject(String bucketName, String objectName, String fileName)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    getObject(bucketName, objectName, null, fileName);
+    downloadObject(
+        DownloadObjectArgs.builder()
+            .bucket(bucketName)
+            .object(objectName)
+            .fileName(fileName)
+            .build());
   }
 
   /**
@@ -2010,7 +2076,52 @@ public class MinioClient {
    *
    * @param bucketName Name of the bucket.
    * @param objectName Object name in the bucket.
-   * @param sse SSE-C type server-side encryption.
+   * @param ssec SSE-C type server-side encryption.
+   * @param fileName Name of the file.
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws IllegalArgumentException throws to indicate invalid argument passed.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidBucketNameException thrown to indicate invalid bucket name passed.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #getObject(GetObjectArgs)}
+   */
+  @Deprecated
+  public void getObject(
+      String bucketName, String objectName, ServerSideEncryptionCustomerKey ssec, String fileName)
+      throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
+          InternalException, InvalidBucketNameException, InvalidKeyException,
+          InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
+    downloadObject(
+        DownloadObjectArgs.builder()
+            .bucket(bucketName)
+            .object(objectName)
+            .ssec(ssec)
+            .fileName(fileName)
+            .build());
+  }
+
+  /**
+   * Downloads data of a SSE-C encrypted object to file.
+   *
+   * <pre>Example:{@code
+   * minioClient.downloadObject(
+   *   GetObjectArgs.builder()
+   *     .bucket("my-bucketname")
+   *     .object("my-objectname")
+   *     .ssec(ssec)
+   *     .fileName("my-filename")
+   *     .build());
+   * }</pre>
+   *
+   * @param args Object of {@link GetObjectArgs}
+   * @param objectName Object name in the bucket.
+   * @param ssec SSE-C type server-side encryption.
    * @param fileName Name of the file.
    * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
    * @throws IllegalArgumentException throws to indicate invalid argument passed.
@@ -2024,21 +2135,21 @@ public class MinioClient {
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
    */
-  public void getObject(
-      String bucketName, String objectName, ServerSideEncryption sse, String fileName)
+  public void downloadObject(DownloadObjectArgs args)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
-    checkReadRequestSse(sse);
-
+    String fileName = args.fileName();
     Path filePath = Paths.get(fileName);
     boolean fileExists = Files.exists(filePath);
 
-    if (fileExists && !Files.isRegularFile(filePath)) {
-      throw new IllegalArgumentException(fileName + ": not a regular file");
-    }
-
-    ObjectStat objectStat = statObject(bucketName, objectName, sse);
+    ObjectStat objectStat =
+        statObject(
+            StatObjectArgs.builder()
+                .bucket(args.bucket())
+                .object(args.object())
+                .ssec(args.ssec())
+                .build());
     long length = objectStat.length();
     String etag = objectStat.etag();
 
@@ -2068,7 +2179,7 @@ public class MinioClient {
       } else if (fileSize > length) {
         throw new IllegalArgumentException(
             "Source object, '"
-                + objectName
+                + args.object()
                 + "', size:"
                 + length
                 + " is smaller than the destination file, '"
@@ -2086,7 +2197,13 @@ public class MinioClient {
     InputStream is = null;
     OutputStream os = null;
     try {
-      is = getObject(bucketName, objectName, tempFileSize, null, sse);
+      is =
+          getObject(
+              GetObjectArgs.builder()
+                  .bucket(args.bucket())
+                  .object(args.object())
+                  .ssec(args.ssec())
+                  .build());
       os =
           Files.newOutputStream(tempFilePath, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
       long bytesWritten = ByteStreams.copy(is, os);
@@ -2285,9 +2402,9 @@ public class MinioClient {
     for (int i = 0; i < sources.size(); i++) {
       ComposeSource src = sources.get(i);
 
-      checkReadRequestSse(src.sse());
+      checkReadRequestSse(src.ssec());
 
-      ObjectStat stat = statObject(src.bucketName(), src.objectName(), src.sse());
+      ObjectStat stat = statObject(src.bucketName(), src.objectName(), src.ssec());
       src.buildHeaders(stat.length(), stat.etag());
 
       if (i != 0 && src.headers().containsKey("x-amz-meta-x-amz-key")) {
@@ -2379,7 +2496,7 @@ public class MinioClient {
           sse,
           src.bucketName(),
           src.objectName(),
-          src.sse(),
+          src.ssec(),
           src.copyConditions());
       return;
     }
@@ -2980,6 +3097,7 @@ public class MinioClient {
    * @throws XmlParserException upon parsing response xml
    * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
+  @Deprecated
   public Iterable<Result<Item>> listObjects(final String bucketName) throws XmlParserException {
     return listObjects(bucketName, null);
   }
@@ -3002,6 +3120,7 @@ public class MinioClient {
    * @throws XmlParserException upon parsing response xml
    * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
+  @Deprecated
   public Iterable<Result<Item>> listObjects(final String bucketName, final String prefix)
       throws XmlParserException {
     // list all objects recursively
@@ -3030,6 +3149,7 @@ public class MinioClient {
    * @see #listObjects(String bucketName, String prefix, boolean recursive, boolean useVersion1)
    * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
+  @Deprecated
   public Iterable<Result<Item>> listObjects(
       final String bucketName, final String prefix, final boolean recursive) {
     return listObjects(bucketName, prefix, recursive, false);
@@ -3058,6 +3178,7 @@ public class MinioClient {
    * @see #listObjects(String bucketName, String prefix, boolean recursive)
    * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
+  @Deprecated
   public Iterable<Result<Item>> listObjects(
       final String bucketName,
       final String prefix,
@@ -3092,6 +3213,7 @@ public class MinioClient {
    * @see #listObjects(String bucketName, String prefix, boolean recursive)
    * @deprecated use {@link #listObjects(ListObjectsArgs)}
    */
+  @Deprecated
   public Iterable<Result<Item>> listObjects(
       final String bucketName,
       final String prefix,
@@ -5395,7 +5517,7 @@ public class MinioClient {
    * @param requestProgress Flag to request progress information.
    * @param scanStartRange scan start range of the object.
    * @param scanEndRange scan end range of the object.
-   * @param sse SSE-C type server-side encryption.
+   * @param ssec SSE-C type server-side encryption.
    * @return {@link SelectResponseStream} - Contains filtered records and progress.
    * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
    * @throws IllegalArgumentException throws to indicate invalid argument passed.
@@ -5418,7 +5540,7 @@ public class MinioClient {
       boolean requestProgress,
       Long scanStartRange,
       Long scanEndRange,
-      ServerSideEncryption sse)
+      ServerSideEncryptionCustomerKey ssec)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, XmlParserException {
@@ -5426,11 +5548,11 @@ public class MinioClient {
       throw new IllegalArgumentException("bucket name cannot be empty");
     }
     checkObjectName(objectName);
-    checkReadRequestSse(sse);
+    checkReadRequestSse(ssec);
 
     Map<String, String> headerMap = null;
-    if (sse != null) {
-      headerMap = sse.headers();
+    if (ssec != null) {
+      headerMap = ssec.headers();
     }
 
     Map<String, String> queryParamMap = new HashMap<>();

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1626,12 +1626,12 @@ public class MinioClient {
    *
    * <pre>Example:{@code
    * ObjectStat objectStat =
-   *     minioClient.statObject("my-bucketname", "my-objectname", sse);
+   *     minioClient.statObject("my-bucketname", "my-objectname", ssec);
    * }</pre>
    *
    * @param bucketName Name of the bucket.
    * @param objectName Object name in the bucket.
-   * @param sse SSE-C type server-side encryption.
+   * @param ssec SSE-C type server-side encryption.
    * @return {@link ObjectStat} - Populated object information and metadata.
    * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
    * @throws IllegalArgumentException throws to indicate invalid argument passed.

--- a/api/src/main/java/io/minio/ServerSideEncryptionCustomerKey.java
+++ b/api/src/main/java/io/minio/ServerSideEncryptionCustomerKey.java
@@ -1,0 +1,85 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2018 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import com.google.common.io.BaseEncoding;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import javax.security.auth.DestroyFailedException;
+
+public class ServerSideEncryptionCustomerKey extends ServerSideEncryption {
+  final SecretKey secretKey;
+  final Map<String, String> headers;
+  final Map<String, String> copySourceHeaders;
+
+  public ServerSideEncryptionCustomerKey(SecretKey key)
+      throws InvalidKeyException, NoSuchAlgorithmException {
+    this.secretKey = key;
+
+    byte[] keyBytes = key.getEncoded();
+    MessageDigest md5 = MessageDigest.getInstance("MD5");
+    md5.update(keyBytes);
+    String customerKey = BaseEncoding.base64().encode(keyBytes);
+    String customerKeyMd5 = BaseEncoding.base64().encode(md5.digest());
+
+    Map<String, String> map = new HashMap<>();
+    map.put("X-Amz-Server-Side-Encryption-Customer-Algorithm", "AES256");
+    map.put("X-Amz-Server-Side-Encryption-Customer-Key", customerKey);
+    map.put("X-Amz-Server-Side-Encryption-Customer-Key-Md5", customerKeyMd5);
+    this.headers = Collections.unmodifiableMap(map);
+
+    map = new HashMap<>();
+    map.put("X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm", "AES256");
+    map.put("X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key", customerKey);
+    map.put("X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-Md5", customerKeyMd5);
+    this.copySourceHeaders = Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public final Type type() {
+    return Type.SSE_C;
+  }
+
+  @Override
+  public final Map<String, String> headers() {
+    if (this.isDestroyed()) {
+      throw new IllegalStateException("object is already destroyed");
+    }
+
+    return headers;
+  }
+
+  @Override
+  public final Map<String, String> copySourceHeaders() {
+    if (this.isDestroyed()) {
+      throw new IllegalStateException("object is already destroyed");
+    }
+
+    return copySourceHeaders;
+  }
+
+  @Override
+  public final void destroy() throws DestroyFailedException {
+    secretKey.destroy();
+    this.destroyed = true;
+  }
+}

--- a/api/src/main/java/io/minio/SsecObjectArgs.java
+++ b/api/src/main/java/io/minio/SsecObjectArgs.java
@@ -20,8 +20,6 @@ import okhttp3.HttpUrl;
 
 public abstract class SsecObjectArgs extends ObjectArgs {
   protected ServerSideEncryptionCustomerKey ssec;
-  public static final int TYPE_READ = 0;
-  public static final int TYPE_WRITE = 1;
 
   public ServerSideEncryptionCustomerKey ssec() {
     return ssec;

--- a/api/src/main/java/io/minio/SsecObjectArgs.java
+++ b/api/src/main/java/io/minio/SsecObjectArgs.java
@@ -1,0 +1,49 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import okhttp3.HttpUrl;
+
+public abstract class SsecObjectArgs extends ObjectArgs {
+  protected ServerSideEncryptionCustomerKey ssec;
+  public static final int TYPE_READ = 0;
+  public static final int TYPE_WRITE = 1;
+
+  public ServerSideEncryptionCustomerKey ssec() {
+    return ssec;
+  }
+
+  protected void validateSsec(HttpUrl baseUrl) {
+    if (ssec == null) {
+      return;
+    }
+
+    if (ssec.type().requiresTls() && !baseUrl.isHttps()) {
+      throw new IllegalArgumentException(
+          ssec.type().name() + "operations must be performed over a secure connection.");
+    }
+  }
+
+  public abstract static class Builder<B extends Builder<B, A>, A extends SsecObjectArgs>
+      extends ObjectArgs.Builder<B, A> {
+    @SuppressWarnings("unchecked") // Its safe to type cast to B as B is inherited by this class
+    public B ssec(ServerSideEncryptionCustomerKey ssec) {
+      operations.add(args -> args.ssec = ssec);
+      return (B) this;
+    }
+  }
+}

--- a/api/src/main/java/io/minio/StatObjectArgs.java
+++ b/api/src/main/java/io/minio/StatObjectArgs.java
@@ -17,26 +17,11 @@
 package io.minio;
 
 /** Argument class of MinioClient.statObject(). */
-public class StatObjectArgs extends ObjectArgs {
-  private ServerSideEncryption ssec;
-
-  public ServerSideEncryption ssec() {
-    return ssec;
-  }
-
+public class StatObjectArgs extends SsecObjectArgs {
   public static Builder builder() {
     return new Builder();
   }
 
   /** Argument builder of {@link StatObjectArgs}. */
-  public static final class Builder extends ObjectArgs.Builder<Builder, StatObjectArgs> {
-    public Builder ssec(ServerSideEncryption ssec) {
-      if (ssec != null && ssec.type() != ServerSideEncryption.Type.SSE_C) {
-        throw new IllegalArgumentException("only SSE-C type server-side encryption is allowed");
-      }
-
-      operations.add(args -> args.ssec = ssec);
-      return this;
-    }
-  }
+  public static final class Builder extends SsecObjectArgs.Builder<Builder, StatObjectArgs> {}
 }

--- a/api/src/test/java/io/minio/MinioClientTest.java
+++ b/api/src/test/java/io/minio/MinioClientTest.java
@@ -312,19 +312,6 @@ public class MinioClientTest {
   @Test(expected = IllegalArgumentException.class)
   public void testReadSse1()
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, MinioException {
-    MinioClient client = new MinioClient("https://play.min.io:9000");
-    client.statObject(
-        StatObjectArgs.builder()
-            .bucket("mybucket")
-            .object("myobject")
-            .ssec(ServerSideEncryption.atRest())
-            .build());
-    Assert.fail("exception should be thrown");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testReadSse2()
-      throws NoSuchAlgorithmException, IOException, InvalidKeyException, MinioException {
     KeyGenerator keyGen = KeyGenerator.getInstance("AES");
     keyGen.init(256);
     MinioClient client = new MinioClient("http://play.min.io:9000");
@@ -454,7 +441,13 @@ public class MinioClientTest {
   public void testGetObjectNegativeOffset()
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, MinioException {
     MinioClient client = new MinioClient("https://play.min.io:9000");
-    client.getObject("mybucket", "myobject", -1L, 5L);
+    client.getObject(
+        GetObjectArgs.builder()
+            .bucket("mybucket")
+            .object("myobject")
+            .offset(-1L)
+            .length(5L)
+            .build());
     Assert.fail("exception should be thrown");
   }
 
@@ -462,7 +455,13 @@ public class MinioClientTest {
   public void testGetObjectNegativeLength()
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, MinioException {
     MinioClient client = new MinioClient("https://play.min.io:9000");
-    client.getObject("mybucket", "myobject", 0L, -5L);
+    client.getObject(
+        GetObjectArgs.builder()
+            .bucket("mybucket")
+            .object("myobject")
+            .offset(0L)
+            .length(-5L)
+            .build());
     Assert.fail("exception should be thrown");
   }
 
@@ -470,7 +469,13 @@ public class MinioClientTest {
   public void testGetObjectZeroLength()
       throws NoSuchAlgorithmException, IOException, InvalidKeyException, MinioException {
     MinioClient client = new MinioClient("https://play.min.io:9000");
-    client.getObject("mybucket", "myobject", 0L, 0L);
+    client.getObject(
+        GetObjectArgs.builder()
+            .bucket("mybucket")
+            .object("myobject")
+            .offset(0L)
+            .length(0L)
+            .build());
     Assert.fail("exception should be thrown");
   }
 }

--- a/api/src/test/java/io/minio/StatObjectArgsTest.java
+++ b/api/src/test/java/io/minio/StatObjectArgsTest.java
@@ -66,21 +66,12 @@ public class StatObjectArgsTest {
     Assert.fail("exception should be thrown");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testUnsupportedSseBuild() {
-    StatObjectArgs.builder()
-        .bucket("mybucket")
-        .ssec(ServerSideEncryption.atRest())
-        .object("myobject")
-        .build();
-    Assert.fail("exception should be thrown");
-  }
-
   @Test
   public void testBuild() throws NoSuchAlgorithmException, InvalidKeyException {
     KeyGenerator keyGen = KeyGenerator.getInstance("AES");
     keyGen.init(256);
-    ServerSideEncryption ssec = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+    ServerSideEncryptionCustomerKey ssec =
+        ServerSideEncryption.withCustomerKey(keyGen.generateKey());
     StatObjectArgs args =
         StatObjectArgs.builder()
             .bucket("mybucket")

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,25 +22,25 @@ MinioClient s3Client = new MinioClient("https://s3.amazonaws.com",
 | [`deleteBucketEncryption`](#deleteBucketEncryption)           | [`copyObject`](#copyObject)                             |
 | [`deleteBucketLifeCycle`](#deleteBucketLifeCycle)             | [`deleteObjectTags`](#deleteObjectTags)                 |
 | [`deleteBucketPolicy`](#deleteBucketPolicy)                   | [`disableObjectLegalHold`](#disableObjectLegalHold)     |
-| [`deleteBucketTags`](#deleteBucketTags)                       | [`enableObjectLegalHold`](#enableObjectLegalHold)       |
-| [`disableVersioning`](#disableVersioning)                     | [`getObject`](#getObject)                               |
-| [`enableVersioning`](#enableVersioning)                       | [`getObjectRetention`](#getObjectRetention)             |
-| [`getBucketEncryption`](#getBucketEncryption)                 | [`getObjectTags`](#getObjectTags)                       |
-| [`getBucketLifeCycle`](#getBucketLifeCycle)                   | [`getObjectUrl`](#getObjectUrl)                         |
-| [`getBucketNotification`](#getBucketNotification)             | [`getPresignedObjectUrl`](#getPresignedObjectUrl)       |
-| [`getBucketPolicy`](#getBucketPolicy)                         | [`isObjectLegalHoldEnabled`](#isObjectLegalHoldEnabled) |
-| [`getBucketTags`](#getBucketTags)                             | [`listObjects`](#listObjects)                           |
-| [`getDefaultRetention`](#getDefaultRetention)                 | [`presignedGetObject`](#presignedGetObject)             |
-| [`listBuckets`](#listBuckets)                                 | [`presignedPostPolicy`](#presignedPostPolicy)           |
-| [`listenBucketNotification`](#listenBucketNotification)       | [`presignedPutObject`](#presignedPutObject)             |
-| [`listIncompleteUploads`](#listIncompleteUploads)             | [`putObject`](#putObject)                               |
-| [`makeBucket`](#makeBucket)                                   | [`removeObject`](#removeObject)                         |
-| [`removeAllBucketNotification`](#removeAllBucketNotification) | [`removeObjects`](#removeObjects)                       |
-| [`removeBucket`](#removeBucket)                               | [`selectObjectContent`](#selectObjectContent)           |
-| [`removeIncompleteUpload`](#removeIncompleteUpload)           | [`setObjectRetention`](#setObjectRetention)             |
-| [`setBucketEncryption`](#setBucketEncryption)                 | [`setObjectTags`](#setObjectTags)                       |
-| [`setBucketLifeCycle`](#setBucketLifeCycle)                   | [`statObject`](#statObject)                             |
-| [`setBucketNotification`](#setBucketNotification)             |                                                         |
+| [`deleteBucketTags`](#deleteBucketTags)                       | [`downloadObject`](#downloadObject)                     |
+| [`disableVersioning`](#disableVersioning)                     | [`enableObjectLegalHold`](#enableObjectLegalHold)       |
+| [`enableVersioning`](#enableVersioning)                       | [`getObject`](#getObject)                               |
+| [`getBucketEncryption`](#getBucketEncryption)                 | [`getObjectRetention`](#getObjectRetention)             |
+| [`getBucketLifeCycle`](#getBucketLifeCycle)                   | [`getObjectTags`](#getObjectTags)                       |
+| [`getBucketNotification`](#getBucketNotification)             | [`getObjectUrl`](#getObjectUrl)                         |
+| [`getBucketPolicy`](#getBucketPolicy)                         | [`getPresignedObjectUrl`](#getPresignedObjectUrl)       |
+| [`getBucketTags`](#getBucketTags)                             | [`isObjectLegalHoldEnabled`](#isObjectLegalHoldEnabled) |
+| [`getDefaultRetention`](#getDefaultRetention)                 | [`listObjects`](#listObjects)                           |
+| [`listBuckets`](#listBuckets)                                 | [`presignedGetObject`](#presignedGetObject)             |
+| [`listenBucketNotification`](#listenBucketNotification)       | [`presignedPostPolicy`](#presignedPostPolicy)           |
+| [`listIncompleteUploads`](#listIncompleteUploads)             | [`presignedPutObject`](#presignedPutObject)             |
+| [`makeBucket`](#makeBucket)                                   | [`putObject`](#putObject)                               |
+| [`removeAllBucketNotification`](#removeAllBucketNotification) | [`removeObject`](#removeObject)                         |
+| [`removeBucket`](#removeBucket)                               | [`removeObjects`](#removeObjects)                       |
+| [`removeIncompleteUpload`](#removeIncompleteUpload)           | [`selectObjectContent`](#selectObjectContent)           |
+| [`setBucketEncryption`](#setBucketEncryption)                 | [`setObjectRetention`](#setObjectRetention)             |
+| [`setBucketLifeCycle`](#setBucketLifeCycle)                   | [`setObjectTags`](#setObjectTags)                       |
+| [`setBucketNotification`](#setBucketNotification)             | [`statObject`](#statObject)                             |
 | [`setBucketPolicy`](#setBucketPolicy)                         |                                                         |
 | [`setBucketTags`](#setBucketTags)                             |                                                         |
 | [`setDefaultRetention`](#setDefaultRetention)                 |                                                         |
@@ -654,9 +654,9 @@ for (Result<Upload> result : results) {
 Lists object information of a bucket.
 
 __Parameters__
-| Parameter      | Type     | Description         |
-|:---------------|:---------|:--------------------|
-| ``args`` | _[ListObjectsArgs]_ | Arguments to list objects |
+| Parameter        | Type                | Description               |
+|:-----------------|:--------------------|:--------------------------|
+| ``args``         | _[ListObjectsArgs]_ | Arguments to list objects |
 
 | Returns                                                                   |
 |:--------------------------------------------------------------------------|
@@ -1055,16 +1055,15 @@ minioClient.enableObjectLegalHold("my-bucketname", "my-objectname", null);
 ```
 
 <a name="getObject"></a>
-### getObject(String bucketName, String objectName)
-`public InputStream getObject(String bucketName, String objectName)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-)_
+### getObject(GetObjectArgs args)
+`public InputStream getObject(GetObjectArgs args)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-io.minio.GetObjectArgs-)_
 
 Gets data of an object. Returned `InputStream` must be closed after use to release network resources.
 
 __Parameters__
-| Parameter      | Type     | Description                |
-|:---------------|:---------|:---------------------------|
-| ``bucketName`` | _String_ | Name of the bucket.        |
-| ``objectName`` | _String_ | Object name in the bucket. |
+| Parameter      | Type            | Description                |
+|:---------------|:----------------|:---------------------------|
+| ``args``       | _GetObjectArgs_ | Arguments.                 |
 
 | Returns                               |
 |:--------------------------------------|
@@ -1072,145 +1071,88 @@ __Parameters__
 
 __Example__
 ```java
-try (InputStream stream = minioClient.getObject("my-bucketname", "my-objectname")) {
+// get object given the bucket and object name
+try (InputStream stream = minioClient.getObject(
+  GetObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .build()) {
+  // Read data from stream
+}
+
+// get object data from offset
+try (InputStream stream = minioClient.getObject(
+  GetObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .offset(1024L)
+  .build()) {
+  // Read data from stream
+}
+
+// get object data from offset to length
+try (InputStream stream = minioClient.getObject(
+  GetObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .offset(1024L)
+  .length(4096L)
+  .build()) {
+  // Read data from stream
+}
+
+// get data of an SSE-C encrypted object
+try (InputStream stream = minioClient.getObject(
+  GetObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .ssec(ssec)
+  .build()) {
+  // Read data from stream
+}
+
+// get object data from offset to length of an SSE-C encrypted object
+try (InputStream stream = minioClient.getObject(
+  GetObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .offset(1024L)
+  .length(4096L)
+  .ssec(ssec)
+  .build()) {
   // Read data from stream
 }
 ```
 
-<a name="getObject"></a>
-### getObject(String bucketName, String objectName, long offset)
-`public InputStream getObject(String bucketName, String objectName, long offset)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-long-)_
-
-Gets data from offset of an object. Returned `InputStream` must be closed after use to release network resources.
-
-__Parameters__
-| Parameter      | Type     | Description                         |
-|:---------------|:---------|:------------------------------------|
-| ``bucketName`` | _String_ | Name of the bucket.                 |
-| ``objectName`` | _String_ | Object name in the bucket.          |
-| ``offset``     | _long_   | Start byte position of object data. |
-
-| Returns                               |
-|:--------------------------------------|
-| _InputStream_ - Contains object data. |
-
-__Example__
-```java
-try (InputStream stream = minioClient.getObject("my-bucketname", "my-objectname", 1024L)) {
-  // Read data from stream
-}
-```
-
-<a name="getObject"></a>
-### getObject(String bucketName, String objectName, long offset, Long length)
-`public InputStream getObject(String bucketName,  String objectName, long offset, Long length)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-long-java.lang.Long-)_
-
-Gets data from offset to length of an object. Returned {@link InputStream} must be closed after use to release network resources.
-
-__Parameters__
-| Parameter      | Type     | Description                                            |
-|:---------------|:---------|:-------------------------------------------------------|
-| ``bucketName`` | _String_ | Name of the bucket.                                    |
-| ``objectName`` | _String_ | Object name in the bucket.                             |
-| ``offset``     | _long_   | Start byte position of object data.                    |
-| ``length``     | _Long_   | (Optional) Number of bytes of object data from offset. |
-
-| Returns                               |
-|:--------------------------------------|
-| _InputStream_ - Contains object data. |
-
-__Example__
-```java
-try (InputStream stream = minioClient.getObject("my-bucketname", "my-objectname", 1024L, 4096L)) {
-  // Read data from stream
-}
-```
-
-<a name="getObject"></a>
-### getObject(String bucketName, String objectName, ServerSideEncryption sse)
-`public InputStream getObject(String bucketName, String objectName, ServerSideEncryption sse)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-io.minio.ServerSideEncryption-)_
-
-Gets data of a SSE-C encrypted object. Returned {@link InputStream} must be closed after use to release network resources.
-
-__Parameters__
-| Parameter      | Type                     | Description                        |
-|:---------------|:-------------------------|:-----------------------------------|
-| ``bucketName`` | _String_                 | Name of the bucket.                |
-| ``objectName`` | _String_                 | Object name in the bucket.         |
-| ``sse``        | _[ServerSideEncryption]_ | SSE-C type server-side encryption. |
-
-| Returns                               |
-|:--------------------------------------|
-| _InputStream_ - Contains object data. |
-
-__Example__
-```java
-try (InputStream stream = minioClient.getObject("my-bucketname", "my-objectname", ssec)) {
-  // Read data from stream
-}
-```
-
-<a name="getObject"></a>
-### getObject(String bucketName, String objectName, Long offset, Long length, ServerSideEncryption sse)
-`public InputStream getObject(String bucketName, String objectName, Long offset, Long length, ServerSideEncryption sse)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-java.lang.Long-java.lang.Long-io.minio.ServerSideEncryption-)_
-
-Gets data from offset to length of a SSE-C encrypted object. Returned {@link InputStream} must be closed after use to release network resources.
-
-__Parameters__
-| Parameter      | Type                     | Description                                            |
-|:---------------|:-------------------------|:-------------------------------------------------------|
-| ``bucketName`` | _String_                 | Name of the bucket.                                    |
-| ``objectName`` | _String_                 | Object name in the bucket.                             |
-| ``offset``     | _Long_                   | (Optional) Start byte position of object data.         |
-| ``length``     | _Long_                   | (Optional) Number of bytes of object data from offset. |
-| ``sse``        | _[ServerSideEncryption]_ | (Optional) Server-side encryption.                     |
-
-| Returns                               |
-|:--------------------------------------|
-| _InputStream_ - Contains object data. |
-
-__Example__
-```java
-try (InputStream stream = minioClient.getObject("my-bucketname", "my-objectname", 1024L, 4096L, ssec)) {
-  // Read data from stream
-}
-```
-
-<a name="getObject"></a>
-### getObject(String bucketName, String objectName, String fileName)
-`public void getObject(String bucketName, String objectName, String fileName)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-java.lang.String-)_
+<a name="downloadObject"></a>
+### downloadObject(DownloadObjectArgs args)
+`public void downloadObject(DownloadObjectArgs args)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-io.minio.DownloadObjectArgs-)_
 
 Downloads data of an object to file.
 
 __Parameters__
-| Parameter      | Type     | Description                |
-|:---------------|:---------|:---------------------------|
-| ``bucketName`` | _String_ | Name of the bucket.        |
-| ``objectName`` | _String_ | Object name in the bucket. |
-| ``fileName``   | _String_ | Name of the file.          |
+| Parameter        | Type                 | Description                  |
+|:-----------------|:---------------------|:-----------------------------|
+| ``args``         | _DownloadObjectArgs_ | Arguments.                   |
 
 __Example__
 ```java
-minioClient.getObject("my-bucketname", "my-objectname", "my-object-file");
-```
+// Download object given the bucket, object name and output file name
+minioClient.downloadObject(
+  DownloadObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .fileName("my-object-file")
+  .build());
 
-<a name="getObject"></a>
-### getObject(String bucketName, String objectName, ServerSideEncryption sse, String fileName)
-`public void getObject(String bucketName, String objectName, ServerSideEncryption sse, String fileName)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#getObject-java.lang.String-java.lang.String-io.minio.ServerSideEncryption-java.lang.String-)_
-
-Downloads server-side encrypted object in bucket to given file name.
-
-__Parameters__
-| Parameter      | Type                     | Description                        |
-|:---------------|:-------------------------|:-----------------------------------|
-| ``bucketName`` | _String_                 | Name of the bucket.                |
-| ``objectName`` | _String_                 | Object name in the bucket.         |
-| ``sse``        | _[ServerSideEncryption]_ | SSE-C type server-side encryption. |
-| ``fileName``   | _String_                 | Name of the file.                  |
-
-__Example__
-```java
-minioClient.getObject("my-bucketname", "my-objectname", ssec, "my-object-file");
+// Download server-side encrypted object in bucket to given file name
+minioClient.downloadObject(
+  DownloadObjectArgs.builder()
+  .bucket("my-bucketname")
+  .object("my-objectname")
+  .ssec(ssec)
+  .fileName("my-object-file")
+  .build());
 ```
 
  <a name="getObjectRetention"></a>
@@ -1591,24 +1533,24 @@ for (Result<DeleteError> result : results) {
 ```
 
  <a name="selectObjectContent"></a>
-### selectObjectContent(String bucketName, String objectName, String sqlExpression, InputSerialization is, OutputSerialization os, boolean requestProgress, Long scanStartRange, Long scanEndRange, ServerSideEncryption sse)
-`public SelectResponseStream selectObjectContent(String bucketName, String objectName, String sqlExpression, InputSerialization is, OutputSerialization os, boolean requestProgress, Long scanStartRange, Long scanEndRange, ServerSideEncryption sse)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#selectObjectContent-java.lang.String-java.lang.String-java.lang.String-io.minio.messages.InputSerialization-io.minio.messages.OutputSerialization-boolean-java.lang.Long-java.lang.Long-io.minio.ServerSideEncryption-)_
+### selectObjectContent(String bucketName, String objectName, String sqlExpression, InputSerialization is, OutputSerialization os, boolean requestProgress, Long scanStartRange, Long scanEndRange, ServerSideEncryptionCustomerKey ssec)
+`public SelectResponseStream selectObjectContent(String bucketName, String objectName, String sqlExpression, InputSerialization is, OutputSerialization os, boolean requestProgress, Long scanStartRange, Long scanEndRange, ServerSideEncryptionCustomerKey ssec)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#selectObjectContent-java.lang.String-java.lang.String-java.lang.String-io.minio.messages.InputSerialization-io.minio.messages.OutputSerialization-boolean-java.lang.Long-java.lang.Long-io.minio.ServerSideEncryptionCustomerKey-)_
 
 Selects content of a object by SQL expression.
 
 __Parameters__
 
-| Parameter           | Type                     | Description                           |
-|:--------------------|:-------------------------|:--------------------------------------|
-| ``bucketName``      | _String_                 | Name of the bucket.                   |
-| ``objectName``      | _String_                 | Object name in the bucket.            |
-| ``sqlExpression``   | _String_                 | SQL expression.                       |
-| ``is``              | _[InputSerialization]_   | Input specification of object data.   |
-| ``os``              | _[OutputSerialization]_  | Output specification of result.       |
-| ``requestProgress`` | _boolean_                | Flag to request progress information. |
-| ``scanStartRange``  | _Long_                   | scan start range of the object.       |
-| ``scanEndRange``    | _Long_                   | scan end range of the object.         |
-| ``sse``             | _[ServerSideEncryption]_ | SSE-C type server-side encryption.    |
+| Parameter           | Type                                | Description                           |
+|:--------------------|:------------------------------------|:--------------------------------------|
+| ``bucketName``      | _String_                            | Name of the bucket.                   |
+| ``objectName``      | _String_                            | Object name in the bucket.            |
+| ``sqlExpression``   | _String_                            | SQL expression.                       |
+| ``is``              | _[InputSerialization]_              | Input specification of object data.   |
+| ``os``              | _[OutputSerialization]_             | Output specification of result.       |
+| ``requestProgress`` | _boolean_                           | Flag to request progress information. |
+| ``scanStartRange``  | _Long_                              | scan start range of the object.       |
+| ``scanEndRange``    | _Long_                              | scan end range of the object.         |
+| ``sse``             | _[ServerSideEncryptionCustomerKey]_ | SSE-C type server-side encryption.    |
 
 | Returns                                                            |
 |:-------------------------------------------------------------------|
@@ -1756,6 +1698,7 @@ ObjectStat objectStat =
 [Item]: http://minio.github.io/minio-java/io/minio/messages/Item.html
 [ComposeSource]: http://minio.github.io/minio-java/io/minio/ComposeSource.html
 [ServerSideEncryption]: http://minio.github.io/minio-java/io/minio/ServerSideEncryption.html
+[ServerSideEncryptionCustomerKey]: http://minio.github.io/minio-java/io/minio/ServerSideEncryptionCustomerKey.html
 [CopyConditions]: http://minio.github.io/minio-java/io/minio/CopyConditions.html
 [PostPolicy]: http://minio.github.io/minio-java/io/minio/PostPolicy.html
 [PutObjectOptions]: http://minio.github.io/minio-java/io/minio/PutObjectOptions.html
@@ -1792,3 +1735,5 @@ ObjectStat objectStat =
 [GetBucketPolicyArgs]: http://minio.github.io/minio-java/io/minio/GetBucketPolicyArgs.html
 [SetBucketPolicyArgs]: http://minio.github.io/minio-java/io/minio/SetBucketPolicyArgs.html
 [DeleteBucketPolicyArgs]: http://minio.github.io/minio-java/io/minio/DeleteBucketPolicyArgs.html
+[GetObjectArgs]: http://minio.github.io/minio-java/io/minio/GetObjectArgs.html
+[DownloadObjectArgs]: http://minio.github.io/minio-java/io/minio/DownloadObjectArgs.html

--- a/examples/ComposeObjectEncrypted.java
+++ b/examples/ComposeObjectEncrypted.java
@@ -18,6 +18,7 @@ import io.minio.ComposeSource;
 import io.minio.MinioClient;
 import io.minio.PutObjectOptions;
 import io.minio.ServerSideEncryption;
+import io.minio.ServerSideEncryptionCustomerKey;
 import io.minio.errors.MinioException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -42,7 +43,7 @@ public class ComposeObjectEncrypted {
       byte[] key = "01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8);
       SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
 
-      ServerSideEncryption ssePut = ServerSideEncryption.withCustomerKey(secretKeySpec);
+      ServerSideEncryptionCustomerKey ssePut = ServerSideEncryption.withCustomerKey(secretKeySpec);
 
       byte[] keyTarget = "01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8);
       SecretKeySpec secretKeySpecTarget = new SecretKeySpec(keyTarget, "AES");

--- a/examples/DownloadObject.java
+++ b/examples/DownloadObject.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import io.minio.DownloadObjectArgs;
 import io.minio.MinioClient;
 import io.minio.errors.MinioException;
 import java.io.IOException;
@@ -37,7 +38,12 @@ public class DownloadObject {
       //                                           "YOUR-SECRETACCESSKEY");
 
       // Download 'my-objectname' from 'my-bucketname' to 'my-filename'
-      minioClient.getObject("my-bucketname", "my-objectname", "my-filename");
+      minioClient.downloadObject(
+          DownloadObjectArgs.builder()
+              .bucket("my-bucketname")
+              .object("my-objectname")
+              .fileName("my-filename")
+              .build());
       System.out.println("my-objectname is successfully downloaded to my-filename");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);

--- a/examples/GetObject.java
+++ b/examples/GetObject.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
 import io.minio.errors.MinioException;
 import java.io.IOException;
@@ -39,7 +40,9 @@ public class GetObject {
       //                                           "YOUR-SECRETACCESSKEY");
 
       // Get input stream to have content of 'my-objectname' from 'my-bucketname'
-      InputStream stream = minioClient.getObject("my-bucketname", "my-objectname");
+      InputStream stream =
+          minioClient.getObject(
+              GetObjectArgs.builder().bucket("my-bucketname").object("my-objectname").build());
 
       // Read the input stream and print to the console till EOF.
       byte[] buf = new byte[16384];

--- a/examples/GetObjectProgressBar.java
+++ b/examples/GetObjectProgressBar.java
@@ -15,6 +15,7 @@
  */
 
 import com.google.common.io.ByteStreams;
+import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
 import io.minio.ObjectStat;
 import io.minio.StatObjectArgs;
@@ -64,7 +65,8 @@ public class GetObjectProgressBar {
               "Downloading .. ",
               ProgressBarStyle.ASCII,
               objectStat.length(),
-              minioClient.getObject("my-bucketname", "my-objectname"));
+              minioClient.getObject(
+                  GetObjectArgs.builder().bucket("my-bucketname").object("my-objectname").build()));
 
       Path path = Paths.get("my-filename");
       OutputStream os = Files.newOutputStream(path, StandardOpenOption.CREATE);

--- a/examples/GetPartialObject.java
+++ b/examples/GetPartialObject.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
 import io.minio.errors.MinioException;
 import java.io.IOException;
@@ -40,7 +41,14 @@ public class GetPartialObject {
 
       // Get input stream to have content of 'my-objectname' from 'my-bucketname' starts from
       // byte position 1024 and length 4096.
-      InputStream stream = minioClient.getObject("my-bucketname", "my-objectname", 1024L, 4096L);
+      InputStream stream =
+          minioClient.getObject(
+              GetObjectArgs.builder()
+                  .bucket("my-bucketname")
+                  .object("my-objectname")
+                  .offset(1024L)
+                  .length(4096L)
+                  .build());
 
       // Read the input stream and print to the console till EOF.
       byte[] buf = new byte[16384];

--- a/examples/PutGetObjectEncrypted.java
+++ b/examples/PutGetObjectEncrypted.java
@@ -1,6 +1,8 @@
+import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectOptions;
 import io.minio.ServerSideEncryption;
+import io.minio.ServerSideEncryptionCustomerKey;
 import io.minio.errors.MinioException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -61,17 +63,24 @@ public class PutGetObjectEncrypted {
       keyGen.init(256);
 
       // To test SSE-C
-      ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+      ServerSideEncryptionCustomerKey ssec =
+          ServerSideEncryption.withCustomerKey(keyGen.generateKey());
 
       PutObjectOptions options = new PutObjectOptions(bais.available(), -1);
-      options.setSse(sse);
+      options.setSse(ssec);
       minioClient.putObject("my-bucketname", "my-objectname", bais, options);
 
       bais.close();
 
       System.out.println("my-objectname is encrypted and uploaded successfully.");
 
-      InputStream stream = minioClient.getObject("my-bucketname", "my-objectname", sse);
+      InputStream stream =
+          minioClient.getObject(
+              GetObjectArgs.builder()
+                  .bucket("my-bucketname")
+                  .object("my-objectname")
+                  .ssec(ssec)
+                  .build());
 
       // Read the input stream and print to the console till EOF.
       byte[] buf = new byte[16384];

--- a/examples/PutGetObjectEncryptedFile.java
+++ b/examples/PutGetObjectEncryptedFile.java
@@ -1,6 +1,8 @@
+import io.minio.DownloadObjectArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectOptions;
 import io.minio.ServerSideEncryption;
+import io.minio.ServerSideEncryptionCustomerKey;
 import io.minio.errors.MinioException;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -34,13 +36,20 @@ public class PutGetObjectEncryptedFile {
       keyGen.init(256);
 
       // To test SSE-C
-      ServerSideEncryption sse = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+      ServerSideEncryptionCustomerKey ssec =
+          ServerSideEncryption.withCustomerKey(keyGen.generateKey());
       PutObjectOptions options = new PutObjectOptions(inputfileSize, -1);
-      options.setSse(sse);
+      options.setSse(ssec);
       minioClient.putObject(bucketName, objectName, inputfile, options);
       System.out.println("my-objectname is encrypted and uploaded successfully.");
 
-      minioClient.getObject(bucketName, objectName, sse, outputfile);
+      minioClient.downloadObject(
+          DownloadObjectArgs.builder()
+              .bucket(bucketName)
+              .object(objectName)
+              .ssec(ssec)
+              .fileName(outputfile)
+              .build());
       System.out.println("Content of my-objectname saved to my-outputfile ");
     } catch (MinioException e) {
       System.out.println("Error occurred: " + e);

--- a/examples/StatObject.java
+++ b/examples/StatObject.java
@@ -17,6 +17,7 @@
 import io.minio.MinioClient;
 import io.minio.ObjectStat;
 import io.minio.ServerSideEncryption;
+import io.minio.ServerSideEncryptionCustomerKey;
 import io.minio.StatObjectArgs;
 import io.minio.errors.MinioException;
 import java.io.IOException;
@@ -43,7 +44,8 @@ public class StatObject {
 
       KeyGenerator keyGen = KeyGenerator.getInstance("AES");
       keyGen.init(256);
-      ServerSideEncryption ssec = ServerSideEncryption.withCustomerKey(keyGen.generateKey());
+      ServerSideEncryptionCustomerKey ssec =
+          ServerSideEncryption.withCustomerKey(keyGen.generateKey());
       String versionId = "ac38316c-fe14-4f96-9f76-8f675ae5a79e";
 
       {


### PR DESCRIPTION
New Argument class: `GetObjectArgs`

Arguments supported:
 - offset (Long)
 - length (Long)
 - ssec (ServerSideEncryptionWithCustomerKey)

Since there are multiple APIs / args classes that need `ssec` as an argument, introduced an intermediate abstract class `SsecObjectArgs` that supports the `ssec` argument, and provides common logic related to it e.g. validations.

Since the return type of the methods that support downloading the object as a file is `void`, we cannot name it the same as `getObject`. So introduced a new method called `downloadObject` for downloading the object, which internally uses `getObject`. And introduced a new args class `DownloadObjectArgs` for it.

Also,
  - Enhanced the method `FunctionalTest#handleException` to support  logging of the arguments as well.
  - Moved the class `ServerSideEncryptionWithCustomerKey` outside of `ServerSideEncryption` and made it into a standalone class with the name `ServerSideEncryptionCustomerKey`