### PR TITLE
Mint - Add environment variable RUN_ON_FAIL

### DIFF
--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -176,6 +176,7 @@ public class FunctionalTest {
   private static String bucketNameWithLock = getRandomName();
   private static boolean mintEnv = false;
   private static boolean isQuickTest = false;
+  private static boolean isRunOnFail = false;
   private static Path dataFile1Kb;
   private static Path dataFile6Mb;
   private static String endpoint;
@@ -429,6 +430,9 @@ public class FunctionalTest {
           startTime,
           null,
           e.toString() + " >>> " + Arrays.toString(e.getStackTrace()));
+      if (isRunOnFail) {
+        return;
+      }
     } else {
       System.out.println("<FAILED> " + methodName + " " + ((args == null) ? "" : args));
     }
@@ -3925,6 +3929,7 @@ public class FunctionalTest {
     mintEnv = (mintMode != null);
     if (mintEnv) {
       isQuickTest = !mintMode.equals("full");
+      isRunOnFail = "1".equals(System.getenv("RUN_ON_FAIL"));
       String dataDir = System.getenv("MINT_DATA_DIR");
       if (dataDir != null && !dataDir.equals("")) {
         dataFile1Kb = Paths.get(dataDir, "datafile-1-kB");


### PR DESCRIPTION
Refering to https://github.com/minio/minio/issues/11996

## Description
By setting the variable `RUN_ON_FAIL` all tests from minio-java are executed independent of failures.

 ## Motivation and Context
A single failing test from the test package causes all the remaining tests to be skipped.

## How to test this PR?
`RUN_ON_FAIL=1`
At least two tests must fail.

`RUN_ON_FAIL=0`
The behavior is not changed if the environment variable is not set or equals 0.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated