### PR TITLE
Fail if unsupported okhttp3 is found.

### DIFF
--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -100,6 +100,14 @@ import okhttp3.ResponseBody;
 
 /** Core S3 API client. */
 public abstract class S3Base {
+  static {
+    try {
+      RequestBody.create(new byte[] {}, null);
+    } catch (NoSuchMethodError ex) {
+      throw new RuntimeException("Unsupported OkHttp library found. Must use okhttp >= 4.8.1", ex);
+    }
+  }
+
   protected static final String NO_SUCH_BUCKET_MESSAGE = "Bucket does not exist";
   protected static final String NO_SUCH_BUCKET = "NoSuchBucket";
   protected static final String NO_SUCH_BUCKET_POLICY = "NoSuchBucketPolicy";


### PR DESCRIPTION
As `okhttp` 4.x and 3.x use same package name `okhttp3`, `minio-java`
fails at middle of runtime if `okhttp` 3.x is used. This patch fails
at beginning if unsupported okhttp3 is found.

Signed-off-by: Bala.FA <bala.gluster@gmail.com>