### PR TITLE
fix MinioAdminClient.listCannedPolicies() to return proper string values

### DIFF
--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -364,7 +364,9 @@ public class MinioAdminClient {
               .getTypeFactory()
               .constructMapType(HashMap.class, String.class, JsonNode.class);
       HashMap<String, String> policies = new HashMap<>();
-      OBJECT_MAPPER.<Map<String, JsonNode>>readValue(response.body().bytes(), mapType).forEach((key, value) -> policies.put(key, value.toString()));
+      OBJECT_MAPPER
+          .<Map<String, JsonNode>>readValue(response.body().bytes(), mapType)
+          .forEach((key, value) -> policies.put(key, value.toString()));
       return policies;
     }
   }

--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -17,6 +17,7 @@
 
 package io.minio.admin;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.google.common.collect.ImmutableMultimap;
@@ -355,13 +356,13 @@ public class MinioAdminClient {
    * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
    * @throws IOException thrown to indicate I/O error on MinIO REST operation.
    */
-  public Map<String, String> listCannedPolicies()
+  public Map<String, JsonNode> listCannedPolicies()
       throws NoSuchAlgorithmException, InvalidKeyException, IOException {
     try (Response response = execute(Method.GET, Command.LIST_CANNED_POLICIES, null, null)) {
       MapType mapType =
           OBJECT_MAPPER
               .getTypeFactory()
-              .constructMapType(HashMap.class, String.class, Object.class);
+              .constructMapType(HashMap.class, String.class, JsonNode.class);
       return OBJECT_MAPPER.readValue(response.body().bytes(), mapType);
     }
   }

--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -356,14 +356,16 @@ public class MinioAdminClient {
    * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
    * @throws IOException thrown to indicate I/O error on MinIO REST operation.
    */
-  public Map<String, JsonNode> listCannedPolicies()
+  public Map<String, String> listCannedPolicies()
       throws NoSuchAlgorithmException, InvalidKeyException, IOException {
     try (Response response = execute(Method.GET, Command.LIST_CANNED_POLICIES, null, null)) {
       MapType mapType =
           OBJECT_MAPPER
               .getTypeFactory()
               .constructMapType(HashMap.class, String.class, JsonNode.class);
-      return OBJECT_MAPPER.readValue(response.body().bytes(), mapType);
+      HashMap<String, String> policies = new HashMap<>();
+      OBJECT_MAPPER.<Map<String, JsonNode>>readValue(response.body().bytes(), mapType).forEach((key, value) -> policies.put(key, value.toString()));
+      return policies;
     }
   }
 

--- a/functional/TestMinioAdminClient.java
+++ b/functional/TestMinioAdminClient.java
@@ -75,7 +75,8 @@ public class TestMinioAdminClient {
     long startTime = System.currentTimeMillis();
     try {
       Map<String, String> policies = adminClient.listCannedPolicies();
-      Assert.assertTrue(policies.containsKey(policyName));
+      String policy = policies.get(policyName);
+      Assert.assertTrue(policy != null && !policy.isEmpty());
     } catch (Exception e) {
       FunctionalTest.handleException(methodName, null, startTime, e);
     }

--- a/functional/TestMinioAdminClient.java
+++ b/functional/TestMinioAdminClient.java
@@ -75,8 +75,8 @@ public class TestMinioAdminClient {
 
     long startTime = System.currentTimeMillis();
     try {
-      Map<String, JsonNode> policies = adminClient.listCannedPolicies();
-      JsonNode policy = policies.get(policyName);
+      Map<String, String> policies = adminClient.listCannedPolicies();
+      String policy = policies.get(policyName);
       Assert.assertTrue(policy != null);
     } catch (Exception e) {
       FunctionalTest.handleException(methodName, null, startTime, e);

--- a/functional/TestMinioAdminClient.java
+++ b/functional/TestMinioAdminClient.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import com.fasterxml.jackson.databind.JsonNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.minio.admin.*;
 import java.util.Map;
@@ -74,9 +75,9 @@ public class TestMinioAdminClient {
 
     long startTime = System.currentTimeMillis();
     try {
-      Map<String, String> policies = adminClient.listCannedPolicies();
-      String policy = policies.get(policyName);
-      Assert.assertTrue(policy != null && !policy.isEmpty());
+      Map<String, JsonNode> policies = adminClient.listCannedPolicies();
+      JsonNode policy = policies.get(policyName);
+      Assert.assertTrue(policy != null);
     } catch (Exception e) {
       FunctionalTest.handleException(methodName, null, startTime, e);
     }

--- a/functional/TestMinioAdminClient.java
+++ b/functional/TestMinioAdminClient.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import com.fasterxml.jackson.databind.JsonNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.minio.admin.*;
 import java.util.Map;


### PR DESCRIPTION
Currently, the returned map when listing all canned policies will return <String, LinkedHashMap> due to the policy (value) being a json blob. There's really no nice way to force jackson to treat it as raw json, thus my suggestion is to just treat it as a JsonNode, which then the user can either convert to a String, or if they've a pojo if they have it. 

First commit shows how the unit test fix exposes the failure, and the second commit contains the actual fix. 