### PR TITLE
Fix issue with downloading objects inside a folder

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -284,7 +284,7 @@ public class MinioClient extends S3Base {
 
     StatObjectResponse stat = statObject(new StatObjectArgs(args));
 
-    String tempFilename = filename + "." + stat.etag() + ".part.minio";
+    String tempFilename = filename + "." + stat.etag().replaceAll("/", "") + ".part.minio";
     Path tempFilePath = Paths.get(tempFilename);
     boolean tempFileExists = Files.exists(tempFilePath);
 

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -284,7 +284,7 @@ public class MinioClient extends S3Base {
 
     StatObjectResponse stat = statObject(new StatObjectArgs(args));
 
-    String tempFilename = filename + "." + stat.etag().replaceAll("/", "") + ".part.minio";
+    String tempFilename = filename + "." + S3Escaper.encode(stat.etag()) + ".part.minio";
     Path tempFilePath = Paths.get(tempFilename);
     boolean tempFileExists = Files.exists(tempFilePath);
 


### PR DESCRIPTION
This is a fix for a small issue I ran into. I'm doing the following:
```
DownloadObjectArgs.builder()
                    .bucket("my-bucket")
                    .object("production/object.zip")
                    .filename("/app/downloads/object.zip")
                    .build()
```
                    
And I got the following error:
```
java.nio.file.NoSuchFileException: /app/downloads/object.zip.-CP/Qwejp1PCQEEA=.part.minio
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106) ~[?:?]
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
        at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219) ~[?:?]
        at java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:484) ~[?:?]
        at java.nio.file.Files.newOutputStream(Files.java:228) ~[?:?]
        at io.minio.MinioClient.downloadObject(MinioClient.java:1101) ~[common.jar:?]
```

The issue was resolved after removing slashes from the etag to prevent the temporary file from being placed in a subfolder. 