### PR TITLE
Add support for continuation token for listObjectsV2

### DIFF
--- a/api/src/main/java/io/minio/ListObjectsArgs.java
+++ b/api/src/main/java/io/minio/ListObjectsArgs.java
@@ -38,7 +38,12 @@ public class ListObjectsArgs extends BucketArgs {
       return "";
     }
 
-    return (delimiter.isEmpty() ? "/" : delimiter);
+    if (continuationToken != null && !continuationToken.isEmpty()) {
+      // for continuation token, the delimiter has to be empty
+      return null;
+    } else {
+      return (delimiter.isEmpty() ? "/" : delimiter);
+    }
   }
 
   public boolean useUrlEncodingType() {

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1868,7 +1868,10 @@ public class MinioClient {
     return executeListObjectsV2(args);
   }
 
-  public ListBucketResultV2 listObjectsV2(ListObjectsArgs args) throws InvalidResponseException, NoSuchAlgorithmException, InvalidKeyException, ServerException, InternalException, XmlParserException, IOException, InsufficientDataException, ErrorResponseException {
+  public ListBucketResultV2 listObjectsV2(ListObjectsArgs args)
+      throws InvalidResponseException, NoSuchAlgorithmException, InvalidKeyException,
+          ServerException, InternalException, XmlParserException, IOException,
+          InsufficientDataException, ErrorResponseException {
     return executeListObjectsV2(
             args.bucket(),
             args.region(),
@@ -1881,7 +1884,8 @@ public class MinioClient {
             args.fetchOwner(),
             args.includeUserMetadata(),
             args.extraHeaders(),
-            args.extraQueryParams()).result();
+            args.extraQueryParams())
+        .result();
   }
 
   private abstract class ObjectIterator implements Iterator<Result<Item>> {

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -1865,7 +1865,23 @@ public class MinioClient {
       return listObjectsV1(args);
     }
 
-    return listObjectsV2(args);
+    return executeListObjectsV2(args);
+  }
+
+  public ListBucketResultV2 listObjectsV2(ListObjectsArgs args) throws InvalidResponseException, NoSuchAlgorithmException, InvalidKeyException, ServerException, InternalException, XmlParserException, IOException, InsufficientDataException, ErrorResponseException {
+    return executeListObjectsV2(
+            args.bucket(),
+            args.region(),
+            args.delimiter(),
+            args.useUrlEncodingType() ? "url" : null,
+            args.startAfter(),
+            args.maxKeys(),
+            args.prefix(),
+            args.continuationToken(),
+            args.fetchOwner(),
+            args.includeUserMetadata(),
+            args.extraHeaders(),
+            args.extraQueryParams()).result();
   }
 
   private abstract class ObjectIterator implements Iterator<Result<Item>> {
@@ -2001,7 +2017,7 @@ public class MinioClient {
     }
   }
 
-  private Iterable<Result<Item>> listObjectsV2(ListObjectsArgs args) {
+  private Iterable<Result<Item>> executeListObjectsV2(ListObjectsArgs args) {
     return new Iterable<Result<Item>>() {
       @Override
       public Iterator<Result<Item>> iterator() {
@@ -2018,7 +2034,7 @@ public class MinioClient {
             this.prefixIterator = null;
 
             ListObjectsV2Response response =
-                listObjectsV2(
+                executeListObjectsV2(
                     args.bucket(),
                     args.region(),
                     args.delimiter(),
@@ -4371,7 +4387,7 @@ public class MinioClient {
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
    */
-  protected ListObjectsV2Response listObjectsV2(
+  protected ListObjectsV2Response executeListObjectsV2(
       String bucketName,
       String region,
       String delimiter,

--- a/api/src/main/java/io/minio/messages/Metadata.java
+++ b/api/src/main/java/io/minio/messages/Metadata.java
@@ -29,6 +29,9 @@ import org.simpleframework.xml.stream.OutputNode;
 @Root(name = "Metadata")
 @Convert(Metadata.MetadataConverter.class)
 public class Metadata {
+  private static final String AWS_META_KEY_PREFIX = "X-Amz-Meta-";
+  private static final int AWS_META_KEY_PREFIX_LENGTH = AWS_META_KEY_PREFIX.length();
+
   Map<String, String> map;
 
   public Metadata() {}
@@ -52,7 +55,8 @@ public class Metadata {
           break;
         }
 
-        map.put(childNode.getName(), childNode.getValue());
+        String key = childNode.getName().startsWith(AWS_META_KEY_PREFIX) ? childNode.getName().substring(AWS_META_KEY_PREFIX_LENGTH) : childNode.getName();
+        map.put(key.toLowerCase(), childNode.getValue());
       }
 
       if (map.size() > 0) {

--- a/api/src/main/java/io/minio/messages/Metadata.java
+++ b/api/src/main/java/io/minio/messages/Metadata.java
@@ -16,8 +16,10 @@
 
 package io.minio.messages;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.convert.Convert;
@@ -55,8 +57,11 @@ public class Metadata {
           break;
         }
 
-        String key = childNode.getName().startsWith(AWS_META_KEY_PREFIX) ? childNode.getName().substring(AWS_META_KEY_PREFIX_LENGTH) : childNode.getName();
-        map.put(key.toLowerCase(), childNode.getValue());
+        String key =
+            childNode.getName().startsWith(AWS_META_KEY_PREFIX)
+                ? childNode.getName().substring(AWS_META_KEY_PREFIX_LENGTH)
+                : childNode.getName();
+        map.put(key.toLowerCase(Locale.US), childNode.getValue());
       }
 
       if (map.size() > 0) {

--- a/api/src/main/java/io/minio/messages/Metadata.java
+++ b/api/src/main/java/io/minio/messages/Metadata.java
@@ -16,7 +16,6 @@
 
 package io.minio.messages;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;


### PR DESCRIPTION
Add support for listObjetsV2 to provide and use continuationToken to continue listing of the selected bucket.
Also match the user metadata keys returned from statObject metod with listObjects (remove the "protocol" X-AWS-Meta prefix).