### PR TITLE
Implement args builder for selectObjectContent API

### DIFF
--- a/api/src/main/java/io/minio/BaseArgs.java
+++ b/api/src/main/java/io/minio/BaseArgs.java
@@ -46,6 +46,19 @@ public abstract class BaseArgs {
 
     protected abstract void validate(A args);
 
+    protected void validateNotNull(Object arg, String argName) {
+      if (arg == null) {
+        throw new IllegalArgumentException(argName + " must not be null.");
+      }
+    }
+
+    protected void validateNotEmptyString(String arg, String argName) {
+      validateNotNull(arg, argName);
+      if (arg.isEmpty()) {
+        throw new IllegalArgumentException(argName + " must be a non-empty string.");
+      }
+    }
+
     public Builder() {
       this.operations = new ArrayList<>();
     }

--- a/api/src/main/java/io/minio/SelectObjectContentArgs.java
+++ b/api/src/main/java/io/minio/SelectObjectContentArgs.java
@@ -1,0 +1,91 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2015, 2016, 2017, 2018, 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import io.minio.messages.InputSerialization;
+import io.minio.messages.OutputSerialization;
+
+public class SelectObjectContentArgs extends SsecObjectArgs {
+  private String sqlExpression;
+  private InputSerialization inputSerialization;
+  private OutputSerialization outputSerialization;
+  private Boolean requestProgress;
+  private Long scanStartRange;
+  private Long scanEndRange;
+
+  public Long scanEndRange() {
+    return scanEndRange;
+  }
+
+  public Long scanStartRange() {
+    return scanStartRange;
+  }
+
+  public Boolean requestProgress() {
+    return requestProgress;
+  }
+
+  public OutputSerialization outputSerialization() {
+    return outputSerialization;
+  }
+
+  public InputSerialization inputSerialization() {
+    return inputSerialization;
+  }
+
+  public String sqlExpression() {
+    return sqlExpression;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder
+      extends SsecObjectArgs.Builder<Builder, SelectObjectContentArgs> {
+    public Builder sqlExpression(String sqlExpression) {
+      operations.add(args -> args.sqlExpression = sqlExpression);
+      return this;
+    }
+
+    public Builder inputSerialization(InputSerialization inputSerialization) {
+      operations.add(args -> args.inputSerialization = inputSerialization);
+      return this;
+    }
+
+    public Builder outputSerialization(OutputSerialization outputSerialization) {
+      operations.add(args -> args.outputSerialization = outputSerialization);
+      return this;
+    }
+
+    public Builder requestProgress(Boolean requestProgress) {
+      operations.add(args -> args.requestProgress = requestProgress);
+      return this;
+    }
+
+    public Builder scanStartRange(Long scanStartRange) {
+      operations.add(args -> args.scanStartRange = scanStartRange);
+      return this;
+    }
+
+    public Builder scanEndRange(Long scanEndRange) {
+      operations.add(args -> args.scanEndRange = scanEndRange);
+      return this;
+    }
+  }
+}

--- a/api/src/main/java/io/minio/SelectObjectContentArgs.java
+++ b/api/src/main/java/io/minio/SelectObjectContentArgs.java
@@ -1,6 +1,6 @@
 /*
  * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2015, 2016, 2017, 2018, 2019 MinIO, Inc.
+ * (C) 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/minio/SelectObjectContentArgs.java
+++ b/api/src/main/java/io/minio/SelectObjectContentArgs.java
@@ -58,17 +58,32 @@ public class SelectObjectContentArgs extends SsecObjectArgs {
 
   public static final class Builder
       extends SsecObjectArgs.Builder<Builder, SelectObjectContentArgs> {
+    private void validateSqlExpression(String se) {
+      validateNotEmptyString(se, "sqlExpression");
+    }
+
     public Builder sqlExpression(String sqlExpression) {
+      validateSqlExpression(sqlExpression);
       operations.add(args -> args.sqlExpression = sqlExpression);
       return this;
     }
 
+    private void validateInputSerialization(InputSerialization is) {
+      validateNotNull(is, "inputSerialization");
+    }
+
     public Builder inputSerialization(InputSerialization inputSerialization) {
+      validateInputSerialization(inputSerialization);
       operations.add(args -> args.inputSerialization = inputSerialization);
       return this;
     }
 
+    private void validateOutputSerialization(OutputSerialization os) {
+      validateNotNull(os, "outputSerialization");
+    }
+
     public Builder outputSerialization(OutputSerialization outputSerialization) {
+      validateOutputSerialization(outputSerialization);
       operations.add(args -> args.outputSerialization = outputSerialization);
       return this;
     }
@@ -86,6 +101,14 @@ public class SelectObjectContentArgs extends SsecObjectArgs {
     public Builder scanEndRange(Long scanEndRange) {
       operations.add(args -> args.scanEndRange = scanEndRange);
       return this;
+    }
+
+    @Override
+    protected void validate(SelectObjectContentArgs args) {
+      super.validate(args);
+      validateSqlExpression(args.sqlExpression());
+      validateInputSerialization(args.inputSerialization());
+      validateOutputSerialization(args.outputSerialization());
     }
   }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1586,8 +1586,8 @@ for (Result<DeleteError> result : results) {
 ```
 
  <a name="selectObjectContent"></a>
-### selectObjectContent(String bucketName, String objectName, String sqlExpression, InputSerialization is, OutputSerialization os, boolean requestProgress, Long scanStartRange, Long scanEndRange, ServerSideEncryptionCustomerKey ssec)
-`public SelectResponseStream selectObjectContent(String bucketName, String objectName, String sqlExpression, InputSerialization is, OutputSerialization os, boolean requestProgress, Long scanStartRange, Long scanEndRange, ServerSideEncryptionCustomerKey ssec)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#selectObjectContent-java.lang.String-java.lang.String-java.lang.String-io.minio.messages.InputSerialization-io.minio.messages.OutputSerialization-boolean-java.lang.Long-java.lang.Long-io.minio.ServerSideEncryptionCustomerKey-)_
+### selectObjectContent(SelectObjectContentArgs args)
+`public SelectResponseStream selectObjectContent(SelectObjectContentArgs args)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#selectObjectContent-io.minio.SelectObjectContentArgs-)_
 
 Selects content of a object by SQL expression.
 
@@ -1595,15 +1595,7 @@ __Parameters__
 
 | Parameter           | Type                                | Description                           |
 |:--------------------|:------------------------------------|:--------------------------------------|
-| ``bucketName``      | _String_                            | Name of the bucket.                   |
-| ``objectName``      | _String_                            | Object name in the bucket.            |
-| ``sqlExpression``   | _String_                            | SQL expression.                       |
-| ``is``              | _[InputSerialization]_              | Input specification of object data.   |
-| ``os``              | _[OutputSerialization]_             | Output specification of result.       |
-| ``requestProgress`` | _boolean_                           | Flag to request progress information. |
-| ``scanStartRange``  | _Long_                              | scan start range of the object.       |
-| ``scanEndRange``    | _Long_                              | scan end range of the object.         |
-| ``sse``             | _[ServerSideEncryptionCustomerKey]_ | SSE-C type server-side encryption.    |
+| ``args``            | _SelectObjectContentArgs_           | Arguments.                            |
 
 | Returns                                                            |
 |:-------------------------------------------------------------------|
@@ -1614,8 +1606,16 @@ __Example__
 String sqlExpression = "select * from S3Object";
 InputSerialization is = new InputSerialization(null, false, null, null, FileHeaderInfo.USE, null, null, null);
 OutputSerialization os = new OutputSerialization(null, null, null, QuoteFields.ASNEEDED, null);
-SelectResponseStream stream = minioClient.selectObjectContent("my-bucketname", "my-objectName", sqlExpression,
-    is, os, true, null, null, null);
+SelectResponseStream stream =
+    minioClient.selectObjectContent(
+        SelectObjectContentArgs.builder()
+            .bucket("my-bucketname")
+            .object("my-objectName")
+            .sqlExpression(sqlExpression)
+            .inputSerialization(is)
+            .outputSerialization(os)
+            .requestProgress(true)
+            .build());
 
 byte[] buf = new byte[512];
 int bytesRead = stream.read(buf, 0, buf.length);
@@ -1799,3 +1799,4 @@ ObjectStat objectStat =
 [GetBucketNotificationArgs]: http://minio.github.io/minio-java/io/minio/GetBucketNotificationArgs.html
 [SetBucketNotificationArgs]: http://minio.github.io/minio-java/io/minio/SetBucketNotificationArgs.html
 [ListenBucketNotificationArgs]: http://minio.github.io/minio-java/io/minio/ListenBucketNotificationArgs.html
+[SelectObjectContentArgs]: http://minio.github.io/minio-java/io/minio/SelectObjectContentArgs.html

--- a/docs/API.md
+++ b/docs/API.md
@@ -1595,7 +1595,7 @@ __Parameters__
 
 | Parameter           | Type                                | Description                           |
 |:--------------------|:------------------------------------|:--------------------------------------|
-| ``args``            | _SelectObjectContentArgs_           | Arguments.                            |
+| ``args``            | _[SelectObjectContentArgs]_           | Arguments.                            |
 
 | Returns                                                            |
 |:-------------------------------------------------------------------|

--- a/examples/SelectObjectContent.java
+++ b/examples/SelectObjectContent.java
@@ -16,6 +16,7 @@
 
 import io.minio.MinioClient;
 import io.minio.PutObjectOptions;
+import io.minio.SelectObjectContentArgs;
 import io.minio.SelectResponseStream;
 import io.minio.errors.MinioException;
 import io.minio.messages.FileHeaderInfo;
@@ -65,7 +66,14 @@ public class SelectObjectContent {
 
       SelectResponseStream stream =
           minioClient.selectObjectContent(
-              "my-bucketname", "my-objectName", sqlExpression, is, os, true, null, null, null);
+              SelectObjectContentArgs.builder()
+                  .bucket("my-bucketname")
+                  .object("my-objectName")
+                  .sqlExpression(sqlExpression)
+                  .inputSerialization(is)
+                  .outputSerialization(os)
+                  .requestProgress(true)
+                  .build());
 
       byte[] buf = new byte[512];
       int bytesRead = stream.read(buf, 0, buf.length);

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -4254,13 +4254,7 @@ public class FunctionalTest {
 
       mintSuccessLog(methodName, args, startTime);
     } catch (Exception e) {
-      mintFailedLog(
-          methodName,
-          args,
-          startTime,
-          null,
-          e.toString() + " >>> " + Arrays.toString(e.getStackTrace()));
-      throw e;
+      handleException(methodName, args, startTime, e);
     } finally {
       if (responseStream != null) {
         responseStream.close();


### PR DESCRIPTION
Introduced new args class `SelectObjectContentArgs` that extends from
`SsecObjectArgs` and has the following attributes:
  - bucket (inherited)
  - object (inherited)
  - ssec (inherited)
  - sqlExpression
  - inputSerialization
  - outputSerialization
  - requestProgress
  - scanStartRange
  - scanEndRange