### PR TITLE
Make Gradle snippet in README compatible with Gradle 7+, Groovy and Kotlin DSLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Java 1.8 or above.
 ## Gradle usage
 ```
 dependencies {
-    compile 'io.minio:minio:8.3.3'
+    implementation("io.minio:minio:8.3.3")
 }
 ```
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -22,7 +22,7 @@ Java 1.8或更高版本:
 ## 使用gradle
 ```
 dependencies {
-    compile 'io.minio:minio:3.0.10'
+    implementation("io.minio:minio:3.0.10")
 }
 ```
 


### PR DESCRIPTION
Besides Groovy, Gradle also provides support for a [Kotlin DSL](https://docs.gradle.org/current/userguide/kotlin_dsl.html) to configure builds.

To get people running MinIO quickly regardless of the DSL they use, this PR changes the snippet so that it is both valid Groovy syntax and valid Kotlin syntax.

This also changes the `compile` keyword to `implementation`, since `compile` has been deprecated in Gradle 7+.