### PR TITLE
Remove resume support in downloadObject() API.

### DIFF
--- a/api/src/main/java/io/minio/DownloadObjectArgs.java
+++ b/api/src/main/java/io/minio/DownloadObjectArgs.java
@@ -17,7 +17,6 @@
 package io.minio;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
@@ -44,11 +43,8 @@ public class DownloadObjectArgs extends ObjectReadArgs {
     private void validateFilename(String filename) {
       validateNotEmptyString(filename, "filename");
 
-      Path filePath = Paths.get(filename);
-      boolean fileExists = Files.exists(filePath);
-
-      if (fileExists && !Files.isRegularFile(filePath)) {
-        throw new IllegalArgumentException(filename + ": not a regular file");
+      if (Files.exists(Paths.get(filename))) {
+        throw new IllegalArgumentException("Destination file " + filename + " already exists");
       }
     }
   }


### PR DESCRIPTION
In downloadObject() API expects undocumented `Range` header and to
make a reliable trusted object download, the resume support is
removed. With this change, `IllegalArgumentException` is thrown if
destination file exists and the API always downloads given object
freshly.

Signed-off-by: Bala.FA <bala@minio.io>