### PR TITLE
Add base argument class for conditionally reading objects.

### DIFF
--- a/api/src/main/java/io/minio/CopySource.java
+++ b/api/src/main/java/io/minio/CopySource.java
@@ -16,13 +16,13 @@
 
 package io.minio;
 
-/** Argument class of MinioClient.getObject(). */
-public class GetObjectArgs extends ObjectConditionalReadArgs {
+/** A source object defintion for {@link CopyObjectArgs}. */
+public class CopySource extends ObjectConditionalReadArgs {
   public static Builder builder() {
     return new Builder();
   }
 
-  /** Argument builder of {@link GetObjectArgs}. */
+  /** Argument builder of {@link CopySource}. */
   public static final class Builder
-      extends ObjectConditionalReadArgs.Builder<Builder, GetObjectArgs> {}
+      extends ObjectConditionalReadArgs.Builder<Builder, CopySource> {}
 }

--- a/api/src/main/java/io/minio/ObjectConditionalReadArgs.java
+++ b/api/src/main/java/io/minio/ObjectConditionalReadArgs.java
@@ -1,0 +1,142 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import java.time.ZonedDateTime;
+
+public abstract class ObjectConditionalReadArgs extends ObjectReadArgs {
+  protected Long offset;
+  protected Long length;
+  protected String matchETag;
+  protected String notMatchETag;
+  protected ZonedDateTime modifiedSince;
+  protected ZonedDateTime unmodifiedSince;
+
+  public Long offset() {
+    return offset;
+  }
+
+  public Long length() {
+    return length;
+  }
+
+  public String matchETag() {
+    return matchETag;
+  }
+
+  public String notMatchETag() {
+    return notMatchETag;
+  }
+
+  public ZonedDateTime modifiedSince() {
+    return modifiedSince;
+  }
+
+  public ZonedDateTime unmodifiedSince() {
+    return unmodifiedSince;
+  }
+
+  public Multimap<String, String> genCopyHeaders() {
+    Multimap<String, String> headers = HashMultimap.create();
+
+    String copySource = S3Escaper.encodePath("/" + bucketName + "/" + objectName);
+    if (versionId != null) {
+      copySource += "?versionId=" + S3Escaper.encode(versionId);
+    }
+
+    headers.put("x-amz-copy-source", copySource);
+
+    if (ssec != null) {
+      headers.putAll(Multimaps.forMap(ssec.copySourceHeaders()));
+    }
+
+    if (matchETag != null) {
+      headers.put("x-amz-copy-source-if-match", matchETag);
+    }
+
+    if (notMatchETag != null) {
+      headers.put("x-amz-copy-source-if-none-match", notMatchETag);
+    }
+
+    if (modifiedSince != null) {
+      headers.put(
+          "x-amz-copy-source-if-modified-since",
+          modifiedSince.format(Time.HTTP_HEADER_DATE_FORMAT));
+    }
+
+    if (unmodifiedSince != null) {
+      headers.put(
+          "x-amz-copy-source-if-unmodified-since",
+          unmodifiedSince.format(Time.HTTP_HEADER_DATE_FORMAT));
+    }
+
+    return headers;
+  }
+
+  @SuppressWarnings("unchecked") // Its safe to type cast to B as B is inherited by this class
+  public abstract static class Builder<B extends Builder<B, A>, A extends ObjectConditionalReadArgs>
+      extends ObjectReadArgs.Builder<B, A> {
+    private void validateLength(Long length) {
+      if (length != null && length <= 0) {
+        throw new IllegalArgumentException("length should be greater than zero");
+      }
+    }
+
+    private void validateOffset(Long offset) {
+      if (offset != null && offset < 0) {
+        throw new IllegalArgumentException("offset should be zero or greater");
+      }
+    }
+
+    public B offset(Long offset) {
+      validateOffset(offset);
+      operations.add(args -> args.offset = offset);
+      return (B) this;
+    }
+
+    public B length(Long length) {
+      validateLength(length);
+      operations.add(args -> args.length = length);
+      return (B) this;
+    }
+
+    public B matchETag(String etag) {
+      validateNullOrNotEmptyString(etag, "etag");
+      operations.add(args -> args.matchETag = etag);
+      return (B) this;
+    }
+
+    public B notMatchETag(String etag) {
+      validateNullOrNotEmptyString(etag, "etag");
+      operations.add(args -> args.notMatchETag = etag);
+      return (B) this;
+    }
+
+    public B modifiedSince(ZonedDateTime modifiedTime) {
+      operations.add(args -> args.modifiedSince = modifiedTime);
+      return (B) this;
+    }
+
+    public B unmodifiedSince(ZonedDateTime unmodifiedTime) {
+      operations.add(args -> args.unmodifiedSince = unmodifiedTime);
+      return (B) this;
+    }
+  }
+}

--- a/api/src/main/java/io/minio/StatObjectArgs.java
+++ b/api/src/main/java/io/minio/StatObjectArgs.java
@@ -17,11 +17,28 @@
 package io.minio;
 
 /** Argument class of MinioClient.statObject(). */
-public class StatObjectArgs extends ObjectReadArgs {
+public class StatObjectArgs extends ObjectConditionalReadArgs {
+  protected StatObjectArgs() {}
+
+  public StatObjectArgs(ObjectConditionalReadArgs args) {
+    this.extraHeaders = args.extraHeaders;
+    this.extraQueryParams = args.extraQueryParams;
+    this.bucketName = args.bucketName;
+    this.region = args.region;
+    this.objectName = args.objectName;
+    this.versionId = args.versionId;
+    this.ssec = args.ssec;
+    this.matchETag = args.matchETag;
+    this.notMatchETag = args.notMatchETag;
+    this.modifiedSince = args.modifiedSince;
+    this.unmodifiedSince = args.unmodifiedSince;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
 
   /** Argument builder of {@link StatObjectArgs}. */
-  public static final class Builder extends ObjectReadArgs.Builder<Builder, StatObjectArgs> {}
+  public static final class Builder
+      extends ObjectConditionalReadArgs.Builder<Builder, StatObjectArgs> {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
   id "com.github.johnrengelman.shadow" version "5.2.0"
   id "com.github.spotbugs" version "4.0.1"
   id "io.codearte.nexus-staging" version "0.21.2"
-  id "com.diffplug.gradle.spotless" version "3.27.2"
+  id "com.diffplug.gradle.spotless" version "4.4.0"
 }
 
 /*
@@ -101,7 +101,6 @@ subprojects {
             importOrder 'edu', 'com', 'io', 'java', 'javax', 'org', ''
             removeUnusedImports()
             googleJavaFormat()
-            paddedCell()
         }
         groovyGradle {
             target '*.gradle'

--- a/examples/CopyObject.java
+++ b/examples/CopyObject.java
@@ -16,6 +16,7 @@
  */
 
 import io.minio.CopyObjectArgs;
+import io.minio.CopySource;
 import io.minio.MinioClient;
 import io.minio.ServerSideEncryption;
 import io.minio.ServerSideEncryptionCustomerKey;
@@ -72,7 +73,11 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-objectname")
+                        .build())
                 .build());
         System.out.println(
             "my-source-bucketname/my-objectname copied "
@@ -86,8 +91,11 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
-                .srcObject("my-source-objectname")
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-source-objectname")
+                        .build())
                 .build());
         System.out.println(
             "my-source-bucketname/my-source-objectname copied "
@@ -101,7 +109,11 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-objectname")
+                        .build())
                 .sse(sseKms) // Replace with actual key.
                 .build());
         System.out.println(
@@ -116,7 +128,11 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-objectname")
+                        .build())
                 .sse(sseS3) // Replace with actual key.
                 .build());
         System.out.println(
@@ -131,7 +147,11 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-objectname")
+                        .build())
                 .sse(ssec) // Replace with actual key.
                 .build());
         System.out.println(
@@ -146,9 +166,12 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
-                .srcObject("my-source-objectname")
-                .srcSsec(ssec) // Replace with actual key.
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-source-objectname")
+                        .ssec(ssec) // Replace with actual key.
+                        .build())
                 .build());
         System.out.println(
             "my-source-bucketname/my-source-objectname copied "
@@ -162,9 +185,13 @@ public class CopyObject {
             CopyObjectArgs.builder()
                 .bucket("my-bucketname")
                 .object("my-objectname")
-                .srcBucket("my-source-bucketname")
+                .source(
+                    CopySource.builder()
+                        .bucket("my-source-bucketname")
+                        .object("my-objectname")
+                        .matchETag(etag) // Replace with actual etag.
+                        .build())
                 .headers(headers) // Replace with actual headers.
-                .srcMatchETag(etag) // Replace with actual ETag.
                 .build());
         System.out.println(
             "my-source-bucketname/my-objectname copied "


### PR DESCRIPTION
`GetObject`, `HeadObject` and `CopyObject` S3 API support conditions
on reading objects. This patch introduces common base class
`ObjectConditionalReadArgs` for `GetObjectArgs`, `StatObjectArgs`,
`CopySource` and `ComposeSource` to avoid code duplication.