### PR TITLE
Upgrade guava dependency to v30.0-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
 
     dependencies {
         compile "com.carrotsearch.thirdparty:simple-xml-safe:2.7.1"
-        compile "com.google.guava:guava:29.0-jre"
+        compile "com.google.guava:guava:30.0-jre"
         compile "com.squareup.okhttp3:okhttp:4.8.1"
         compile "com.fasterxml.jackson.core:jackson-annotations:2.11.2"
         compile "com.fasterxml.jackson.core:jackson-core:2.11.2"


### PR DESCRIPTION
First of all thanks for providing this great project!
With this PR I want to bump guava. In my project I'm using Snyk vulnerability scanner, that revealed following security issue with current version of `minio-java`:

```
Issues with no direct upgrade or patch:
  ✗ Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@29.0-jre
    introduced by MY_LIBRARY@SOME_VERSION > MY_MINIO_WRAPPER@SOME_VERSION > io.minio:minio@8.2.1 > com.google.guava:guava@29.0-jre
  This issue was fixed in versions: 30.0-android, 30.0-jre
```
More details on Guava vulnerability: https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415 