### PR TITLE
add handling optional AWS_CONTAINER_AUTHORIZATION_TOKEN

### DIFF
--- a/api/src/main/java/io/minio/credentials/IamAwsProvider.java
+++ b/api/src/main/java/io/minio/credentials/IamAwsProvider.java
@@ -109,8 +109,18 @@ public class IamAwsProvider extends EnvironmentProvider {
   }
 
   private Credentials fetchCredentials(HttpUrl url) {
-    try (Response response =
-        httpClient.newCall(new Request.Builder().url(url).method("GET", null).build()).execute()) {
+    Request req = null;
+    if (getProperty("AWS_CONTAINER_AUTHORIZATION_TOKEN") != null) {
+      req =
+          new Request.Builder()
+              .url(url)
+              .method("GET", null)
+              .addHeader("Authorization", getProperty("AWS_CONTAINER_AUTHORIZATION_TOKEN"))
+              .build();
+    } else {
+      req = new Request.Builder().url(url).method("GET", null).build();
+    }
+    try (Response response = httpClient.newCall(req).execute()) {
       if (!response.isSuccessful()) {
         throw new ProviderException(url + " failed with HTTP status code " + response.code());
       }


### PR DESCRIPTION
Supporting the optional AWS_CONTAINER_AUTHORIZATION_TOKEN environment variable (per https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EC2ContainerCredentialsProviderWrapper.html) for retrieving credentials from AWS_CONTAINER_CREDENTIALS_FULL_URI.

Can be tested directly on any AWS Cloud Shell to access a S3 bucket. 