### PR TITLE
Remove 3/4 of Gradle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,6 @@ subprojects {
 
 project(':api') {
     apply plugin: 'java'
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'com.github.johnrengelman.shadow'
@@ -244,7 +243,6 @@ project(':api') {
 
 project(':adminapi') {
     apply plugin: 'java'
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'com.github.johnrengelman.shadow'

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ subprojects {
         compile "org.bouncycastle:bcprov-jdk15on:1.69"
         compileOnly "com.github.spotbugs:spotbugs-annotations:4.1.2"
 
-        testCompile "com.squareup.okhttp3:mockwebserver:4.8.1"
-        testCompile "junit:junit:4.13"
+        testImplementation "com.squareup.okhttp3:mockwebserver:4.8.1"
+        testImplementation "junit:junit:4.13"
     }
 
     configurations.all() {
@@ -259,7 +259,7 @@ project(':adminapi') {
 
     dependencies {
         compile project(':api')
-        testCompile project(':api')
+        testImplementation project(':api')
     }
 
     jar {

--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ project(':api') {
     jar {
         manifest {
             attributes('Implementation-Title': archivesBaseName,
-                    'Implementation-Version': version,
+                    'Implementation-Version': archiveVersion.get(),
                     'Built-By': 'MinIO, inc',
                     'Built-JDK': System.getProperty('java.version'),
                     'Source-Compatibility': sourceCompatibility,
@@ -265,7 +265,7 @@ project(':adminapi') {
     jar {
         manifest {
             attributes('Implementation-Title': archivesBaseName,
-                    'Implementation-Version': version,
+                    'Implementation-Version': archiveVersion.get(),
                     'Built-By': 'MinIO, inc',
                     'Built-JDK': System.getProperty('java.version'),
                     'Source-Compatibility': sourceCompatibility,


### PR DESCRIPTION
When building a code there is warning:

> Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
> Use '--warning-mode all' to show the individual deprecation warnings.
> See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings

I've corrected 3 of 4 problems. For the last one (changing `compile` for `api/implementation/runOnly` etc.) I'd need to know a project structure little better.