### PR TITLE
fix {copy,compose}Object to handle single source appropriately.

### DIFF
--- a/api/src/main/java/io/minio/CopyObjectArgs.java
+++ b/api/src/main/java/io/minio/CopyObjectArgs.java
@@ -24,6 +24,23 @@ public class CopyObjectArgs extends ObjectWriteArgs {
   private Directive metadataDirective;
   private Directive taggingDirective;
 
+  protected CopyObjectArgs() {}
+
+  public CopyObjectArgs(ComposeObjectArgs args) {
+    this.extraHeaders = args.extraHeaders;
+    this.extraQueryParams = args.extraQueryParams;
+    this.bucketName = args.bucketName;
+    this.region = args.region;
+    this.objectName = args.objectName;
+    this.headers = args.headers;
+    this.userMetadata = args.userMetadata;
+    this.sse = args.sse;
+    this.tags = args.tags;
+    this.retention = args.retention;
+    this.legalHold = args.legalHold;
+    this.source = new CopySource(args.sources().get(0));
+  }
+
   public CopySource source() {
     return source;
   }

--- a/api/src/main/java/io/minio/CopySource.java
+++ b/api/src/main/java/io/minio/CopySource.java
@@ -18,6 +18,24 @@ package io.minio;
 
 /** A source object defintion for {@link CopyObjectArgs}. */
 public class CopySource extends ObjectConditionalReadArgs {
+  protected CopySource() {}
+
+  public CopySource(ObjectConditionalReadArgs args) {
+    this.extraHeaders = args.extraHeaders;
+    this.extraQueryParams = args.extraQueryParams;
+    this.bucketName = args.bucketName;
+    this.region = args.region;
+    this.objectName = args.objectName;
+    this.versionId = args.versionId;
+    this.ssec = args.ssec;
+    this.offset = args.offset;
+    this.length = args.length;
+    this.matchETag = args.matchETag;
+    this.notMatchETag = args.notMatchETag;
+    this.modifiedSince = args.modifiedSince;
+    this.unmodifiedSince = args.unmodifiedSince;
+  }
+
   public static Builder builder() {
     return new Builder();
   }


### PR DESCRIPTION
* When size of source of copyObject() is greater than 5GiB, use composeObject().
* When single source of composeObject() makes single part with no offset/length,
  use copyObject().