### PR TITLE
Create a separate jar for the admin api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,7 +250,7 @@ project(':adminapi') {
     apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: "de.marcphilipp.nexus-publish"
 
-    archivesBaseName = 'minio'
+    archivesBaseName = 'minio-admin'
 
     configurations.all {
         resolutionStrategy {


### PR DESCRIPTION
Completely missed this when doing my last contribution! Currently, there's no way for someone to access the admin-api, as the artifact (`minio`) is already made for the regular client. 