### PR TITLE
Add serialVersionUID to exceptions

### DIFF
--- a/api/src/main/java/io/minio/errors/BucketPolicyTooLargeException.java
+++ b/api/src/main/java/io/minio/errors/BucketPolicyTooLargeException.java
@@ -19,6 +19,8 @@ package io.minio.errors;
 /** Thrown to indicate that received bucket policy is larger than 20KiB size. */
 @SuppressWarnings("WeakerAccess")
 public class BucketPolicyTooLargeException extends MinioException {
+  private static final long serialVersionUID = -4589481215582512545L;
+
   public BucketPolicyTooLargeException(String bucketName) {
     super("Bucket policy is larger than 20KiB size for bucket " + bucketName);
   }

--- a/api/src/main/java/io/minio/errors/ErrorResponseException.java
+++ b/api/src/main/java/io/minio/errors/ErrorResponseException.java
@@ -24,6 +24,8 @@ import okhttp3.Response;
 /** Thrown to indicate that error response is received when executing Amazon S3 operation. */
 @SuppressWarnings("WeakerAccess")
 public class ErrorResponseException extends MinioException {
+  private static final long serialVersionUID = -2933211538346902928L;
+
   private final ErrorResponse errorResponse;
 
   @SuppressFBWarnings(

--- a/api/src/main/java/io/minio/errors/InsufficientDataException.java
+++ b/api/src/main/java/io/minio/errors/InsufficientDataException.java
@@ -20,6 +20,8 @@ package io.minio.errors;
  * Thrown to indicate that reading given InputStream gets EOFException before reading given length.
  */
 public class InsufficientDataException extends MinioException {
+  private static final long serialVersionUID = -1619719290805056566L;
+
   /** Constructs a new InsufficientDataException with given error message. */
   public InsufficientDataException(String message) {
     super(message);

--- a/api/src/main/java/io/minio/errors/InternalException.java
+++ b/api/src/main/java/io/minio/errors/InternalException.java
@@ -20,6 +20,8 @@ package io.minio.errors;
  * Thrown to indicate that unexpected internal library error occured while processing given request.
  */
 public class InternalException extends MinioException {
+  private static final long serialVersionUID = 138336287983212416L;
+
   /** Constructs a new InternalException with given error message. */
   public InternalException(String message, String httpTrace) {
     super(message, httpTrace);

--- a/api/src/main/java/io/minio/errors/InvalidResponseException.java
+++ b/api/src/main/java/io/minio/errors/InvalidResponseException.java
@@ -18,6 +18,8 @@ package io.minio.errors;
 
 /** Thrown to indicate that non-xml response thrown from server. */
 public class InvalidResponseException extends MinioException {
+  private static final long serialVersionUID = -4793742105569629274L;
+
   public InvalidResponseException(
       int responseCode, String contentType, String body, String httpTrace) {
     super(

--- a/api/src/main/java/io/minio/errors/MinioException.java
+++ b/api/src/main/java/io/minio/errors/MinioException.java
@@ -18,6 +18,8 @@ package io.minio.errors;
 
 /** Base Exception class for all minio-java exceptions. */
 public class MinioException extends Exception {
+  private static final long serialVersionUID = -7241010318779326306L;
+
   String httpTrace = null;
 
   /** Constructs a new MinioException. */

--- a/api/src/main/java/io/minio/errors/ServerException.java
+++ b/api/src/main/java/io/minio/errors/ServerException.java
@@ -18,6 +18,8 @@ package io.minio.errors;
 
 /** Thrown to indicate that S3 service returning HTTP server error. */
 public class ServerException extends MinioException {
+  private static final long serialVersionUID = 6395201577368980633L;
+
   public ServerException(String message, String httpTrace) {
     super(message, httpTrace);
   }

--- a/api/src/main/java/io/minio/errors/XmlParserException.java
+++ b/api/src/main/java/io/minio/errors/XmlParserException.java
@@ -18,6 +18,8 @@ package io.minio.errors;
 
 /** Thrown to indicate that error at XML marshalling or unmarshalling. */
 public class XmlParserException extends MinioException {
+  private static final long serialVersionUID = -3877568719271880309L;
+
   Exception exception;
 
   public XmlParserException(Exception exception) {


### PR DESCRIPTION
I don't know if there is a rule for that, but eclipse likes to complain about a lack of `serialVersionUID` and this is a way for exceptions in `java.*` packages.