### PR TITLE
Implement args builder for removeIncompleteUpload

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -5935,16 +5935,51 @@ public class MinioClient {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated use {@link #removeIncompleteUpload(RemoveIncompleteUploadArgs)}
    */
+  @Deprecated
   public void removeIncompleteUpload(String bucketName, String objectName)
       throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
           InternalException, InvalidBucketNameException, InvalidKeyException,
           InvalidResponseException, IOException, NoSuchAlgorithmException, ServerException,
           XmlParserException {
-    for (Result<Upload> r : listIncompleteUploads(bucketName, objectName, true, false)) {
+    removeIncompleteUpload(
+        RemoveIncompleteUploadArgs.builder().bucket(bucketName).object(objectName).build());
+  }
+
+  /**
+   * Removes incomplete uploads of an object.
+   *
+   * <pre>Example:{@code
+   * minioClient.removeIncompleteUpload(
+   *     RemoveIncompleteUploadArgs.builder()
+   *     .bucket("my-bucketname")
+   *     .object("my-objectname")
+   *     .build());
+   * }</pre>
+   *
+   * @param args instance of {@link RemoveIncompleteUploadArgs}
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws IllegalArgumentException throws to indicate invalid argument passed.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidBucketNameException thrown to indicate invalid bucket name passed.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public void removeIncompleteUpload(RemoveIncompleteUploadArgs args)
+      throws ErrorResponseException, IllegalArgumentException, InsufficientDataException,
+          InternalException, InvalidBucketNameException, InvalidKeyException,
+          InvalidResponseException, IOException, NoSuchAlgorithmException, ServerException,
+          XmlParserException {
+    for (Result<Upload> r : listIncompleteUploads(args.bucket(), args.object(), true, false)) {
       Upload upload = r.get();
-      if (objectName.equals(upload.objectName())) {
-        abortMultipartUpload(bucketName, objectName, upload.uploadId());
+      if (args.object().equals(upload.objectName())) {
+        abortMultipartUpload(args.bucket(), args.object(), upload.uploadId());
         return;
       }
     }

--- a/api/src/main/java/io/minio/RemoveIncompleteUploadArgs.java
+++ b/api/src/main/java/io/minio/RemoveIncompleteUploadArgs.java
@@ -1,0 +1,28 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+public class RemoveIncompleteUploadArgs extends ObjectArgs {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder
+      extends ObjectArgs.Builder<Builder, RemoveIncompleteUploadArgs> {}
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -803,20 +803,23 @@ minioClient.removeBucket(RemoveBucketArgs.builder().bucket(bucketName).build());
 ```
 
 <a name="removeIncompleteUpload"></a>
-### removeIncompleteUpload(String bucketName, String objectName)
-`public void removeIncompleteUpload(String bucketName, String objectName)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#removeIncompleteUpload-java.lang.String-java.lang.String-)_
+### removeIncompleteUpload(RemoveIncompleteUploadArgs args)
+`public void removeIncompleteUpload(String bucketName, String objectName)` _[[Javadoc]](http://minio.github.io/minio-java/io/minio/MinioClient.html#removeIncompleteUpload-io.minio.RemoveIncompleteUploadArgs-)_
 
 Removes incomplete uploads of an object.
 
 __Parameters__
-| Parameter      | Type     | Description                |
-|:---------------|:---------|:---------------------------|
-| ``bucketName`` | _String_ | Name of the bucket.        |
-| ``objectName`` | _String_ | Object name in the bucket. |
+| Parameter        | Type                           | Description                  |
+|:-----------------|:-------------------------------|:-----------------------------|
+| ``args``         | _[RemoveIncompleteUploadArgs]_ | Arguments.                   |
 
 __Example__
 ```java
-minioClient.removeIncompleteUpload("my-bucketname", "my-objectname");
+minioClient.removeIncompleteUpload(
+    RemoveIncompleteUploadArgs.builder()
+        .bucket("my-bucketname")
+        .object("my-objectname")
+        .build());
 ```
 
 <a name="setBucketEncryption"></a>
@@ -1821,3 +1824,4 @@ ObjectStat objectStat =
 [GetDefaultRetentionArgs]: http://minio.github.io/minio-java/io/minio/GetDefaultRetentionArgs.html
 [SetDefaultRetentionArgs]: http://minio.github.io/minio-java/io/minio/SetDefaultRetentionArgs.html
 [DeleteDefaultRetentionArgs]: http://minio.github.io/minio-java/io/minio/DeleteDefaultRetentionArgs.html
+[RemoveIncompleteUploadArgs]: http://minio.github.io/minio-java/io/minio/DeleteDefaultRetentionArgs.html

--- a/examples/RemoveIncompleteUpload.java
+++ b/examples/RemoveIncompleteUpload.java
@@ -15,6 +15,7 @@
  */
 
 import io.minio.MinioClient;
+import io.minio.RemoveIncompleteUploadArgs;
 import io.minio.errors.MinioException;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -37,7 +38,11 @@ public class RemoveIncompleteUpload {
       //                                           "YOUR-SECRETACCESSKEY");
 
       // Remove all incomplete multipart upload sessions for a given bucket and object name.
-      minioClient.removeIncompleteUpload("my-bucketname", "my-objectname");
+      minioClient.removeIncompleteUpload(
+          RemoveIncompleteUploadArgs.builder()
+              .bucket("my-bucketname")
+              .object("my-objectname")
+              .build());
       System.out.println(
           "successfully removed all incomplete upload session of my-bucketname/my-objectname");
     } catch (MinioException e) {

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -55,6 +55,7 @@ import io.minio.ObjectStat;
 import io.minio.PostPolicy;
 import io.minio.PutObjectOptions;
 import io.minio.RemoveBucketArgs;
+import io.minio.RemoveIncompleteUploadArgs;
 import io.minio.RemoveObjectArgs;
 import io.minio.Result;
 import io.minio.SelectObjectContentArgs;
@@ -2013,7 +2014,8 @@ public class FunctionalTest {
         }
       }
 
-      client.removeIncompleteUpload(bucketName, objectName);
+      client.removeIncompleteUpload(
+          RemoveIncompleteUploadArgs.builder().bucket(bucketName).object(objectName).build());
       mintSuccessLog("listIncompleteUploads(String bucketName)", null, startTime);
     } catch (Exception e) {
       mintFailedLog(
@@ -2053,7 +2055,8 @@ public class FunctionalTest {
         }
       }
 
-      client.removeIncompleteUpload(bucketName, objectName);
+      client.removeIncompleteUpload(
+          RemoveIncompleteUploadArgs.builder().bucket(bucketName).object(objectName).build());
       mintSuccessLog("listIncompleteUploads(String bucketName, String prefix)", null, startTime);
     } catch (Exception e) {
       mintFailedLog(
@@ -2098,7 +2101,8 @@ public class FunctionalTest {
         }
       }
 
-      client.removeIncompleteUpload(bucketName, objectName);
+      client.removeIncompleteUpload(
+          RemoveIncompleteUploadArgs.builder().bucket(bucketName).object(objectName).build());
       mintSuccessLog(
           "listIncompleteUploads(final String bucketName, final String prefix, final boolean recursive)",
           "prefix: minio, recursive: true",
@@ -2116,8 +2120,9 @@ public class FunctionalTest {
 
   /** Test: removeIncompleteUpload(String bucketName, String objectName). */
   public static void removeIncompleteUploads_test() throws Exception {
+    String methodName = "removeIncompleteUpload(RemoveIncompleteUploadArgs args)";
     if (!mintEnv) {
-      System.out.println("Test: removeIncompleteUpload(String bucketName, String objectName)");
+      System.out.println("Test: " + methodName);
     }
 
     long startTime = System.currentTimeMillis();
@@ -2141,17 +2146,11 @@ public class FunctionalTest {
         }
       }
 
-      client.removeIncompleteUpload(bucketName, objectName);
-      mintSuccessLog(
-          "removeIncompleteUpload(String bucketName, String objectName)", null, startTime);
+      client.removeIncompleteUpload(
+          RemoveIncompleteUploadArgs.builder().bucket(bucketName).object(objectName).build());
+      mintSuccessLog(methodName, null, startTime);
     } catch (Exception e) {
-      mintFailedLog(
-          "removeIncompleteUpload(String bucketName, String objectName)",
-          null,
-          startTime,
-          null,
-          e.toString() + " >>> " + Arrays.toString(e.getStackTrace()));
-      throw e;
+      handleException(methodName, null, startTime, e);
     }
   }
 


### PR DESCRIPTION
Introduced the new args class `RemoveIncompleteUploadArgs` (extends from
`ObjectArgs` and doesn't add any additional params) and added a new
method

`MinioClient#removeIncompleteUpload(RemoveIncompleteUploadArgs args)`

deprecating the existing method

`MinioClient#removeIncompleteUpload(String bucketName, String objectName)`