### PR TITLE
Added Javadoc bucket versioning setup restrictions

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -3818,6 +3818,10 @@ public class MinioClient {
   /**
    * Enables object versioning feature in a bucket.
    *
+   * Versioning feature is available only for erasure coded and distributed erasure coded setups
+   * For further information:
+   * @see <a href="https://docs.minio.io/docs/minio-bucket-versioning-guide.html">Minio bucket versioning guide</a>
+   *
    * <pre>Example:{@code
    * minioClient.enableVersioning(EnableVersioningArgs.builder().bucket("my-bucketname").build());
    * }</pre>


### PR DESCRIPTION
Hello, I think that javadoc for the `enableVersioning` should contains information about the setup restrictions.
I copy paste the required setup from the [documentation](https://docs.minio.io/docs/minio-bucket-versioning-guide.html) and put the link to it.
