### PR TITLE
Remove value field from io.minio.http.Method enum

### DIFF
--- a/api/src/main/java/io/minio/http/Method.java
+++ b/api/src/main/java/io/minio/http/Method.java
@@ -18,14 +18,9 @@ package io.minio.http;
 
 /** HTTP methods. */
 public enum Method {
-  GET("GET"),
-  HEAD("HEAD"),
-  POST("POST"),
-  PUT("PUT"),
-  DELETE("DELETE");
-  private final String value;
-
-  private Method(String value) {
-    this.value = value;
-  }
+  GET,
+  HEAD,
+  POST,
+  PUT,
+  DELETE;
 }


### PR DESCRIPTION
Field is private and have no public getters. The value is never used.