### PR TITLE
Add async client support

### DIFF
--- a/api/src/main/java/io/minio/AbortMultipartUploadResponse.java
+++ b/api/src/main/java/io/minio/AbortMultipartUploadResponse.java
@@ -18,7 +18,7 @@ package io.minio;
 
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#abortMultipartUpload}. */
+/** Response class of {@link S3Base#abortMultipartUploadAsync}. */
 public class AbortMultipartUploadResponse extends GenericResponse {
   private String uploadId;
 

--- a/api/src/main/java/io/minio/BucketExistsArgs.java
+++ b/api/src/main/java/io/minio/BucketExistsArgs.java
@@ -16,7 +16,7 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#bucketExists}. */
+/** Argument class of {@link MinioAsyncClient#bucketExists} and {@link MinioClient#bucketExists}. */
 public class BucketExistsArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/ComposeObjectArgs.java
+++ b/api/src/main/java/io/minio/ComposeObjectArgs.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.Objects;
 import okhttp3.HttpUrl;
 
-/** Argument class of {@link MinioClient#composeObject}. */
+/**
+ * Argument class of {@link MinioAsyncClient#composeObject} and {@link MinioClient#composeObject}.
+ */
 public class ComposeObjectArgs extends ObjectWriteArgs {
   List<ComposeSource> sources;
 

--- a/api/src/main/java/io/minio/CopyObjectArgs.java
+++ b/api/src/main/java/io/minio/CopyObjectArgs.java
@@ -19,7 +19,7 @@ package io.minio;
 import java.util.Objects;
 import okhttp3.HttpUrl;
 
-/** Argument class of {@link MinioClient#copyObject}. */
+/** Argument class of {@link MinioAsyncClient#copyObject} and {@link MinioClient#copyObject}. */
 public class CopyObjectArgs extends ObjectWriteArgs {
   private CopySource source = null;
   private Directive metadataDirective;

--- a/api/src/main/java/io/minio/CreateMultipartUploadResponse.java
+++ b/api/src/main/java/io/minio/CreateMultipartUploadResponse.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.InitiateMultipartUploadResult;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#createMultipartUpload}. */
+/** Response class of {@link S3Base#createMultipartUploadAsync}. */
 public class CreateMultipartUploadResponse extends GenericResponse {
   private InitiateMultipartUploadResult result;
 

--- a/api/src/main/java/io/minio/DeleteBucketEncryptionArgs.java
+++ b/api/src/main/java/io/minio/DeleteBucketEncryptionArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteBucketEncryption}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteBucketEncryption} and {@link
+ * MinioClient#deleteBucketEncryption}.
+ */
 public class DeleteBucketEncryptionArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteBucketLifecycleArgs.java
+++ b/api/src/main/java/io/minio/DeleteBucketLifecycleArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteBucketLifecycle}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteBucketLifecycle} and {@link
+ * MinioClient#deleteBucketLifecycle}.
+ */
 public class DeleteBucketLifecycleArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteBucketNotificationArgs.java
+++ b/api/src/main/java/io/minio/DeleteBucketNotificationArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteBucketNotification}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteBucketNotification} and {@link
+ * MinioClient#deleteBucketNotification}.
+ */
 public class DeleteBucketNotificationArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteBucketPolicyArgs.java
+++ b/api/src/main/java/io/minio/DeleteBucketPolicyArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteBucketPolicy}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteBucketPolicy} and {@link
+ * MinioClient#deleteBucketPolicy}.
+ */
 public class DeleteBucketPolicyArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteBucketReplicationArgs.java
+++ b/api/src/main/java/io/minio/DeleteBucketReplicationArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteBucketReplication}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteBucketReplication} and {@link
+ * MinioClient#deleteBucketReplication}.
+ */
 public class DeleteBucketReplicationArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteBucketTagsArgs.java
+++ b/api/src/main/java/io/minio/DeleteBucketTagsArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteBucketTags}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteBucketTags} and {@link
+ * MinioClient#deleteBucketTags}.
+ */
 public class DeleteBucketTagsArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteObjectLockConfigurationArgs.java
+++ b/api/src/main/java/io/minio/DeleteObjectLockConfigurationArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteObjectLockConfiguration}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteObjectLockConfiguration} and {@link
+ * MinioClient#deleteObjectLockConfiguration}.
+ */
 public class DeleteObjectLockConfigurationArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteObjectTagsArgs.java
+++ b/api/src/main/java/io/minio/DeleteObjectTagsArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#deleteObjectTags}. */
+/**
+ * Argument class of {@link MinioAsyncClient#deleteObjectTags} and {@link
+ * MinioClient#deleteObjectTags}.
+ */
 public class DeleteObjectTagsArgs extends ObjectVersionArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DeleteObjectsResponse.java
+++ b/api/src/main/java/io/minio/DeleteObjectsResponse.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.DeleteResult;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#listObjectsV1}. */
+/** Response class of {@link S3Base#deleteObjectsAsync}. */
 public class DeleteObjectsResponse extends GenericResponse {
   private DeleteResult result;
 

--- a/api/src/main/java/io/minio/DisableObjectLegalHoldArgs.java
+++ b/api/src/main/java/io/minio/DisableObjectLegalHoldArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#disableObjectLegalHold}. */
+/**
+ * Argument class of {@link MinioAsyncClient#disableObjectLegalHold} and {@link
+ * MinioClient#disableObjectLegalHold}.
+ */
 public class DisableObjectLegalHoldArgs extends ObjectVersionArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/DownloadObjectArgs.java
+++ b/api/src/main/java/io/minio/DownloadObjectArgs.java
@@ -18,7 +18,9 @@ package io.minio;
 
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#downloadObject}. */
+/**
+ * Argument class of {@link MinioAsyncClient#downloadObject} and {@link MinioClient#downloadObject}.
+ */
 public class DownloadObjectArgs extends ObjectReadArgs {
   private String filename;
   private boolean overwrite;

--- a/api/src/main/java/io/minio/EnableObjectLegalHoldArgs.java
+++ b/api/src/main/java/io/minio/EnableObjectLegalHoldArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#enableObjectLegalHold}. */
+/**
+ * Argument class of {@link MinioAsyncClient#enableObjectLegalHold} and {@link
+ * MinioClient#enableObjectLegalHold}.
+ */
 public class EnableObjectLegalHoldArgs extends ObjectVersionArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketEncryptionArgs.java
+++ b/api/src/main/java/io/minio/GetBucketEncryptionArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketEncryption}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketEncryption} and {@link
+ * MinioClient#getBucketEncryption}.
+ */
 public class GetBucketEncryptionArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketLifecycleArgs.java
+++ b/api/src/main/java/io/minio/GetBucketLifecycleArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketLifecycle}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketLifecycle} and {@link
+ * MinioClient#getBucketLifecycle}.
+ */
 public class GetBucketLifecycleArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketNotificationArgs.java
+++ b/api/src/main/java/io/minio/GetBucketNotificationArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketNotification}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketNotification} and {@link
+ * MinioClient#getBucketNotification}.
+ */
 public class GetBucketNotificationArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketPolicyArgs.java
+++ b/api/src/main/java/io/minio/GetBucketPolicyArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketPolicy}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketPolicy} and {@link
+ * MinioClient#getBucketPolicy}.
+ */
 public class GetBucketPolicyArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketReplicationArgs.java
+++ b/api/src/main/java/io/minio/GetBucketReplicationArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketReplication}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketReplication} and {@link
+ * MinioClient#getBucketReplication}.
+ */
 public class GetBucketReplicationArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketTagsArgs.java
+++ b/api/src/main/java/io/minio/GetBucketTagsArgs.java
@@ -16,7 +16,9 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketTags}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketTags} and {@link MinioClient#getBucketTags}.
+ */
 public class GetBucketTagsArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetBucketVersioningArgs.java
+++ b/api/src/main/java/io/minio/GetBucketVersioningArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getBucketVersioning}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getBucketVersioning} and {@link
+ * MinioClient#getBucketVersioning}.
+ */
 public class GetBucketVersioningArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetObjectArgs.java
+++ b/api/src/main/java/io/minio/GetObjectArgs.java
@@ -16,7 +16,7 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getObject}. */
+/** Argument class of {@link MinioAsyncClient#getObject} and {@link MinioClient#getObject}. */
 public class GetObjectArgs extends ObjectConditionalReadArgs {
   protected GetObjectArgs() {}
 

--- a/api/src/main/java/io/minio/GetObjectLockConfigurationArgs.java
+++ b/api/src/main/java/io/minio/GetObjectLockConfigurationArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getObjectLockConfiguration}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getObjectLockConfiguration} and {@link
+ * MinioClient#getObjectLockConfiguration}.
+ */
 public class GetObjectLockConfigurationArgs extends BucketArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetObjectResponse.java
+++ b/api/src/main/java/io/minio/GetObjectResponse.java
@@ -20,7 +20,11 @@ import java.io.FilterInputStream;
 import java.io.InputStream;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#getObject}. */
+/**
+ * Response class of {@link MinioAsyncClient#getObject} and {@link MinioClient#getObject}. This
+ * class is {@link InputStream} interface compatible and it must be closed after use to release
+ * underneath network resources.
+ */
 public class GetObjectResponse extends FilterInputStream {
   private GenericResponse response;
 

--- a/api/src/main/java/io/minio/GetObjectRetentionArgs.java
+++ b/api/src/main/java/io/minio/GetObjectRetentionArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getObjectRetention}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getObjectRetention} and {@link
+ * MinioClient#getObjectRetention}.
+ */
 public class GetObjectRetentionArgs extends ObjectVersionArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetObjectTagsArgs.java
+++ b/api/src/main/java/io/minio/GetObjectTagsArgs.java
@@ -16,7 +16,9 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#getObjectTags}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getObjectTags} and {@link MinioClient#getObjectTags}.
+ */
 public class GetObjectTagsArgs extends ObjectVersionArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/GetPresignedObjectUrlArgs.java
+++ b/api/src/main/java/io/minio/GetPresignedObjectUrlArgs.java
@@ -20,7 +20,10 @@ import io.minio.http.Method;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-/** Argument class of {@link MinioClient#getPresignedObjectUrl}. */
+/**
+ * Argument class of {@link MinioAsyncClient#getPresignedObjectUrl} and {@link
+ * MinioClient#getPresignedObjectUrl}.
+ */
 public class GetPresignedObjectUrlArgs extends ObjectVersionArgs {
   // default expiration for a presigned URL is 7 days in seconds
   public static final int DEFAULT_EXPIRY_TIME = (int) TimeUnit.DAYS.toSeconds(7);

--- a/api/src/main/java/io/minio/IsObjectLegalHoldEnabledArgs.java
+++ b/api/src/main/java/io/minio/IsObjectLegalHoldEnabledArgs.java
@@ -16,7 +16,10 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#isObjectLegalHoldEnabled}. */
+/**
+ * Argument class of {@link MinioAsyncClient#isObjectLegalHoldEnabled} and {@link
+ * MinioClient#isObjectLegalHoldEnabled}.
+ */
 public class IsObjectLegalHoldEnabledArgs extends ObjectVersionArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/ListBucketsArgs.java
+++ b/api/src/main/java/io/minio/ListBucketsArgs.java
@@ -16,7 +16,7 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#listBuckets}. */
+/** Argument class of {@link MinioAsyncClient#listBuckets} and {@link MinioClient#listBuckets}. */
 public class ListBucketsArgs extends BaseArgs {
   public static Builder builder() {
     return new Builder();

--- a/api/src/main/java/io/minio/ListMultipartUploadsResponse.java
+++ b/api/src/main/java/io/minio/ListMultipartUploadsResponse.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListMultipartUploadsResult;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#listMultipartUploads}. */
+/** Response class of {@link S3Base#listMultipartUploadsAsync}. */
 public class ListMultipartUploadsResponse extends GenericResponse {
   private ListMultipartUploadsResult result;
 

--- a/api/src/main/java/io/minio/ListObjectVersionsResponse.java
+++ b/api/src/main/java/io/minio/ListObjectVersionsResponse.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListVersionsResult;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#listObjectVersions}. */
+/** Response class of {@link S3Base#listObjectVersionsAsync}. */
 public class ListObjectVersionsResponse extends GenericResponse {
   private ListVersionsResult result;
 

--- a/api/src/main/java/io/minio/ListObjectsArgs.java
+++ b/api/src/main/java/io/minio/ListObjectsArgs.java
@@ -18,7 +18,7 @@ package io.minio;
 
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#listObjects}. */
+/** Argument class of {@link MinioAsyncClient#listObjects} and {@link MinioClient#listObjects}. */
 public class ListObjectsArgs extends BucketArgs {
   private String delimiter = "";
   private boolean useUrlEncodingType = true;

--- a/api/src/main/java/io/minio/ListObjectsV1Response.java
+++ b/api/src/main/java/io/minio/ListObjectsV1Response.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListBucketResultV1;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#listObjectsV1}. */
+/** Response class of {@link S3Base#listObjectsV1}. */
 public class ListObjectsV1Response extends GenericResponse {
   private ListBucketResultV1 result;
 

--- a/api/src/main/java/io/minio/ListObjectsV1Response.java
+++ b/api/src/main/java/io/minio/ListObjectsV1Response.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListBucketResultV1;
 import okhttp3.Headers;
 
-/** Response class of {@link S3Base#listObjectsV1}. */
+/** Response class of {@link S3Base#listObjectsV1Async}. */
 public class ListObjectsV1Response extends GenericResponse {
   private ListBucketResultV1 result;
 

--- a/api/src/main/java/io/minio/ListObjectsV2Response.java
+++ b/api/src/main/java/io/minio/ListObjectsV2Response.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListBucketResultV2;
 import okhttp3.Headers;
 
-/** Response class of {@link S3Base#listObjectsV2}. */
+/** Response class of {@link S3Base#listObjectsV2Async}. */
 public class ListObjectsV2Response extends GenericResponse {
   private ListBucketResultV2 result;
 

--- a/api/src/main/java/io/minio/ListObjectsV2Response.java
+++ b/api/src/main/java/io/minio/ListObjectsV2Response.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListBucketResultV2;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#listObjectsV2}. */
+/** Response class of {@link S3Base#listObjectsV2}. */
 public class ListObjectsV2Response extends GenericResponse {
   private ListBucketResultV2 result;
 

--- a/api/src/main/java/io/minio/ListPartsResponse.java
+++ b/api/src/main/java/io/minio/ListPartsResponse.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.ListPartsResult;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#listParts}. */
+/** Response class of {@link S3Base#listPartsAsync}. */
 public class ListPartsResponse extends GenericResponse {
   private ListPartsResult result;
 

--- a/api/src/main/java/io/minio/ListenBucketNotificationArgs.java
+++ b/api/src/main/java/io/minio/ListenBucketNotificationArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import java.util.Arrays;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#listenBucketNotification}. */
+/**
+ * Argument class of {@link MinioClient#listenBucketNotification} and {@link
+ * MinioClient#listenBucketNotification}.
+ */
 public class ListenBucketNotificationArgs extends BucketArgs {
   private String prefix;
   private String suffix;

--- a/api/src/main/java/io/minio/ListenBucketNotificationArgs.java
+++ b/api/src/main/java/io/minio/ListenBucketNotificationArgs.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Argument class of {@link MinioClient#listenBucketNotification} and {@link
+ * Argument class of {@link MinioAsyncClient#listenBucketNotification} and {@link
  * MinioClient#listenBucketNotification}.
  */
 public class ListenBucketNotificationArgs extends BucketArgs {

--- a/api/src/main/java/io/minio/MakeBucketArgs.java
+++ b/api/src/main/java/io/minio/MakeBucketArgs.java
@@ -18,7 +18,7 @@ package io.minio;
 
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#makeBucket}. */
+/** Argument class of {@link MinioAsyncClient#makeBucket} and {@link MinioClient#makeBucket}. */
 public class MakeBucketArgs extends BucketArgs {
   private boolean objectLock;
 

--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -1,0 +1,3326 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2022 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.io.ByteStreams;
+import io.minio.credentials.Credentials;
+import io.minio.credentials.Provider;
+import io.minio.credentials.StaticProvider;
+import io.minio.errors.BucketPolicyTooLargeException;
+import io.minio.errors.ErrorResponseException;
+import io.minio.errors.InsufficientDataException;
+import io.minio.errors.InternalException;
+import io.minio.errors.InvalidResponseException;
+import io.minio.errors.ServerException;
+import io.minio.errors.XmlParserException;
+import io.minio.http.HttpUtils;
+import io.minio.http.Method;
+import io.minio.messages.Bucket;
+import io.minio.messages.CopyObjectResult;
+import io.minio.messages.CreateBucketConfiguration;
+import io.minio.messages.DeleteError;
+import io.minio.messages.DeleteObject;
+import io.minio.messages.Item;
+import io.minio.messages.LegalHold;
+import io.minio.messages.LifecycleConfiguration;
+import io.minio.messages.ListAllMyBucketsResult;
+import io.minio.messages.NotificationConfiguration;
+import io.minio.messages.NotificationRecords;
+import io.minio.messages.ObjectLockConfiguration;
+import io.minio.messages.Part;
+import io.minio.messages.ReplicationConfiguration;
+import io.minio.messages.Retention;
+import io.minio.messages.SelectObjectContentRequest;
+import io.minio.messages.SseConfiguration;
+import io.minio.messages.Tags;
+import io.minio.messages.VersioningConfiguration;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.xerial.snappy.SnappyFramedOutputStream;
+
+/**
+ * Simple Storage Service (aka S3) client to perform bucket and object operations asynchronously.
+ *
+ * <h2>Bucket operations</h2>
+ *
+ * <ul>
+ *   <li>Create, list and delete buckets.
+ *   <li>Put, get and delete bucket lifecycle configuration.
+ *   <li>Put, get and delete bucket policy configuration.
+ *   <li>Put, get and delete bucket encryption configuration.
+ *   <li>Put and get bucket default retention configuration.
+ *   <li>Put and get bucket notification configuration.
+ *   <li>Enable and disable bucket versioning.
+ * </ul>
+ *
+ * <h2>Object operations</h2>
+ *
+ * <ul>
+ *   <li>Put, get, delete and list objects.
+ *   <li>Create objects by combining existing objects.
+ *   <li>Put and get object retention and legal hold.
+ *   <li>Filter object content by SQL statement.
+ * </ul>
+ *
+ * <p>If access/secret keys are provided, all S3 operation requests are signed using AWS Signature
+ * Version 4; else they are performed anonymously.
+ *
+ * <p>Examples on using this library are available <a
+ * href="https://github.com/minio/minio-java/tree/master/src/test/java/io/minio/examples">here</a>.
+ *
+ * <p>Use {@code MinioAsyncClient.builder()} to create S3 client.
+ *
+ * <pre>{@code
+ * // Create client with anonymous access.
+ * MinioAsyncClient minioAsyncClient =
+ *     MinioAsyncClient.builder().endpoint("https://play.min.io").build();
+ *
+ * // Create client with credentials.
+ * MinioAsyncClient minioAsyncClient =
+ *     MinioAsyncClient.builder()
+ *         .endpoint("https://play.min.io")
+ *         .credentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+ *         .build();
+ * }</pre>
+ */
+public class MinioAsyncClient extends S3Base {
+  private MinioAsyncClient(
+      HttpUrl baseUrl,
+      String region,
+      boolean isAwsHost,
+      boolean isAcceleratedHost,
+      boolean isDualStackHost,
+      boolean useVirtualStyle,
+      Provider provider,
+      OkHttpClient httpClient) {
+    super(
+        baseUrl,
+        region,
+        isAwsHost,
+        isAcceleratedHost,
+        isDualStackHost,
+        useVirtualStyle,
+        provider,
+        httpClient);
+  }
+
+  protected MinioAsyncClient(MinioAsyncClient client) {
+    super(client);
+  }
+
+  /**
+   * Gets information of an object asynchronously.
+   *
+   * <pre>Example:{@code
+   * // Get information of an object.
+   * CompletableFuture<StatObjectResponse> future =
+   *     minioAsyncClient.statObject(
+   *         StatObjectArgs.builder().bucket("my-bucketname").object("my-objectname").build());
+   *
+   * // Get information of SSE-C encrypted object.
+   * CompletableFuture<StatObjectResponse> future =
+   *     minioAsyncClient.statObject(
+   *         StatObjectArgs.builder()
+   *             .bucket("my-bucketname")
+   *             .object("my-objectname")
+   *             .ssec(ssec)
+   *             .build());
+   *
+   * // Get information of a versioned object.
+   * CompletableFuture<StatObjectResponse> future =
+   *     minioAsyncClient.statObject(
+   *         StatObjectArgs.builder()
+   *             .bucket("my-bucketname")
+   *             .object("my-objectname")
+   *             .versionId("version-id")
+   *             .build());
+   *
+   * // Get information of a SSE-C encrypted versioned object.
+   * CompletableFuture<StatObjectResponse> future =
+   *     minioAsyncClient.statObject(
+   *         StatObjectArgs.builder()
+   *             .bucket("my-bucketname")
+   *             .object("my-objectname")
+   *             .versionId("version-id")
+   *             .ssec(ssec)
+   *             .build());
+   * }</pre>
+   *
+   * @param args {@link StatObjectArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link StatObjectResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   * @see StatObjectResponse
+   */
+  public CompletableFuture<StatObjectResponse> statObject(StatObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return super.statObjectAsync(args);
+  }
+
+  /**
+   * Gets data from offset to length of a SSE-C encrypted object asynchronously.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<GetObjectResponse> future = minioAsyncClient.getObject(
+   *     GetObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .offset(offset)
+   *         .length(len)
+   *         .ssec(ssec)
+   *         .build()
+   * }</pre>
+   *
+   * @param args Object of {@link GetObjectArgs}
+   * @return {@link CompletableFuture}&lt;{@link GetObjectResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   * @see GetObjectResponse
+   */
+  public CompletableFuture<GetObjectResponse> getObject(GetObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    args.validateSsec(this.baseUrl);
+    return executeGetAsync(
+            args,
+            args.getHeaders(),
+            (args.versionId() != null) ? newMultimap("versionId", args.versionId()) : null)
+        .thenApply(
+            response -> {
+              return new GetObjectResponse(
+                  response.headers(),
+                  args.bucket(),
+                  args.region(),
+                  args.object(),
+                  response.body().byteStream());
+            });
+  }
+
+  private void downloadObject(
+      String filename,
+      boolean overwrite,
+      StatObjectResponse statObjectResponse,
+      GetObjectResponse getObjectResponse)
+      throws IOException {
+    OutputStream os = null;
+    try {
+      Path filePath = Paths.get(filename);
+      String tempFilename =
+          filename + "." + S3Escaper.encode(statObjectResponse.etag()) + ".part.minio";
+      Path tempFilePath = Paths.get(tempFilename);
+      if (Files.exists(tempFilePath)) Files.delete(tempFilePath);
+      os = Files.newOutputStream(tempFilePath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+      long bytesWritten = ByteStreams.copy(getObjectResponse, os);
+      if (bytesWritten != statObjectResponse.size()) {
+        throw new IOException(
+            tempFilename
+                + ": unexpected data written.  expected = "
+                + statObjectResponse.size()
+                + ", written = "
+                + bytesWritten);
+      }
+
+      if (overwrite) {
+        Files.move(tempFilePath, filePath, StandardCopyOption.REPLACE_EXISTING);
+      } else {
+        Files.move(tempFilePath, filePath);
+      }
+    } finally {
+      getObjectResponse.close();
+      if (os != null) os.close();
+    }
+  }
+
+  /**
+   * Downloads data of a SSE-C encrypted object to file.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.downloadObject(
+   *     DownloadObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .ssec(ssec)
+   *         .filename("my-filename")
+   *         .build());
+   * }</pre>
+   *
+   * @param args Object of {@link DownloadObjectArgs}
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> downloadObject(DownloadObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    String filename = args.filename();
+    Path filePath = Paths.get(filename);
+    if (!args.overwrite() && Files.exists(filePath)) {
+      throw new IllegalArgumentException("Destination file " + filename + " already exists");
+    }
+
+    return statObjectAsync(new StatObjectArgs(args))
+        .thenCombine(
+            getObject(new GetObjectArgs(args)),
+            (statObjectResponse, getObjectResponse) -> {
+              try {
+                downloadObject(filename, args.overwrite(), statObjectResponse, getObjectResponse);
+                return null;
+              } catch (IOException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenAccept(nullValue -> {});
+  }
+
+  /**
+   * Creates an object by server-side copying data from another object.
+   *
+   * <pre>Example:{@code
+   * // Create object "my-objectname" in bucket "my-bucketname" by copying from object
+   * // "my-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-objectname")
+   *                 .build())
+   *         .build());
+   *
+   * // Create object "my-objectname" in bucket "my-bucketname" by copying from object
+   * // "my-source-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-source-objectname")
+   *                 .build())
+   *         .build());
+   *
+   * // Create object "my-objectname" in bucket "my-bucketname" with SSE-KMS server-side
+   * // encryption by copying from object "my-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-objectname")
+   *                 .build())
+   *         .sse(sseKms) // Replace with actual key.
+   *         .build());
+   *
+   * // Create object "my-objectname" in bucket "my-bucketname" with SSE-S3 server-side
+   * // encryption by copying from object "my-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-objectname")
+   *                 .build())
+   *         .sse(sseS3) // Replace with actual key.
+   *         .build());
+   *
+   * // Create object "my-objectname" in bucket "my-bucketname" with SSE-C server-side encryption
+   * // by copying from object "my-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-objectname")
+   *                 .build())
+   *         .sse(ssec) // Replace with actual key.
+   *         .build());
+   *
+   * // Create object "my-objectname" in bucket "my-bucketname" by copying from SSE-C encrypted
+   * // object "my-source-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-source-objectname")
+   *                 .ssec(ssec) // Replace with actual key.
+   *                 .build())
+   *         .build());
+   *
+   * // Create object "my-objectname" in bucket "my-bucketname" with custom headers conditionally
+   * // by copying from object "my-objectname" in bucket "my-source-bucketname".
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.copyObject(
+   *     CopyObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .source(
+   *             CopySource.builder()
+   *                 .bucket("my-source-bucketname")
+   *                 .object("my-objectname")
+   *                 .matchETag(etag) // Replace with actual etag.
+   *                 .build())
+   *         .headers(headers) // Replace with actual headers.
+   *         .build());
+   * }</pre>
+   *
+   * @param args {@link CopyObjectArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ObjectWriteResponse> copyObject(CopyObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    args.validateSse(this.baseUrl);
+
+    return CompletableFuture.supplyAsync(
+            () -> args.source().offset() != null && args.source().length() != null)
+        .thenCompose(
+            condition -> {
+              if (condition) {
+                try {
+                  return statObjectAsync(new StatObjectArgs((ObjectReadArgs) args.source()));
+                } catch (InsufficientDataException
+                    | InternalException
+                    | InvalidKeyException
+                    | IOException
+                    | NoSuchAlgorithmException
+                    | XmlParserException e) {
+                  throw new CompletionException(e);
+                }
+              }
+              return CompletableFuture.completedFuture(null);
+            })
+        .thenApply(stat -> (stat == null) ? (long) -1 : stat.size())
+        .thenCompose(
+            size -> {
+              if (args.source().offset() != null
+                  || args.source().length() != null
+                  || size > ObjectWriteArgs.MAX_PART_SIZE) {
+                if (args.metadataDirective() != null
+                    && args.metadataDirective() == Directive.COPY) {
+                  throw new IllegalArgumentException(
+                      "COPY metadata directive is not applicable to source object size greater than"
+                          + " 5 GiB");
+                }
+                if (args.taggingDirective() != null && args.taggingDirective() == Directive.COPY) {
+                  throw new IllegalArgumentException(
+                      "COPY tagging directive is not applicable to source object size greater than"
+                          + " 5 GiB");
+                }
+
+                try {
+                  return composeObject(new ComposeObjectArgs(args));
+                } catch (InsufficientDataException
+                    | InternalException
+                    | InvalidKeyException
+                    | IOException
+                    | NoSuchAlgorithmException
+                    | XmlParserException e) {
+                  throw new CompletionException(e);
+                }
+              }
+              return CompletableFuture.completedFuture(null);
+            })
+        .thenCompose(
+            objectWriteResponse -> {
+              if (objectWriteResponse != null) {
+                return CompletableFuture.completedFuture(objectWriteResponse);
+              }
+
+              Multimap<String, String> headers = args.genHeaders();
+
+              if (args.metadataDirective() != null) {
+                headers.put("x-amz-metadata-directive", args.metadataDirective().name());
+              }
+
+              if (args.taggingDirective() != null) {
+                headers.put("x-amz-tagging-directive", args.taggingDirective().name());
+              }
+
+              headers.putAll(args.source().genCopyHeaders());
+
+              try {
+                return executePutAsync(args, headers, null, null, 0)
+                    .thenApply(
+                        response -> {
+                          try {
+                            CopyObjectResult result =
+                                Xml.unmarshal(CopyObjectResult.class, response.body().charStream());
+                            return new ObjectWriteResponse(
+                                response.headers(),
+                                args.bucket(),
+                                args.region(),
+                                args.object(),
+                                result.etag(),
+                                response.header("x-amz-version-id"));
+                          } catch (XmlParserException e) {
+                            throw new CompletionException(e);
+                          } finally {
+                            response.close();
+                          }
+                        });
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            });
+  }
+
+  private CompletableFuture<Part[]> uploadPartCopy(
+      String bucketName,
+      String region,
+      String objectName,
+      String uploadId,
+      int partNumber,
+      Multimap<String, String> headers,
+      Part[] parts)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return uploadPartCopyAsync(bucketName, region, objectName, uploadId, partNumber, headers, null)
+        .thenApply(
+            uploadPartCopyResponse -> {
+              parts[partNumber - 1] = new Part(partNumber, uploadPartCopyResponse.result().etag());
+              return parts;
+            });
+  }
+
+  /**
+   * Creates an object by combining data from different source objects using server-side copy.
+   *
+   * <pre>Example:{@code
+   * List<ComposeSource> sourceObjectList = new ArrayList<ComposeSource>();
+   *
+   * sourceObjectList.add(
+   *    ComposeSource.builder().bucket("my-job-bucket").object("my-objectname-part-one").build());
+   * sourceObjectList.add(
+   *    ComposeSource.builder().bucket("my-job-bucket").object("my-objectname-part-two").build());
+   * sourceObjectList.add(
+   *    ComposeSource.builder().bucket("my-job-bucket").object("my-objectname-part-three").build());
+   *
+   * // Create my-bucketname/my-objectname by combining source object list.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.composeObject(
+   *    ComposeObjectArgs.builder()
+   *        .bucket("my-bucketname")
+   *        .object("my-objectname")
+   *        .sources(sourceObjectList)
+   *        .build());
+   *
+   * // Create my-bucketname/my-objectname with user metadata by combining source object
+   * // list.
+   * Map<String, String> userMetadata = new HashMap<>();
+   * userMetadata.put("My-Project", "Project One");
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.composeObject(
+   *     ComposeObjectArgs.builder()
+   *        .bucket("my-bucketname")
+   *        .object("my-objectname")
+   *        .sources(sourceObjectList)
+   *        .userMetadata(userMetadata)
+   *        .build());
+   *
+   * // Create my-bucketname/my-objectname with user metadata and server-side encryption
+   * // by combining source object list.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.composeObject(
+   *   ComposeObjectArgs.builder()
+   *        .bucket("my-bucketname")
+   *        .object("my-objectname")
+   *        .sources(sourceObjectList)
+   *        .userMetadata(userMetadata)
+   *        .ssec(sse)
+   *        .build());
+   * }</pre>
+   *
+   * @param args {@link ComposeObjectArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ObjectWriteResponse> composeObject(ComposeObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    args.validateSse(this.baseUrl);
+    List<ComposeSource> sources = args.sources();
+    int[] partCount = {0};
+    String[] uploadIdCopy = {null};
+
+    return calculatePartCountAsync(sources)
+        .thenApply(
+            count -> {
+              partCount[0] = count;
+              return (count == 1
+                  && args.sources().get(0).offset() == null
+                  && args.sources().get(0).length() == null);
+            })
+        .thenCompose(
+            copyObjectFlag -> {
+              if (copyObjectFlag) {
+                try {
+                  return copyObject(new CopyObjectArgs(args));
+                } catch (InsufficientDataException
+                    | InternalException
+                    | InvalidKeyException
+                    | IOException
+                    | NoSuchAlgorithmException
+                    | XmlParserException e) {
+                  throw new CompletionException(e);
+                }
+              }
+              return CompletableFuture.completedFuture(null);
+            })
+        .thenCompose(
+            objectWriteResponse -> {
+              if (objectWriteResponse != null) {
+                return CompletableFuture.completedFuture(objectWriteResponse);
+              }
+
+              CompletableFuture<ObjectWriteResponse> completableFuture =
+                  CompletableFuture.supplyAsync(
+                          () -> {
+                            Multimap<String, String> headers = newMultimap(args.extraHeaders());
+                            headers.putAll(args.genHeaders());
+                            return headers;
+                          })
+                      .thenCompose(
+                          headers -> {
+                            try {
+                              return createMultipartUploadAsync(
+                                  args.bucket(),
+                                  args.region(),
+                                  args.object(),
+                                  headers,
+                                  args.extraQueryParams());
+                            } catch (InsufficientDataException
+                                | InternalException
+                                | InvalidKeyException
+                                | IOException
+                                | NoSuchAlgorithmException
+                                | XmlParserException e) {
+                              throw new CompletionException(e);
+                            }
+                          })
+                      .thenApply(
+                          createMultipartUploadResponse -> {
+                            String uploadId = createMultipartUploadResponse.result().uploadId();
+                            uploadIdCopy[0] = uploadId;
+                            return uploadId;
+                          })
+                      .thenCompose(
+                          uploadId -> {
+                            Multimap<String, String> ssecHeaders = HashMultimap.create();
+                            if (args.sse() != null
+                                && args.sse() instanceof ServerSideEncryptionCustomerKey) {
+                              ssecHeaders.putAll(newMultimap(args.sse().headers()));
+                            }
+
+                            int partNumber = 0;
+                            CompletableFuture<Part[]> future =
+                                CompletableFuture.supplyAsync(
+                                    () -> {
+                                      return new Part[partCount[0]];
+                                    });
+                            for (ComposeSource src : sources) {
+                              long size = 0;
+                              try {
+                                size = src.objectSize();
+                              } catch (InternalException e) {
+                                throw new CompletionException(e);
+                              }
+                              if (src.length() != null) {
+                                size = src.length();
+                              } else if (src.offset() != null) {
+                                size -= src.offset();
+                              }
+                              long offset = 0;
+                              if (src.offset() != null) offset = src.offset();
+
+                              final Multimap<String, String> headers;
+                              try {
+                                headers = newMultimap(src.headers());
+                              } catch (InternalException e) {
+                                throw new CompletionException(e);
+                              }
+                              headers.putAll(ssecHeaders);
+
+                              if (size <= ObjectWriteArgs.MAX_PART_SIZE) {
+                                partNumber++;
+                                if (src.length() != null) {
+                                  headers.put(
+                                      "x-amz-copy-source-range",
+                                      "bytes=" + offset + "-" + (offset + src.length() - 1));
+                                } else if (src.offset() != null) {
+                                  headers.put(
+                                      "x-amz-copy-source-range",
+                                      "bytes=" + offset + "-" + (offset + size - 1));
+                                }
+
+                                final int partNum = partNumber;
+                                future =
+                                    future.thenCompose(
+                                        parts -> {
+                                          try {
+                                            return uploadPartCopy(
+                                                args.bucket(),
+                                                args.region(),
+                                                args.object(),
+                                                uploadId,
+                                                partNum,
+                                                headers,
+                                                parts);
+                                          } catch (InsufficientDataException
+                                              | InternalException
+                                              | InvalidKeyException
+                                              | IOException
+                                              | NoSuchAlgorithmException
+                                              | XmlParserException e) {
+                                            throw new CompletionException(e);
+                                          }
+                                        });
+                                continue;
+                              }
+
+                              while (size > 0) {
+                                partNumber++;
+
+                                long startBytes = offset;
+                                long endBytes = startBytes + ObjectWriteArgs.MAX_PART_SIZE;
+                                if (size < ObjectWriteArgs.MAX_PART_SIZE)
+                                  endBytes = startBytes + size;
+
+                                Multimap<String, String> headersCopy = newMultimap(headers);
+                                headersCopy.put(
+                                    "x-amz-copy-source-range",
+                                    "bytes=" + startBytes + "-" + endBytes);
+
+                                final int partNum = partNumber;
+                                future =
+                                    future.thenCompose(
+                                        parts -> {
+                                          try {
+                                            return uploadPartCopy(
+                                                args.bucket(),
+                                                args.region(),
+                                                args.object(),
+                                                uploadId,
+                                                partNum,
+                                                headersCopy,
+                                                parts);
+                                          } catch (InsufficientDataException
+                                              | InternalException
+                                              | InvalidKeyException
+                                              | IOException
+                                              | NoSuchAlgorithmException
+                                              | XmlParserException e) {
+                                            throw new CompletionException(e);
+                                          }
+                                        });
+                                offset = startBytes;
+                                size -= (endBytes - startBytes);
+                              }
+                            }
+
+                            return future;
+                          })
+                      .thenCompose(
+                          parts -> {
+                            try {
+                              return completeMultipartUploadAsync(
+                                  args.bucket(),
+                                  args.region(),
+                                  args.object(),
+                                  uploadIdCopy[0],
+                                  parts,
+                                  null,
+                                  null);
+                            } catch (InsufficientDataException
+                                | InternalException
+                                | InvalidKeyException
+                                | IOException
+                                | NoSuchAlgorithmException
+                                | XmlParserException e) {
+                              throw new CompletionException(e);
+                            }
+                          });
+
+              completableFuture.exceptionally(
+                  e -> {
+                    if (uploadIdCopy[0] != null) {
+                      try {
+                        abortMultipartUploadAsync(
+                                args.bucket(),
+                                args.region(),
+                                args.object(),
+                                uploadIdCopy[0],
+                                null,
+                                null)
+                            .get();
+                      } catch (InsufficientDataException
+                          | InternalException
+                          | InvalidKeyException
+                          | IOException
+                          | NoSuchAlgorithmException
+                          | XmlParserException
+                          | InterruptedException
+                          | ExecutionException ex) {
+                        throw new CompletionException(ex);
+                      }
+                    }
+                    throw new CompletionException(e);
+                  });
+              return completableFuture;
+            });
+  }
+
+  /**
+   * Gets presigned URL of an object for HTTP method, expiry time and custom request parameters.
+   *
+   * <pre>Example:{@code
+   * // Get presigned URL string to delete 'my-objectname' in 'my-bucketname' and its life time
+   * // is one day.
+   * String url =
+   *    minioAsyncClient.getPresignedObjectUrl(
+   *        GetPresignedObjectUrlArgs.builder()
+   *            .method(Method.DELETE)
+   *            .bucket("my-bucketname")
+   *            .object("my-objectname")
+   *            .expiry(24 * 60 * 60)
+   *            .build());
+   * System.out.println(url);
+   *
+   * // Get presigned URL string to upload 'my-objectname' in 'my-bucketname'
+   * // with response-content-type as application/json and life time as one day.
+   * Map<String, String> reqParams = new HashMap<String, String>();
+   * reqParams.put("response-content-type", "application/json");
+   *
+   * String url =
+   *    minioAsyncClient.getPresignedObjectUrl(
+   *        GetPresignedObjectUrlArgs.builder()
+   *            .method(Method.PUT)
+   *            .bucket("my-bucketname")
+   *            .object("my-objectname")
+   *            .expiry(1, TimeUnit.DAYS)
+   *            .extraQueryParams(reqParams)
+   *            .build());
+   * System.out.println(url);
+   *
+   * // Get presigned URL string to download 'my-objectname' in 'my-bucketname' and its life time
+   * // is 2 hours.
+   * String url =
+   *    minioAsyncClient.getPresignedObjectUrl(
+   *        GetPresignedObjectUrlArgs.builder()
+   *            .method(Method.GET)
+   *            .bucket("my-bucketname")
+   *            .object("my-objectname")
+   *            .expiry(2, TimeUnit.HOURS)
+   *            .build());
+   * System.out.println(url);
+   * }</pre>
+   *
+   * @param args {@link GetPresignedObjectUrlArgs} object.
+   * @return String - URL string.
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   * @throws ServerException
+   */
+  public String getPresignedObjectUrl(GetPresignedObjectUrlArgs args)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          XmlParserException, ServerException {
+    checkArgs(args);
+
+    byte[] body =
+        (args.method() == Method.PUT || args.method() == Method.POST) ? HttpUtils.EMPTY_BODY : null;
+
+    Multimap<String, String> queryParams = newMultimap(args.extraQueryParams());
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+
+    String region = null;
+    try {
+      region = getRegionAsync(args.bucket(), args.region()).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+    }
+
+    if (provider == null) {
+      HttpUrl url = buildUrl(args.method(), args.bucket(), args.object(), region, queryParams);
+      return url.toString();
+    }
+
+    Credentials creds = provider.fetch();
+    if (creds.sessionToken() != null) queryParams.put("X-Amz-Security-Token", creds.sessionToken());
+    HttpUrl url = buildUrl(args.method(), args.bucket(), args.object(), region, queryParams);
+    Request request =
+        createRequest(
+            url,
+            args.method(),
+            args.extraHeaders() == null ? null : httpHeaders(args.extraHeaders()),
+            body,
+            0,
+            creds);
+    url = Signer.presignV4(request, region, creds.accessKey(), creds.secretKey(), args.expiry());
+    return url.toString();
+  }
+
+  /**
+   * Gets form-data of {@link PostPolicy} of an object to upload its data using POST method.
+   *
+   * <pre>Example:{@code
+   * // Create new post policy for 'my-bucketname' with 7 days expiry from now.
+   * PostPolicy policy = new PostPolicy("my-bucketname", ZonedDateTime.now().plusDays(7));
+   *
+   * // Add condition that 'key' (object name) equals to 'my-objectname'.
+   * policy.addEqualsCondition("key", "my-objectname");
+   *
+   * // Add condition that 'Content-Type' starts with 'image/'.
+   * policy.addStartsWithCondition("Content-Type", "image/");
+   *
+   * // Add condition that 'content-length-range' is between 64kiB to 10MiB.
+   * policy.addContentLengthRangeCondition(64 * 1024, 10 * 1024 * 1024);
+   *
+   * Map<String, String> formData = minioAsyncClient.getPresignedPostFormData(policy);
+   *
+   * // Upload an image using POST object with form-data.
+   * MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+   * multipartBuilder.setType(MultipartBody.FORM);
+   * for (Map.Entry<String, String> entry : formData.entrySet()) {
+   *   multipartBuilder.addFormDataPart(entry.getKey(), entry.getValue());
+   * }
+   * multipartBuilder.addFormDataPart("key", "my-objectname");
+   * multipartBuilder.addFormDataPart("Content-Type", "image/png");
+   *
+   * // "file" must be added at last.
+   * multipartBuilder.addFormDataPart(
+   *     "file", "my-objectname", RequestBody.create(new File("Pictures/avatar.png"), null));
+   *
+   * Request request =
+   *     new Request.Builder()
+   *         .url("https://play.min.io/my-bucketname")
+   *         .post(multipartBuilder.build())
+   *         .build();
+   * OkHttpClient httpClient = new OkHttpClient().newBuilder().build();
+   * Response response = httpClient.newCall(request).execute();
+   * if (response.isSuccessful()) {
+   *   System.out.println("Pictures/avatar.png is uploaded successfully using POST object");
+   * } else {
+   *   System.out.println("Failed to upload Pictures/avatar.png");
+   * }
+   * }</pre>
+   *
+   * @param policy Post policy of an object.
+   * @return {@code Map<String, String>} - Contains form-data to upload an object using POST method.
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   * @see PostPolicy
+   */
+  public Map<String, String> getPresignedPostFormData(PostPolicy policy)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          ServerException, XmlParserException {
+    if (provider == null) {
+      throw new IllegalArgumentException(
+          "Anonymous access does not require presigned post form-data");
+    }
+
+    String region = null;
+    try {
+      region = getRegionAsync(policy.bucket(), null).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+    }
+    return policy.formData(provider.fetch(), region);
+  }
+
+  /**
+   * Removes an object.
+   *
+   * <pre>Example:{@code
+   * // Remove object.
+   * CompletableFuture<Void> future = minioAsyncClient.removeObject(
+   *     RemoveObjectArgs.builder().bucket("my-bucketname").object("my-objectname").build());
+   *
+   * // Remove versioned object.
+   * CompletableFuture<Void> future = minioAsyncClient.removeObject(
+   *     RemoveObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-versioned-objectname")
+   *         .versionId("my-versionid")
+   *         .build());
+   *
+   * // Remove versioned object bypassing Governance mode.
+   * CompletableFuture<Void> future = minioAsyncClient.removeObject(
+   *     RemoveObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-versioned-objectname")
+   *         .versionId("my-versionid")
+   *         .bypassRetentionMode(true)
+   *         .build());
+   * }</pre>
+   *
+   * @param args {@link RemoveObjectArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> removeObject(RemoveObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(
+            args,
+            args.bypassGovernanceMode()
+                ? newMultimap("x-amz-bypass-governance-retention", "true")
+                : null,
+            (args.versionId() != null) ? newMultimap("versionId", args.versionId()) : null)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Removes multiple objects lazily. Its required to iterate the returned Iterable to perform
+   * removal.
+   *
+   * <pre>Example:{@code
+   * List<DeleteObject> objects = new LinkedList<>();
+   * objects.add(new DeleteObject("my-objectname1"));
+   * objects.add(new DeleteObject("my-objectname2"));
+   * objects.add(new DeleteObject("my-objectname3"));
+   * Iterable<Result<DeleteError>> results =
+   *     minioAsyncClient.removeObjects(
+   *         RemoveObjectsArgs.builder().bucket("my-bucketname").objects(objects).build());
+   * for (Result<DeleteError> result : results) {
+   *   DeleteError error = errorResult.get();
+   *   System.out.println(
+   *       "Error in deleting object " + error.objectName() + "; " + error.message());
+   * }
+   * }</pre>
+   *
+   * @param args {@link RemoveObjectsArgs} object.
+   * @return {@code Iterable<Result<DeleteError>>} - Lazy iterator contains object removal status.
+   */
+  public Iterable<Result<DeleteError>> removeObjects(RemoveObjectsArgs args) {
+    checkArgs(args);
+
+    return new Iterable<Result<DeleteError>>() {
+      @Override
+      public Iterator<Result<DeleteError>> iterator() {
+        return new Iterator<Result<DeleteError>>() {
+          private Result<DeleteError> error = null;
+          private Iterator<DeleteError> errorIterator = null;
+          private boolean completed = false;
+          private Iterator<DeleteObject> objectIter = args.objects().iterator();
+
+          private void setError() {
+            error = null;
+            while (errorIterator.hasNext()) {
+              DeleteError deleteError = errorIterator.next();
+              if (!"NoSuchVersion".equals(deleteError.code())) {
+                error = new Result<>(deleteError);
+                break;
+              }
+            }
+          }
+
+          private synchronized void populate() {
+            if (completed) {
+              return;
+            }
+
+            try {
+              List<DeleteObject> objectList = new LinkedList<>();
+              while (objectIter.hasNext() && objectList.size() < 1000) {
+                objectList.add(objectIter.next());
+              }
+
+              completed = objectList.isEmpty();
+              if (completed) return;
+              DeleteObjectsResponse response = null;
+              try {
+                response =
+                    deleteObjectsAsync(
+                            args.bucket(),
+                            args.region(),
+                            objectList,
+                            true,
+                            args.bypassGovernanceMode(),
+                            args.extraHeaders(),
+                            args.extraQueryParams())
+                        .get();
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              } catch (ExecutionException e) {
+                throwEncapsulatedException(e);
+              }
+              if (!response.result().errorList().isEmpty()) {
+                errorIterator = response.result().errorList().iterator();
+                setError();
+                completed = true;
+              }
+            } catch (ErrorResponseException
+                | InsufficientDataException
+                | InternalException
+                | InvalidKeyException
+                | InvalidResponseException
+                | IOException
+                | NoSuchAlgorithmException
+                | ServerException
+                | XmlParserException e) {
+              error = new Result<>(e);
+              completed = true;
+            }
+          }
+
+          @Override
+          public boolean hasNext() {
+            while (error == null && errorIterator == null && !completed) {
+              populate();
+            }
+
+            if (error == null && errorIterator != null) setError();
+            if (error != null) return true;
+            if (completed) return false;
+
+            errorIterator = null;
+            return hasNext();
+          }
+
+          @Override
+          public Result<DeleteError> next() {
+            if (!hasNext()) throw new NoSuchElementException();
+
+            if (this.error != null) {
+              Result<DeleteError> error = this.error;
+              this.error = null;
+              return error;
+            }
+
+            // This never happens.
+            throw new NoSuchElementException();
+          }
+
+          @Override
+          public void remove() {
+            throw new UnsupportedOperationException();
+          }
+        };
+      }
+    };
+  }
+
+  /**
+   * Lists objects information optionally with versions of a bucket. Supports both the versions 1
+   * and 2 of the S3 API. By default, the <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">version 2</a> API
+   * is used. <br>
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">Version 1</a>
+   * can be used by passing the optional argument {@code useVersion1} as {@code true}.
+   *
+   * <pre>Example:{@code
+   * // Lists objects information.
+   * Iterable<Result<Item>> results = minioAsyncClient.listObjects(
+   *     ListObjectsArgs.builder().bucket("my-bucketname").build());
+   *
+   * // Lists objects information recursively.
+   * Iterable<Result<Item>> results = minioAsyncClient.listObjects(
+   *     ListObjectsArgs.builder().bucket("my-bucketname").recursive(true).build());
+   *
+   * // Lists maximum 100 objects information whose names starts with 'E' and after
+   * // 'ExampleGuide.pdf'.
+   * Iterable<Result<Item>> results = minioAsyncClient.listObjects(
+   *     ListObjectsArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .startAfter("ExampleGuide.pdf")
+   *         .prefix("E")
+   *         .maxKeys(100)
+   *         .build());
+   *
+   * // Lists maximum 100 objects information with version whose names starts with 'E' and after
+   * // 'ExampleGuide.pdf'.
+   * Iterable<Result<Item>> results = minioAsyncClient.listObjects(
+   *     ListObjectsArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .startAfter("ExampleGuide.pdf")
+   *         .prefix("E")
+   *         .maxKeys(100)
+   *         .includeVersions(true)
+   *         .build());
+   * }</pre>
+   *
+   * @param args Instance of {@link ListObjectsArgs} built using the builder
+   * @return {@code Iterable<Result<Item>>} - Lazy iterator contains object information.
+   * @throws XmlParserException upon parsing response xml
+   */
+  public Iterable<Result<Item>> listObjects(ListObjectsArgs args) {
+    if (args.includeVersions() || args.versionIdMarker() != null) {
+      return listObjectVersions(args);
+    }
+
+    if (args.useApiVersion1()) {
+      return listObjectsV1(args);
+    }
+
+    return listObjectsV2(args);
+  }
+
+  /**
+   * Lists bucket information of all buckets.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<List<Bucket>> future = minioAsyncClient.listBuckets();
+   * }</pre>
+   *
+   * @return {@link CompletableFuture}&lt;{@link List}&lt;{@link Bucket}&gt;&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<List<Bucket>> listBuckets()
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return listBuckets(ListBucketsArgs.builder().build());
+  }
+
+  /**
+   * Lists bucket information of all buckets.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<List<Bucket>> future =
+   *     minioAsyncClient.listBuckets(ListBucketsArgs.builder().extraHeaders(headers).build());
+   * }</pre>
+   *
+   * @return {@link CompletableFuture}&lt;{@link List}&lt;{@link Bucket}&gt;&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<List<Bucket>> listBuckets(ListBucketsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeGetAsync(args, null, null)
+        .thenApply(
+            response -> {
+              try {
+                ListAllMyBucketsResult result =
+                    Xml.unmarshal(ListAllMyBucketsResult.class, response.body().charStream());
+                return result.buckets();
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Checks if a bucket exists.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Boolean> future =
+   *      minioAsyncClient.bucketExists(BucketExistsArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link BucketExistsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Boolean}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Boolean> bucketExists(BucketExistsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeHeadAsync(args, null, null)
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex).errorResponse().code().equals(NO_SUCH_BUCKET)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              try {
+                return response != null;
+              } finally {
+                if (response != null) response.close();
+              }
+            });
+  }
+
+  /**
+   * Creates a bucket with region and object lock.
+   *
+   * <pre>Example:{@code
+   * // Create bucket with default region.
+   * CompletableFuture<Void> future = minioAsyncClient.makeBucket(
+   *     MakeBucketArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .build());
+   *
+   * // Create bucket with specific region.
+   * CompletableFuture<Void> future = minioAsyncClient.makeBucket(
+   *     MakeBucketArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .region("us-west-1")
+   *         .build());
+   *
+   * // Create object-lock enabled bucket with specific region.
+   * CompletableFuture<Void> future = minioAsyncClient.makeBucket(
+   *     MakeBucketArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .region("us-west-1")
+   *         .objectLock(true)
+   *         .build());
+   * }</pre>
+   *
+   * @param args Object with bucket name, region and lock functionality
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> makeBucket(MakeBucketArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+
+    String region = args.region();
+    if (this.region != null && !this.region.isEmpty()) {
+      // Error out if region does not match with region passed via constructor.
+      if (region != null && !region.equals(this.region)) {
+        throw new IllegalArgumentException(
+            "region must be " + this.region + ", but passed " + region);
+      }
+
+      region = this.region;
+    }
+
+    if (region == null) {
+      region = US_EAST_1;
+    }
+
+    Multimap<String, String> headers =
+        args.objectLock() ? newMultimap("x-amz-bucket-object-lock-enabled", "true") : null;
+    final String location = region;
+
+    return executeAsync(
+            Method.PUT,
+            args.bucket(),
+            null,
+            location,
+            httpHeaders(merge(args.extraHeaders(), headers)),
+            args.extraQueryParams(),
+            location.equals(US_EAST_1) ? null : new CreateBucketConfiguration(location),
+            0)
+        .thenAccept(
+            response -> {
+              regionCache.put(args.bucket(), location);
+              response.close();
+            });
+  }
+
+  /**
+   * Sets versioning configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketVersioning(
+   *     SetBucketVersioningArgs.builder().bucket("my-bucketname").config(config).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketVersioningArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketVersioning(SetBucketVersioningArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(args, null, newMultimap("versioning", ""), args.config(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets versioning configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<VersioningConfiguration> future =
+   *     minioAsyncClient.getBucketVersioning(
+   *         GetBucketVersioningArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketVersioningArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link VersioningConfiguration}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<VersioningConfiguration> getBucketVersioning(
+      GetBucketVersioningArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("versioning", ""))
+        .thenApply(
+            response -> {
+              try {
+                return Xml.unmarshal(VersioningConfiguration.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets default object retention in a bucket.
+   *
+   * <pre>Example:{@code
+   * ObjectLockConfiguration config = new ObjectLockConfiguration(
+   *     RetentionMode.COMPLIANCE, new RetentionDurationDays(100));
+   * CompletableFuture<Void> future = minioAsyncClient.setObjectLockConfiguration(
+   *     SetObjectLockConfigurationArgs.builder().bucket("my-bucketname").config(config).build());
+   * }</pre>
+   *
+   * @param args {@link SetObjectLockConfigurationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setObjectLockConfiguration(SetObjectLockConfigurationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(args, null, newMultimap("object-lock", ""), args.config(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes default object retention in a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.deleteObjectLockConfiguration(
+   *     DeleteObjectLockConfigurationArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link DeleteObjectLockConfigurationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteObjectLockConfiguration(
+      DeleteObjectLockConfigurationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(
+            args, null, newMultimap("object-lock", ""), new ObjectLockConfiguration(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets default object retention in a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<ObjectLockConfiguration> future =
+   *     minioAsyncClient.getObjectLockConfiguration(
+   *         GetObjectLockConfigurationArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetObjectLockConfigurationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectLockConfiguration}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ObjectLockConfiguration> getObjectLockConfiguration(
+      GetObjectLockConfigurationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("object-lock", ""))
+        .thenApply(
+            response -> {
+              try {
+                return Xml.unmarshal(ObjectLockConfiguration.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets retention configuration to an object.
+   *
+   * <pre>Example:{@code
+   *  Retention retention = new Retention(
+   *       RetentionMode.COMPLIANCE, ZonedDateTime.now().plusYears(1));
+   *  CompletableFuture<Void> future = minioAsyncClient.setObjectRetention(
+   *      SetObjectRetentionArgs.builder()
+   *          .bucket("my-bucketname")
+   *          .object("my-objectname")
+   *          .config(config)
+   *          .bypassGovernanceMode(true)
+   *          .build());
+   * }</pre>
+   *
+   * @param args {@link SetObjectRetentionArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setObjectRetention(SetObjectRetentionArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("retention", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executePutAsync(
+            args,
+            args.bypassGovernanceMode()
+                ? newMultimap("x-amz-bypass-governance-retention", "True")
+                : null,
+            queryParams,
+            args.config(),
+            0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets retention configuration of an object.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Retention> future =
+   *     minioAsyncClient.getObjectRetention(GetObjectRetentionArgs.builder()
+   *        .bucket(bucketName)
+   *        .object(objectName)
+   *        .versionId(versionId)
+   *        .build());
+   * }</pre>
+   *
+   * @param args {@link GetObjectRetentionArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Retention}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Retention> getObjectRetention(GetObjectRetentionArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("retention", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executeGetAsync(args, null, queryParams)
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals(NO_SUCH_OBJECT_LOCK_CONFIGURATION)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return null;
+              try {
+                return Xml.unmarshal(Retention.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Enables legal hold on an object.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.enableObjectLegalHold(
+   *    EnableObjectLegalHoldArgs.builder()
+   *        .bucket("my-bucketname")
+   *        .object("my-objectname")
+   *        .versionId("object-versionId")
+   *        .build());
+   * }</pre>
+   *
+   * @param args {@link EnableObjectLegalHoldArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> enableObjectLegalHold(EnableObjectLegalHoldArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("legal-hold", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executePutAsync(args, null, queryParams, new LegalHold(true), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Disables legal hold on an object.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.disableObjectLegalHold(
+   *    DisableObjectLegalHoldArgs.builder()
+   *        .bucket("my-bucketname")
+   *        .object("my-objectname")
+   *        .versionId("object-versionId")
+   *        .build());
+   * }</pre>
+   *
+   * @param args {@link DisableObjectLegalHoldArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> disableObjectLegalHold(DisableObjectLegalHoldArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("legal-hold", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executePutAsync(args, null, queryParams, new LegalHold(false), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Returns true if legal hold is enabled on an object.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Boolean> future =
+   *     s3Client.isObjectLegalHoldEnabled(
+   *        IsObjectLegalHoldEnabledArgs.builder()
+   *             .bucket("my-bucketname")
+   *             .object("my-objectname")
+   *             .versionId("object-versionId")
+   *             .build());
+   * }</pre>
+   *
+   * @param args {@link IsObjectLegalHoldEnabledArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Boolean}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Boolean> isObjectLegalHoldEnabled(IsObjectLegalHoldEnabledArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("legal-hold", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executeGetAsync(args, null, queryParams)
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals(NO_SUCH_OBJECT_LOCK_CONFIGURATION)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return false;
+              try {
+                LegalHold result = Xml.unmarshal(LegalHold.class, response.body().charStream());
+                return result.status();
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Removes an empty bucket using arguments
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future =
+   *     minioAsyncClient.removeBucket(RemoveBucketArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link RemoveBucketArgs} bucket.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> removeBucket(RemoveBucketArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(args, null, null)
+        .thenAccept(response -> regionCache.remove(args.bucket()));
+  }
+
+  /**
+   * Uploads data from a stream to an object.
+   *
+   * <pre>Example:{@code
+   * // Upload known sized input stream.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.putObject(
+   *     PutObjectArgs.builder().bucket("my-bucketname").object("my-objectname").stream(
+   *             inputStream, size, -1)
+   *         .contentType("video/mp4")
+   *         .build());
+   *
+   * // Upload unknown sized input stream.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.putObject(
+   *     PutObjectArgs.builder().bucket("my-bucketname").object("my-objectname").stream(
+   *             inputStream, -1, 10485760)
+   *         .contentType("video/mp4")
+   *         .build());
+   *
+   * // Create object ends with '/' (also called as folder or directory).
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.putObject(
+   *     PutObjectArgs.builder().bucket("my-bucketname").object("path/to/").stream(
+   *             new ByteArrayInputStream(new byte[] {}), 0, -1)
+   *         .build());
+   *
+   * // Upload input stream with headers and user metadata.
+   * Map<String, String> headers = new HashMap<>();
+   * headers.put("X-Amz-Storage-Class", "REDUCED_REDUNDANCY");
+   * Map<String, String> userMetadata = new HashMap<>();
+   * userMetadata.put("My-Project", "Project One");
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.putObject(
+   *     PutObjectArgs.builder().bucket("my-bucketname").object("my-objectname").stream(
+   *             inputStream, size, -1)
+   *         .headers(headers)
+   *         .userMetadata(userMetadata)
+   *         .build());
+   *
+   * // Upload input stream with server-side encryption.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.putObject(
+   *     PutObjectArgs.builder().bucket("my-bucketname").object("my-objectname").stream(
+   *             inputStream, size, -1)
+   *         .sse(sse)
+   *         .build());
+   * }</pre>
+   *
+   * @param args {@link PutObjectArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ObjectWriteResponse> putObject(PutObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    args.validateSse(this.baseUrl);
+    return putObjectAsync(
+        args,
+        args.stream(),
+        args.objectSize(),
+        args.partSize(),
+        args.partCount(),
+        args.contentType());
+  }
+
+  /**
+   * Uploads data from a file to an object.
+   *
+   * <pre>Example:{@code
+   * // Upload an JSON file.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.uploadObject(
+   *     UploadObjectArgs.builder()
+   *         .bucket("my-bucketname").object("my-objectname").filename("person.json").build());
+   *
+   * // Upload a video file.
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.uploadObject(
+   *     UploadObjectArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .filename("my-video.avi")
+   *         .contentType("video/mp4")
+   *         .build());
+   * }</pre>
+   *
+   * @param args {@link UploadObjectArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ObjectWriteResponse> uploadObject(UploadObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    args.validateSse(this.baseUrl);
+    final RandomAccessFile file = new RandomAccessFile(args.filename(), "r");
+    return putObjectAsync(
+            args, file, args.objectSize(), args.partSize(), args.partCount(), args.contentType())
+        .exceptionally(
+            e -> {
+              try {
+                file.close();
+              } catch (IOException ex) {
+                throw new CompletionException(ex);
+              }
+
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            objectWriteResponse -> {
+              try {
+                file.close();
+              } catch (IOException e) {
+                throw new CompletionException(e);
+              }
+              return objectWriteResponse;
+            });
+  }
+
+  /**
+   * Gets bucket policy configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<String> future =
+   *     minioAsyncClient.getBucketPolicy(
+   *         GetBucketPolicyArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketPolicyArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link String}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<String> getBucketPolicy(GetBucketPolicyArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("policy", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals(NO_SUCH_BUCKET_POLICY)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return "";
+              try {
+                byte[] buf = new byte[MAX_BUCKET_POLICY_SIZE];
+                int bytesRead = 0;
+                bytesRead = response.body().byteStream().read(buf, 0, MAX_BUCKET_POLICY_SIZE);
+                if (bytesRead < 0) {
+                  throw new CompletionException(
+                      new IOException("unexpected EOF when reading bucket policy"));
+                }
+
+                // Read one byte extra to ensure only MAX_BUCKET_POLICY_SIZE data is sent by the
+                // server.
+                if (bytesRead == MAX_BUCKET_POLICY_SIZE) {
+                  int byteRead = 0;
+                  while (byteRead == 0) {
+                    byteRead = response.body().byteStream().read();
+                    if (byteRead < 0) {
+                      break; // reached EOF which is fine.
+                    }
+
+                    if (byteRead > 0) {
+                      throw new CompletionException(
+                          new BucketPolicyTooLargeException(args.bucket()));
+                    }
+                  }
+                }
+
+                return new String(buf, 0, bytesRead, StandardCharsets.UTF_8);
+              } catch (IOException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets bucket policy configuration to a bucket.
+   *
+   * <pre>Example:{@code
+   * // Assume policyJson contains below JSON string;
+   * // {
+   * //     "Statement": [
+   * //         {
+   * //             "Action": [
+   * //                 "s3:GetBucketLocation",
+   * //                 "s3:ListBucket"
+   * //             ],
+   * //             "Effect": "Allow",
+   * //             "Principal": "*",
+   * //             "Resource": "arn:aws:s3:::my-bucketname"
+   * //         },
+   * //         {
+   * //             "Action": "s3:GetObject",
+   * //             "Effect": "Allow",
+   * //             "Principal": "*",
+   * //             "Resource": "arn:aws:s3:::my-bucketname/myobject*"
+   * //         }
+   * //     ],
+   * //     "Version": "2012-10-17"
+   * // }
+   * //
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketPolicy(
+   *     SetBucketPolicyArgs.builder().bucket("my-bucketname").config(policyJson).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketPolicyArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketPolicy(SetBucketPolicyArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(
+            args,
+            newMultimap("Content-Type", "application/json"),
+            newMultimap("policy", ""),
+            args.config(),
+            0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes bucket policy configuration to a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future =
+   *     minioAsyncClient.deleteBucketPolicy(
+   *         DeleteBucketPolicyArgs.builder().bucket("my-bucketname"));
+   * }</pre>
+   *
+   * @param args {@link DeleteBucketPolicyArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteBucketPolicy(DeleteBucketPolicyArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(args, null, newMultimap("policy", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals(NO_SUCH_BUCKET_POLICY)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenAccept(
+            response -> {
+              if (response != null) response.close();
+            });
+  }
+
+  /**
+   * Sets lifecycle configuration to a bucket.
+   *
+   * <pre>Example:{@code
+   * List<LifecycleRule> rules = new LinkedList<>();
+   * rules.add(
+   *     new LifecycleRule(
+   *         Status.ENABLED,
+   *         null,
+   *         new Expiration((ZonedDateTime) null, 365, null),
+   *         new RuleFilter("logs/"),
+   *         "rule2",
+   *         null,
+   *         null,
+   *         null));
+   * LifecycleConfiguration config = new LifecycleConfiguration(rules);
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketLifecycle(
+   *     SetBucketLifecycleArgs.builder().bucket("my-bucketname").config(config).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketLifecycleArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketLifecycle(SetBucketLifecycleArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(args, null, newMultimap("lifecycle", ""), args.config(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes lifecycle configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = deleteBucketLifecycle(
+   *     DeleteBucketLifecycleArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link DeleteBucketLifecycleArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteBucketLifecycle(DeleteBucketLifecycleArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(args, null, newMultimap("lifecycle", ""))
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets lifecycle configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<LifecycleConfiguration> future =
+   *     minioAsyncClient.getBucketLifecycle(
+   *         GetBucketLifecycleArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketLifecycleArgs} object.
+   * @return {@link LifecycleConfiguration} object.
+   * @return {@link CompletableFuture}&lt;{@link LifecycleConfiguration}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<LifecycleConfiguration> getBucketLifecycle(GetBucketLifecycleArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("lifecycle", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals("NoSuchLifecycleConfiguration")) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return null;
+              try {
+                return Xml.unmarshal(LifecycleConfiguration.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Gets notification configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<NotificationConfiguration> future =
+   *     minioAsyncClient.getBucketNotification(
+   *         GetBucketNotificationArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketNotificationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link NotificationConfiguration}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<NotificationConfiguration> getBucketNotification(
+      GetBucketNotificationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("notification", ""))
+        .thenApply(
+            response -> {
+              try {
+                return Xml.unmarshal(NotificationConfiguration.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets notification configuration to a bucket.
+   *
+   * <pre>Example:{@code
+   * List<EventType> eventList = new LinkedList<>();
+   * eventList.add(EventType.OBJECT_CREATED_PUT);
+   * eventList.add(EventType.OBJECT_CREATED_COPY);
+   *
+   * QueueConfiguration queueConfiguration = new QueueConfiguration();
+   * queueConfiguration.setQueue("arn:minio:sqs::1:webhook");
+   * queueConfiguration.setEvents(eventList);
+   * queueConfiguration.setPrefixRule("images");
+   * queueConfiguration.setSuffixRule("pg");
+   *
+   * List<QueueConfiguration> queueConfigurationList = new LinkedList<>();
+   * queueConfigurationList.add(queueConfiguration);
+   *
+   * NotificationConfiguration config = new NotificationConfiguration();
+   * config.setQueueConfigurationList(queueConfigurationList);
+   *
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketNotification(
+   *     SetBucketNotificationArgs.builder().bucket("my-bucketname").config(config).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketNotificationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketNotification(SetBucketNotificationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(args, null, newMultimap("notification", ""), args.config(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes notification configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.deleteBucketNotification(
+   *     DeleteBucketNotificationArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link DeleteBucketNotificationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteBucketNotification(DeleteBucketNotificationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(
+            args, null, newMultimap("notification", ""), new NotificationConfiguration(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets bucket replication configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<ReplicationConfiguration> future =
+   *     minioAsyncClient.getBucketReplication(
+   *         GetBucketReplicationArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketReplicationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ReplicationConfiguration}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ReplicationConfiguration> getBucketReplication(
+      GetBucketReplicationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("replication", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals("ReplicationConfigurationNotFoundError")) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return null;
+              try {
+                return Xml.unmarshal(ReplicationConfiguration.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets bucket replication configuration to a bucket.
+   *
+   * <pre>Example:{@code
+   * Map<String, String> tags = new HashMap<>();
+   * tags.put("key1", "value1");
+   * tags.put("key2", "value2");
+   *
+   * ReplicationRule rule =
+   *     new ReplicationRule(
+   *         new DeleteMarkerReplication(Status.DISABLED),
+   *         new ReplicationDestination(
+   *             null, null, "REPLACE-WITH-ACTUAL-DESTINATION-BUCKET-ARN", null, null, null, null),
+   *         null,
+   *         new RuleFilter(new AndOperator("TaxDocs", tags)),
+   *         "rule1",
+   *         null,
+   *         1,
+   *         null,
+   *         Status.ENABLED);
+   *
+   * List<ReplicationRule> rules = new LinkedList<>();
+   * rules.add(rule);
+   *
+   * ReplicationConfiguration config =
+   *     new ReplicationConfiguration("REPLACE-WITH-ACTUAL-ROLE", rules);
+   *
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketReplication(
+   *     SetBucketReplicationArgs.builder().bucket("my-bucketname").config(config).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketReplicationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketReplication(SetBucketReplicationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(
+            args,
+            (args.objectLockToken() != null)
+                ? newMultimap("x-amz-bucket-object-lock-token", args.objectLockToken())
+                : null,
+            newMultimap("replication", ""),
+            args.config(),
+            0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes bucket replication configuration from a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.deleteBucketReplication(
+   *     DeleteBucketReplicationArgs.builder().bucket("my-bucketname"));
+   * }</pre>
+   *
+   * @param args {@link DeleteBucketReplicationArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteBucketReplication(DeleteBucketReplicationArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(args, null, newMultimap("replication", ""))
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Listens events of object prefix and suffix of a bucket. The returned closable iterator is
+   * lazily evaluated hence its required to iterate to get new records and must be used with
+   * try-with-resource to release underneath network resources.
+   *
+   * <pre>Example:{@code
+   * String[] events = {"s3:ObjectCreated:*", "s3:ObjectAccessed:*"};
+   * try (CloseableIterator<Result<NotificationRecords>> ci =
+   *     minioAsyncClient.listenBucketNotification(
+   *         ListenBucketNotificationArgs.builder()
+   *             .bucket("bucketName")
+   *             .prefix("")
+   *             .suffix("")
+   *             .events(events)
+   *             .build())) {
+   *   while (ci.hasNext()) {
+   *     NotificationRecords records = ci.next().get();
+   *     for (Event event : records.events()) {
+   *       System.out.println("Event " + event.eventType() + " occurred at "
+   *           + event.eventTime() + " for " + event.bucketName() + "/"
+   *           + event.objectName());
+   *     }
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param args {@link ListenBucketNotificationArgs} object.
+   * @return {@code CloseableIterator<Result<NotificationRecords>>} - Lazy closable iterator
+   *     contains event records.
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CloseableIterator<Result<NotificationRecords>> listenBucketNotification(
+      ListenBucketNotificationArgs args)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          ServerException, XmlParserException {
+    checkArgs(args);
+
+    Multimap<String, String> queryParams =
+        newMultimap("prefix", args.prefix(), "suffix", args.suffix());
+    for (String event : args.events()) {
+      queryParams.put("events", event);
+    }
+
+    Response response = null;
+    try {
+      response = executeGetAsync(args, null, queryParams).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+    }
+    NotificationResultRecords result = new NotificationResultRecords(response);
+    return result.closeableIterator();
+  }
+
+  /**
+   * Selects content of an object by SQL expression.
+   *
+   * <pre>Example:{@code
+   * String sqlExpression = "select * from S3Object";
+   * InputSerialization is =
+   *     new InputSerialization(null, false, null, null, FileHeaderInfo.USE, null, null,
+   *         null);
+   * OutputSerialization os =
+   *     new OutputSerialization(null, null, null, QuoteFields.ASNEEDED, null);
+   * SelectResponseStream stream =
+   *     minioAsyncClient.selectObjectContent(
+   *       SelectObjectContentArgs.builder()
+   *       .bucket("my-bucketname")
+   *       .object("my-objectname")
+   *       .sqlExpression(sqlExpression)
+   *       .inputSerialization(is)
+   *       .outputSerialization(os)
+   *       .requestProgress(true)
+   *       .build());
+   *
+   * byte[] buf = new byte[512];
+   * int bytesRead = stream.read(buf, 0, buf.length);
+   * System.out.println(new String(buf, 0, bytesRead, StandardCharsets.UTF_8));
+   *
+   * Stats stats = stream.stats();
+   * System.out.println("bytes scanned: " + stats.bytesScanned());
+   * System.out.println("bytes processed: " + stats.bytesProcessed());
+   * System.out.println("bytes returned: " + stats.bytesReturned());
+   *
+   * stream.close();
+   * }</pre>
+   *
+   * @param args instance of {@link SelectObjectContentArgs}
+   * @return {@link SelectResponseStream} - Contains filtered records and progress.
+   * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws InvalidResponseException thrown to indicate S3 service returned invalid or no error
+   *     response.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public SelectResponseStream selectObjectContent(SelectObjectContentArgs args)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          ServerException, XmlParserException {
+    checkArgs(args);
+    args.validateSsec(this.baseUrl);
+    Response response = null;
+    try {
+      response =
+          executePostAsync(
+                  args,
+                  (args.ssec() != null) ? newMultimap(args.ssec().headers()) : null,
+                  newMultimap("select", "", "select-type", "2"),
+                  new SelectObjectContentRequest(
+                      args.sqlExpression(),
+                      args.requestProgress(),
+                      args.inputSerialization(),
+                      args.outputSerialization(),
+                      args.scanStartRange(),
+                      args.scanEndRange()))
+              .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+    }
+    return new SelectResponseStream(response.body().byteStream());
+  }
+
+  /**
+   * Sets encryption configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketEncryption(
+   *     SetBucketEncryptionArgs.builder().bucket("my-bucketname").config(config).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketEncryptionArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketEncryption(SetBucketEncryptionArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(args, null, newMultimap("encryption", ""), args.config(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets encryption configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<SseConfiguration> future =
+   *     minioAsyncClient.getBucketEncryption(
+   *         GetBucketEncryptionArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketEncryptionArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link SseConfiguration}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<SseConfiguration> getBucketEncryption(GetBucketEncryptionArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("encryption", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals(SERVER_SIDE_ENCRYPTION_CONFIGURATION_NOT_FOUND_ERROR)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return new SseConfiguration(null);
+              try {
+                return Xml.unmarshal(SseConfiguration.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Deletes encryption configuration of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.deleteBucketEncryption(
+   *     DeleteBucketEncryptionArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link DeleteBucketEncryptionArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteBucketEncryption(DeleteBucketEncryptionArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(args, null, newMultimap("encryption", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex)
+                    .errorResponse()
+                    .code()
+                    .equals(SERVER_SIDE_ENCRYPTION_CONFIGURATION_NOT_FOUND_ERROR)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenAccept(
+            response -> {
+              if (response != null) response.close();
+            });
+  }
+
+  /**
+   * Gets tags of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Tags> future =
+   *     minioAsyncClient.getBucketTags(GetBucketTagsArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link GetBucketTagsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Tags}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Tags> getBucketTags(GetBucketTagsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeGetAsync(args, null, newMultimap("tagging", ""))
+        .exceptionally(
+            e -> {
+              Throwable ex = e.getCause();
+
+              if (ex instanceof CompletionException) {
+                ex = ((CompletionException) ex).getCause();
+              }
+
+              if (ex instanceof ExecutionException) {
+                ex = ((ExecutionException) ex).getCause();
+              }
+
+              if (ex instanceof ErrorResponseException) {
+                if (((ErrorResponseException) ex).errorResponse().code().equals("NoSuchTagSet")) {
+                  return null;
+                }
+              }
+              throw new CompletionException(ex);
+            })
+        .thenApply(
+            response -> {
+              if (response == null) return new Tags();
+              try {
+                return Xml.unmarshal(Tags.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets tags to a bucket.
+   *
+   * <pre>Example:{@code
+   * Map<String, String> map = new HashMap<>();
+   * map.put("Project", "Project One");
+   * map.put("User", "jsmith");
+   * CompletableFuture<Void> future = minioAsyncClient.setBucketTags(
+   *     SetBucketTagsArgs.builder().bucket("my-bucketname").tags(map).build());
+   * }</pre>
+   *
+   * @param args {@link SetBucketTagsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setBucketTags(SetBucketTagsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executePutAsync(args, null, newMultimap("tagging", ""), args.tags(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes tags of a bucket.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.deleteBucketTags(
+   *     DeleteBucketTagsArgs.builder().bucket("my-bucketname").build());
+   * }</pre>
+   *
+   * @param args {@link DeleteBucketTagsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteBucketTags(DeleteBucketTagsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    return executeDeleteAsync(args, null, newMultimap("tagging", ""))
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Gets tags of an object.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Tags> future =
+   *     minioAsyncClient.getObjectTags(
+   *         GetObjectTagsArgs.builder().bucket("my-bucketname").object("my-objectname").build());
+   * }</pre>
+   *
+   * @param args {@link GetObjectTagsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Tags}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Tags> getObjectTags(GetObjectTagsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("tagging", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executeGetAsync(args, null, queryParams)
+        .thenApply(
+            response -> {
+              try {
+                return Xml.unmarshal(Tags.class, response.body().charStream());
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Sets tags to an object.
+   *
+   * <pre>Example:{@code
+   * Map<String, String> map = new HashMap<>();
+   * map.put("Project", "Project One");
+   * map.put("User", "jsmith");
+   * CompletableFuture<Void> future = minioAsyncClient.setObjectTags(
+   *     SetObjectTagsArgs.builder()
+   *         .bucket("my-bucketname")
+   *         .object("my-objectname")
+   *         .tags((map)
+   *         .build());
+   * }</pre>
+   *
+   * @param args {@link SetObjectTagsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> setObjectTags(SetObjectTagsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("tagging", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executePutAsync(args, null, queryParams, args.tags(), 0)
+        .thenAccept(response -> response.close());
+  }
+
+  /**
+   * Deletes tags of an object.
+   *
+   * <pre>Example:{@code
+   * CompletableFuture<Void> future = minioAsyncClient.deleteObjectTags(
+   *     DeleteObjectTags.builder().bucket("my-bucketname").object("my-objectname").build());
+   * }</pre>
+   *
+   * @param args {@link DeleteObjectTagsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link Void}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<Void> deleteObjectTags(DeleteObjectTagsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+    Multimap<String, String> queryParams = newMultimap("tagging", "");
+    if (args.versionId() != null) queryParams.put("versionId", args.versionId());
+    return executeDeleteAsync(args, null, queryParams).thenAccept(response -> response.close());
+  }
+
+  /**
+   * Uploads multiple objects in a single put call. It is done by creating intermediate TAR file
+   * optionally compressed which is uploaded to S3 service.
+   *
+   * <pre>Example:{@code
+   * // Upload snowball objects.
+   * List<SnowballObject> objects = new ArrayList<SnowballObject>();
+   * objects.add(
+   *     new SnowballObject(
+   *         "my-object-one",
+   *         new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)),
+   *         5,
+   *         null));
+   * objects.add(
+   *     new SnowballObject(
+   *         "my-object-two",
+   *         new ByteArrayInputStream("java".getBytes(StandardCharsets.UTF_8)),
+   *         4,
+   *         null));
+   * CompletableFuture<ObjectWriteResponse> future = minioAsyncClient.uploadSnowballObjects(
+   *     UploadSnowballObjectsArgs.builder().bucket("my-bucketname").objects(objects).build());
+   * }</pre>
+   *
+   * @param args {@link UploadSnowballObjectsArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  public CompletableFuture<ObjectWriteResponse> uploadSnowballObjects(
+      UploadSnowballObjectsArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    checkArgs(args);
+
+    return CompletableFuture.supplyAsync(
+            () -> {
+              FileOutputStream fos = null;
+              BufferedOutputStream bos = null;
+              SnappyFramedOutputStream sos = null;
+              ByteArrayOutputStream baos = null;
+              TarArchiveOutputStream tarOutputStream = null;
+
+              try {
+                OutputStream os = null;
+                if (args.stagingFilename() != null) {
+                  fos = new FileOutputStream(args.stagingFilename());
+                  bos = new BufferedOutputStream(fos);
+                  os = bos;
+                } else {
+                  baos = new ByteArrayOutputStream();
+                  os = baos;
+                }
+
+                if (args.compression()) {
+                  sos = new SnappyFramedOutputStream(os);
+                  os = sos;
+                }
+
+                tarOutputStream = new TarArchiveOutputStream(os);
+                tarOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+                for (SnowballObject object : args.objects()) {
+                  if (object.filename() != null) {
+                    Path filePath = Paths.get(object.filename());
+                    TarArchiveEntry entry = new TarArchiveEntry(filePath.toFile(), object.name());
+                    tarOutputStream.putArchiveEntry(entry);
+                    Files.copy(filePath, tarOutputStream);
+                  } else {
+                    TarArchiveEntry entry = new TarArchiveEntry(object.name());
+                    if (object.modificationTime() != null) {
+                      entry.setModTime(Date.from(object.modificationTime().toInstant()));
+                    }
+                    entry.setSize(object.size());
+                    tarOutputStream.putArchiveEntry(entry);
+                    ByteStreams.copy(object.stream(), tarOutputStream);
+                  }
+                  tarOutputStream.closeArchiveEntry();
+                }
+                tarOutputStream.finish();
+              } catch (IOException e) {
+                throw new CompletionException(e);
+              } finally {
+                try {
+                  if (tarOutputStream != null) tarOutputStream.flush();
+                  if (sos != null) sos.flush();
+                  if (bos != null) bos.flush();
+                  if (fos != null) fos.flush();
+                  if (tarOutputStream != null) tarOutputStream.close();
+                  if (sos != null) sos.close();
+                  if (bos != null) bos.close();
+                  if (fos != null) fos.close();
+                } catch (IOException e) {
+                  throw new CompletionException(e);
+                }
+              }
+              return baos;
+            })
+        .thenCompose(
+            baos -> {
+              Multimap<String, String> headers = newMultimap(args.extraHeaders());
+              headers.putAll(args.genHeaders());
+              headers.put("X-Amz-Meta-Snowball-Auto-Extract", "true");
+
+              if (args.stagingFilename() == null) {
+                byte[] data = baos.toByteArray();
+                try {
+                  return putObjectAsync(
+                      args.bucket(),
+                      args.region(),
+                      args.object(),
+                      data,
+                      data.length,
+                      headers,
+                      args.extraQueryParams());
+                } catch (InsufficientDataException
+                    | InternalException
+                    | InvalidKeyException
+                    | IOException
+                    | NoSuchAlgorithmException
+                    | XmlParserException e) {
+                  throw new CompletionException(e);
+                }
+              }
+
+              long length = Paths.get(args.stagingFilename()).toFile().length();
+              if (length > ObjectWriteArgs.MAX_OBJECT_SIZE) {
+                throw new IllegalArgumentException(
+                    "tarball size " + length + " is more than maximum allowed 5TiB");
+              }
+              try (RandomAccessFile file = new RandomAccessFile(args.stagingFilename(), "r")) {
+                return putObjectAsync(
+                    args.bucket(),
+                    args.region(),
+                    args.object(),
+                    file,
+                    length,
+                    headers,
+                    args.extraQueryParams());
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            });
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Argument builder of {@link MinioClient}. */
+  public static final class Builder {
+    private HttpUrl baseUrl;
+    private String region;
+    private boolean isAwsHost;
+    private boolean isAcceleratedHost;
+    private boolean isDualStackHost;
+    private boolean useVirtualStyle;
+    private Provider provider;
+    private OkHttpClient httpClient;
+
+    private boolean isAwsChinaHost;
+    private String regionInUrl;
+
+    private boolean isAwsEndpoint(String endpoint) {
+      return (endpoint.startsWith("s3.") || isAwsAccelerateEndpoint(endpoint))
+          && (endpoint.endsWith(".amazonaws.com") || endpoint.endsWith(".amazonaws.com.cn"));
+    }
+
+    private boolean isAwsAccelerateEndpoint(String endpoint) {
+      return endpoint.startsWith("s3-accelerate.");
+    }
+
+    private boolean isAwsDualStackEndpoint(String endpoint) {
+      return endpoint.contains(".dualstack.");
+    }
+
+    /**
+     * Extracts region from AWS endpoint if available. Region is placed at second token normal
+     * endpoints and third token for dualstack endpoints.
+     *
+     * <p>Region is marked in square brackets in below examples.
+     * <pre>
+     * https://s3.[us-east-2].amazonaws.com
+     * https://s3.dualstack.[ca-central-1].amazonaws.com
+     * https://s3.[cn-north-1].amazonaws.com.cn
+     * https://s3.dualstack.[cn-northwest-1].amazonaws.com.cn
+     */
+    private String extractRegion(String endpoint) {
+      String[] tokens = endpoint.split("\\.");
+      String token = tokens[1];
+
+      // If token is "dualstack", then region might be in next token.
+      if (token.equals("dualstack")) {
+        token = tokens[2];
+      }
+
+      // If token is equal to "amazonaws", region is not passed in the endpoint.
+      if (token.equals("amazonaws")) {
+        return null;
+      }
+
+      // Return token as region.
+      return token;
+    }
+
+    private void setBaseUrl(HttpUrl url) {
+      String host = url.host();
+
+      this.isAwsHost = isAwsEndpoint(host);
+      this.isAwsChinaHost = false;
+      if (this.isAwsHost) {
+        this.isAwsChinaHost = host.endsWith(".cn");
+        url =
+            url.newBuilder()
+                .host(this.isAwsChinaHost ? "amazonaws.com.cn" : "amazonaws.com")
+                .build();
+        this.isAcceleratedHost = isAwsAccelerateEndpoint(host);
+        this.isDualStackHost = isAwsDualStackEndpoint(host);
+        this.regionInUrl = extractRegion(host);
+        this.useVirtualStyle = true;
+      } else {
+        this.useVirtualStyle = host.endsWith("aliyuncs.com");
+      }
+
+      this.baseUrl = url;
+    }
+
+    public Builder endpoint(String endpoint) {
+      setBaseUrl(HttpUtils.getBaseUrl(endpoint));
+      return this;
+    }
+
+    public Builder endpoint(String endpoint, int port, boolean secure) {
+      HttpUrl url = HttpUtils.getBaseUrl(endpoint);
+      if (port < 1 || port > 65535) {
+        throw new IllegalArgumentException("port must be in range of 1 to 65535");
+      }
+      url = url.newBuilder().port(port).scheme(secure ? "https" : "http").build();
+
+      setBaseUrl(url);
+      return this;
+    }
+
+    public Builder endpoint(URL url) {
+      HttpUtils.validateNotNull(url, "url");
+      return endpoint(HttpUrl.get(url));
+    }
+
+    public Builder endpoint(HttpUrl url) {
+      HttpUtils.validateNotNull(url, "url");
+      HttpUtils.validateUrl(url);
+      setBaseUrl(url);
+      return this;
+    }
+
+    public Builder region(String region) {
+      HttpUtils.validateNullOrNotEmptyString(region, "region");
+      this.regionInUrl = region;
+      this.region = region;
+      return this;
+    }
+
+    public Builder credentials(String accessKey, String secretKey) {
+      this.provider = new StaticProvider(accessKey, secretKey, null);
+      return this;
+    }
+
+    public Builder credentialsProvider(Provider provider) {
+      this.provider = provider;
+      return this;
+    }
+
+    public Builder httpClient(OkHttpClient httpClient) {
+      HttpUtils.validateNotNull(httpClient, "http client");
+      this.httpClient = httpClient;
+      return this;
+    }
+
+    public MinioAsyncClient build() {
+      HttpUtils.validateNotNull(this.baseUrl, "endpoint");
+      if (this.isAwsChinaHost && this.regionInUrl == null && this.region == null) {
+        throw new IllegalArgumentException(
+            "Region missing in Amazon S3 China endpoint " + this.baseUrl);
+      }
+
+      if (this.httpClient == null) {
+        this.httpClient =
+            HttpUtils.newDefaultHttpClient(
+                DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
+        if (this.region == null) this.region = regionInUrl;
+      }
+
+      return new MinioAsyncClient(
+          baseUrl,
+          region,
+          isAwsHost,
+          isAcceleratedHost,
+          isDualStackHost,
+          useVirtualStyle,
+          provider,
+          httpClient);
+    }
+  }
+}

--- a/api/src/main/java/io/minio/PutObjectArgs.java
+++ b/api/src/main/java/io/minio/PutObjectArgs.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#putObject}. */
+/** Argument class of {@link MinioAsyncClient#putObject} and {@link MinioClient#putObject}. */
 public class PutObjectArgs extends PutObjectBaseArgs {
   private BufferedInputStream stream;
 

--- a/api/src/main/java/io/minio/RemoveBucketArgs.java
+++ b/api/src/main/java/io/minio/RemoveBucketArgs.java
@@ -16,7 +16,7 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#removeBucket}. */
+/** Argument class of {@link MinioAsyncClient#removeBucket} and {@link MinioClient#removeBucket}. */
 public class RemoveBucketArgs extends BucketArgs {
 
   public static Builder builder() {

--- a/api/src/main/java/io/minio/RemoveObjectArgs.java
+++ b/api/src/main/java/io/minio/RemoveObjectArgs.java
@@ -18,7 +18,7 @@ package io.minio;
 
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#removeObject}. */
+/** Argument class of {@link MinioAsyncClient#removeObject} and {@link MinioClient#removeObject}. */
 public class RemoveObjectArgs extends ObjectVersionArgs {
   private boolean bypassGovernanceMode;
 

--- a/api/src/main/java/io/minio/RemoveObjectsArgs.java
+++ b/api/src/main/java/io/minio/RemoveObjectsArgs.java
@@ -20,7 +20,9 @@ import io.minio.messages.DeleteObject;
 import java.util.LinkedList;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#removeObjects}. */
+/**
+ * Argument class of {@link MinioAsyncClient#removeObjects} and {@link MinioClient#removeObjects}.
+ */
 public class RemoveObjectsArgs extends BucketArgs {
   private boolean bypassGovernanceMode;
   private Iterable<DeleteObject> objects = new LinkedList<>();

--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -222,47 +222,22 @@ public abstract class S3Base {
       ex = ((ExecutionException) ex).getCause();
     }
 
-    if (ex instanceof IllegalArgumentException) {
-      throw (IllegalArgumentException) ex;
+    try {
+      throw ex;
+    } catch (IllegalArgumentException
+        | ErrorResponseException
+        | InsufficientDataException
+        | InternalException
+        | InvalidKeyException
+        | InvalidResponseException
+        | IOException
+        | NoSuchAlgorithmException
+        | ServerException
+        | XmlParserException exc) {
+      throw exc;
+    } catch (Throwable exc) {
+      throw new RuntimeException(exc.getCause());
     }
-
-    if (ex instanceof ErrorResponseException) {
-      throw (ErrorResponseException) ex;
-    }
-
-    if (ex instanceof InsufficientDataException) {
-      throw (InsufficientDataException) ex;
-    }
-
-    if (ex instanceof InternalException) {
-      throw (InternalException) ex;
-    }
-
-    if (ex instanceof InvalidKeyException) {
-      throw (InvalidKeyException) ex;
-    }
-
-    if (ex instanceof InvalidResponseException) {
-      throw (InvalidResponseException) ex;
-    }
-
-    if (ex instanceof IOException) {
-      throw (IOException) ex;
-    }
-
-    if (ex instanceof NoSuchAlgorithmException) {
-      throw (NoSuchAlgorithmException) ex;
-    }
-
-    if (ex instanceof ServerException) {
-      throw (ServerException) ex;
-    }
-
-    if (ex instanceof XmlParserException) {
-      throw (XmlParserException) ex;
-    }
-
-    throw new RuntimeException(ex);
   }
 
   private String[] handleRedirectResponse(

--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -80,10 +80,15 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -198,6 +203,66 @@ public abstract class S3Base {
   /** Create new HashMultimap with copy of Multimap. */
   protected Multimap<String, String> newMultimap(Multimap<String, String> map) {
     return (map != null) ? HashMultimap.create(map) : HashMultimap.create();
+  }
+
+  /** Throws encapsulated exception wrapped by {@link ExecutionException}. */
+  public void throwEncapsulatedException(ExecutionException e)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          ServerException, XmlParserException {
+    if (e == null) return;
+
+    Throwable ex = e.getCause();
+
+    if (ex instanceof CompletionException) {
+      ex = ((CompletionException) ex).getCause();
+    }
+
+    if (ex instanceof ExecutionException) {
+      ex = ((ExecutionException) ex).getCause();
+    }
+
+    if (ex instanceof IllegalArgumentException) {
+      throw (IllegalArgumentException) ex;
+    }
+
+    if (ex instanceof ErrorResponseException) {
+      throw (ErrorResponseException) ex;
+    }
+
+    if (ex instanceof InsufficientDataException) {
+      throw (InsufficientDataException) ex;
+    }
+
+    if (ex instanceof InternalException) {
+      throw (InternalException) ex;
+    }
+
+    if (ex instanceof InvalidKeyException) {
+      throw (InvalidKeyException) ex;
+    }
+
+    if (ex instanceof InvalidResponseException) {
+      throw (InvalidResponseException) ex;
+    }
+
+    if (ex instanceof IOException) {
+      throw (IOException) ex;
+    }
+
+    if (ex instanceof NoSuchAlgorithmException) {
+      throw (NoSuchAlgorithmException) ex;
+    }
+
+    if (ex instanceof ServerException) {
+      throw (ServerException) ex;
+    }
+
+    if (ex instanceof XmlParserException) {
+      throw (XmlParserException) ex;
+    }
+
+    throw new RuntimeException(ex);
   }
 
   private String[] handleRedirectResponse(
@@ -416,7 +481,318 @@ public abstract class S3Base {
     return traceBuilder;
   }
 
-  /** Execute HTTP request for given args and parameters. */
+  /** Execute HTTP request asynchronously for given parameters. */
+  protected CompletableFuture<Response> executeAsync(
+      Method method,
+      String bucketName,
+      String objectName,
+      String region,
+      Headers headers,
+      Multimap<String, String> queryParamMap,
+      Object body,
+      int length)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    boolean traceRequestBody = false;
+    if (body != null && !(body instanceof PartSource || body instanceof byte[])) {
+      byte[] bytes;
+      if (body instanceof CharSequence) {
+        bytes = body.toString().getBytes(StandardCharsets.UTF_8);
+      } else {
+        bytes = Xml.marshal(body).getBytes(StandardCharsets.UTF_8);
+      }
+
+      body = bytes;
+      length = bytes.length;
+      traceRequestBody = true;
+    }
+
+    if (body == null && (method == Method.PUT || method == Method.POST)) {
+      body = HttpUtils.EMPTY_BODY;
+    }
+
+    HttpUrl url = buildUrl(method, bucketName, objectName, region, queryParamMap);
+    Credentials creds = (provider == null) ? null : provider.fetch();
+    Request req = createRequest(url, method, headers, body, length, creds);
+    if (creds != null) {
+      req =
+          Signer.signV4S3(
+              req,
+              region,
+              creds.accessKey(),
+              creds.secretKey(),
+              req.header("x-amz-content-sha256"));
+    }
+    final Request request = req;
+
+    StringBuilder traceBuilder =
+        newTraceBuilder(
+            request, traceRequestBody ? new String((byte[]) body, StandardCharsets.UTF_8) : null);
+    PrintWriter traceStream = this.traceStream;
+    if (traceStream != null) traceStream.println(traceBuilder.toString());
+    traceBuilder.append("\n");
+
+    OkHttpClient httpClient = this.httpClient;
+    if (!(body instanceof byte[]) && (method == Method.PUT || method == Method.POST)) {
+      // Issue #924: disable connection retry for PUT and POST methods for other than byte array.
+      httpClient = this.httpClient.newBuilder().retryOnConnectionFailure(false).build();
+    }
+
+    CompletableFuture<Response> completableFuture = new CompletableFuture<>();
+    httpClient
+        .newCall(request)
+        .enqueue(
+            new Callback() {
+              @Override
+              public void onFailure(final Call call, IOException e) {
+                completableFuture.completeExceptionally(e);
+              }
+
+              @Override
+              public void onResponse(Call call, final Response response) throws IOException {
+                String trace =
+                    response.protocol().toString().toUpperCase(Locale.US)
+                        + " "
+                        + response.code()
+                        + "\n"
+                        + response.headers();
+                traceBuilder.append(trace).append("\n");
+                if (traceStream != null) traceStream.println(trace);
+
+                if (response.isSuccessful()) {
+                  if (traceStream != null) {
+                    // Trace response body only if the request is not
+                    // GetObject/ListenBucketNotification
+                    // S3 API.
+                    Set<String> keys = queryParamMap.keySet();
+                    if ((method != Method.GET
+                            || objectName == null
+                            || !Collections.disjoint(keys, TRACE_QUERY_PARAMS))
+                        && !(keys.contains("events")
+                            && (keys.contains("prefix") || keys.contains("suffix")))) {
+                      ResponseBody responseBody = response.peekBody(1024 * 1024);
+                      traceStream.println(responseBody.string());
+                    }
+                    traceStream.println(END_HTTP);
+                  }
+
+                  completableFuture.complete(response);
+                  return;
+                }
+
+                String errorXml = null;
+                try (ResponseBody responseBody = response.body()) {
+                  errorXml = responseBody.string();
+                }
+
+                if (!("".equals(errorXml) && method.equals(Method.HEAD))) {
+                  traceBuilder.append(errorXml).append("\n");
+                  if (traceStream != null) traceStream.println(errorXml);
+                }
+
+                traceBuilder.append(END_HTTP).append("\n");
+                if (traceStream != null) traceStream.println(END_HTTP);
+
+                // Error in case of Non-XML response from server for non-HEAD requests.
+                String contentType = response.headers().get("content-type");
+                if (!method.equals(Method.HEAD)
+                    && (contentType == null
+                        || !Arrays.asList(contentType.split(";")).contains("application/xml"))) {
+                  completableFuture.completeExceptionally(
+                      new InvalidResponseException(
+                          response.code(),
+                          contentType,
+                          errorXml.substring(
+                              0, errorXml.length() > 1024 ? 1024 : errorXml.length()),
+                          traceBuilder.toString()));
+                  return;
+                }
+
+                ErrorResponse errorResponse = null;
+                if (!"".equals(errorXml)) {
+                  try {
+                    errorResponse = Xml.unmarshal(ErrorResponse.class, errorXml);
+                  } catch (XmlParserException e) {
+                    completableFuture.completeExceptionally(e);
+                    return;
+                  }
+                } else if (!method.equals(Method.HEAD)) {
+                  completableFuture.completeExceptionally(
+                      new InvalidResponseException(
+                          response.code(), contentType, errorXml, traceBuilder.toString()));
+                  return;
+                }
+
+                if (errorResponse == null) {
+                  String code = null;
+                  String message = null;
+                  switch (response.code()) {
+                    case 301:
+                    case 307:
+                    case 400:
+                      String[] result = handleRedirectResponse(method, bucketName, response, true);
+                      code = result[0];
+                      message = result[1];
+                      break;
+                    case 404:
+                      if (objectName != null) {
+                        code = "NoSuchKey";
+                        message = "Object does not exist";
+                      } else if (bucketName != null) {
+                        code = NO_SUCH_BUCKET;
+                        message = NO_SUCH_BUCKET_MESSAGE;
+                      } else {
+                        code = "ResourceNotFound";
+                        message = "Request resource not found";
+                      }
+                      break;
+                    case 501:
+                    case 405:
+                      code = "MethodNotAllowed";
+                      message = "The specified method is not allowed against this resource";
+                      break;
+                    case 409:
+                      if (bucketName != null) {
+                        code = NO_SUCH_BUCKET;
+                        message = NO_SUCH_BUCKET_MESSAGE;
+                      } else {
+                        code = "ResourceConflict";
+                        message = "Request resource conflicts";
+                      }
+                      break;
+                    case 403:
+                      code = "AccessDenied";
+                      message = "Access denied";
+                      break;
+                    case 412:
+                      code = "PreconditionFailed";
+                      message = "At least one of the preconditions you specified did not hold";
+                      break;
+                    case 416:
+                      code = "InvalidRange";
+                      message = "The requested range cannot be satisfied";
+                      break;
+                    default:
+                      completableFuture.completeExceptionally(
+                          new ServerException(
+                              "server failed with HTTP status code " + response.code(),
+                              traceBuilder.toString()));
+                      return;
+                  }
+
+                  errorResponse =
+                      new ErrorResponse(
+                          code,
+                          message,
+                          bucketName,
+                          objectName,
+                          request.url().encodedPath(),
+                          response.header("x-amz-request-id"),
+                          response.header("x-amz-id-2"));
+                }
+
+                // invalidate region cache if needed
+                if (errorResponse.code().equals(NO_SUCH_BUCKET)
+                    || errorResponse.code().equals(RETRY_HEAD)) {
+                  regionCache.remove(bucketName);
+                }
+
+                ErrorResponseException e =
+                    new ErrorResponseException(errorResponse, response, traceBuilder.toString());
+                completableFuture.completeExceptionally(e);
+              }
+            });
+    return completableFuture;
+  }
+
+  /** Execute HTTP request asynchronously for given args and parameters. */
+  protected CompletableFuture<Response> executeAsync(
+      Method method,
+      BaseArgs args,
+      Multimap<String, String> headers,
+      Multimap<String, String> queryParams,
+      Object body,
+      int length)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    final String bucketName;
+    final String region;
+    final String objectName;
+
+    if (args instanceof BucketArgs) {
+      bucketName = ((BucketArgs) args).bucket();
+      region = ((BucketArgs) args).region();
+    } else {
+      bucketName = null;
+      region = null;
+    }
+
+    if (args instanceof ObjectArgs) {
+      objectName = ((ObjectArgs) args).object();
+    } else {
+      objectName = null;
+    }
+
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    method,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(merge(args.extraHeaders(), headers)),
+                    merge(args.extraQueryParams(), queryParams),
+                    body,
+                    length);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            });
+  }
+
+  /**
+   * Execute HTTP request for given parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executeAsync}.
+   */
+  @Deprecated
+  protected Response execute(
+      Method method,
+      String bucketName,
+      String objectName,
+      String region,
+      Headers headers,
+      Multimap<String, String> queryParamMap,
+      Object body,
+      int length)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          ServerException, XmlParserException {
+    CompletableFuture<Response> completableFuture =
+        executeAsync(method, bucketName, objectName, region, headers, queryParamMap, body, length);
+    try {
+      return completableFuture.get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
+
+  /**
+   * Execute HTTP request for given args and parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executeAsync}.
+   */
+  @Deprecated
   protected Response execute(
       Method method,
       BaseArgs args,
@@ -449,297 +825,209 @@ public abstract class S3Base {
         length);
   }
 
-  /** Execute HTTP request for given parameters. */
-  protected Response execute(
-      Method method,
-      String bucketName,
-      String objectName,
-      String region,
-      Headers headers,
-      Multimap<String, String> queryParamMap,
-      Object body,
-      int length)
-      throws ErrorResponseException, InsufficientDataException, InternalException,
-          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
-          ServerException, XmlParserException {
-    boolean traceRequestBody = false;
-    if (body != null && !(body instanceof PartSource || body instanceof byte[])) {
-      byte[] bytes;
-      if (body instanceof CharSequence) {
-        bytes = body.toString().getBytes(StandardCharsets.UTF_8);
-      } else {
-        bytes = Xml.marshal(body).getBytes(StandardCharsets.UTF_8);
-      }
-
-      body = bytes;
-      length = bytes.length;
-      traceRequestBody = true;
-    }
-
-    if (body == null && (method == Method.PUT || method == Method.POST))
-      body = HttpUtils.EMPTY_BODY;
-
-    HttpUrl url = buildUrl(method, bucketName, objectName, region, queryParamMap);
-    Credentials creds = (provider == null) ? null : provider.fetch();
-    Request request = createRequest(url, method, headers, body, length, creds);
-    if (creds != null) {
-      request =
-          Signer.signV4S3(
-              request,
-              region,
-              creds.accessKey(),
-              creds.secretKey(),
-              request.header("x-amz-content-sha256"));
-    }
-
-    StringBuilder traceBuilder =
-        newTraceBuilder(
-            request, traceRequestBody ? new String((byte[]) body, StandardCharsets.UTF_8) : null);
-    PrintWriter traceStream = this.traceStream;
-    if (traceStream != null) traceStream.println(traceBuilder.toString());
-    traceBuilder.append("\n");
-
-    OkHttpClient httpClient = this.httpClient;
-    if (!(body instanceof byte[]) && (method == Method.PUT || method == Method.POST)) {
-      // Issue #924: disable connection retry for PUT and POST methods for other than byte array.
-      httpClient = this.httpClient.newBuilder().retryOnConnectionFailure(false).build();
-    }
-
-    Response response = httpClient.newCall(request).execute();
-    String trace =
-        response.protocol().toString().toUpperCase(Locale.US)
-            + " "
-            + response.code()
-            + "\n"
-            + response.headers();
-    traceBuilder.append(trace).append("\n");
-    if (traceStream != null) traceStream.println(trace);
-
-    if (response.isSuccessful()) {
-      if (traceStream != null) {
-        // Trace response body only if the request is not GetObject/ListenBucketNotification S3 API.
-        Set<String> keys = queryParamMap.keySet();
-        if ((method != Method.GET
-                || objectName == null
-                || !Collections.disjoint(keys, TRACE_QUERY_PARAMS))
-            && !(keys.contains("events") && (keys.contains("prefix") || keys.contains("suffix")))) {
-          ResponseBody responseBody = response.peekBody(1024 * 1024);
-          traceStream.println(responseBody.string());
-        }
-        traceStream.println(END_HTTP);
-      }
-      return response;
-    }
-
-    String errorXml = null;
-    try (ResponseBody responseBody = response.body()) {
-      errorXml = responseBody.string();
-    }
-
-    if (!("".equals(errorXml) && method.equals(Method.HEAD))) {
-      traceBuilder.append(errorXml).append("\n");
-      if (traceStream != null) traceStream.println(errorXml);
-    }
-
-    traceBuilder.append(END_HTTP).append("\n");
-    if (traceStream != null) traceStream.println(END_HTTP);
-
-    // Error in case of Non-XML response from server for non-HEAD requests.
-    String contentType = response.headers().get("content-type");
-    if (!method.equals(Method.HEAD)
-        && (contentType == null
-            || !Arrays.asList(contentType.split(";")).contains("application/xml"))) {
-      throw new InvalidResponseException(
-          response.code(),
-          contentType,
-          errorXml.substring(0, errorXml.length() > 1024 ? 1024 : errorXml.length()),
-          traceBuilder.toString());
-    }
-
-    ErrorResponse errorResponse = null;
-    if (!"".equals(errorXml)) {
-      errorResponse = Xml.unmarshal(ErrorResponse.class, errorXml);
-    } else if (!method.equals(Method.HEAD)) {
-      throw new InvalidResponseException(
-          response.code(), contentType, errorXml, traceBuilder.toString());
-    }
-
-    if (errorResponse == null) {
-      String code = null;
-      String message = null;
-      switch (response.code()) {
-        case 301:
-        case 307:
-        case 400:
-          String[] result = handleRedirectResponse(method, bucketName, response, true);
-          code = result[0];
-          message = result[1];
-          break;
-        case 404:
-          if (objectName != null) {
-            code = "NoSuchKey";
-            message = "Object does not exist";
-          } else if (bucketName != null) {
-            code = NO_SUCH_BUCKET;
-            message = NO_SUCH_BUCKET_MESSAGE;
-          } else {
-            code = "ResourceNotFound";
-            message = "Request resource not found";
-          }
-          break;
-        case 501:
-        case 405:
-          code = "MethodNotAllowed";
-          message = "The specified method is not allowed against this resource";
-          break;
-        case 409:
-          if (bucketName != null) {
-            code = NO_SUCH_BUCKET;
-            message = NO_SUCH_BUCKET_MESSAGE;
-          } else {
-            code = "ResourceConflict";
-            message = "Request resource conflicts";
-          }
-          break;
-        case 403:
-          code = "AccessDenied";
-          message = "Access denied";
-          break;
-        case 412:
-          code = "PreconditionFailed";
-          message = "At least one of the preconditions you specified did not hold";
-          break;
-        case 416:
-          code = "InvalidRange";
-          message = "The requested range cannot be satisfied";
-          break;
-        default:
-          throw new ServerException(
-              "server failed with HTTP status code " + response.code(), traceBuilder.toString());
-      }
-
-      errorResponse =
-          new ErrorResponse(
-              code,
-              message,
-              bucketName,
-              objectName,
-              request.url().encodedPath(),
-              response.header("x-amz-request-id"),
-              response.header("x-amz-id-2"));
-    }
-
-    // invalidate region cache if needed
-    if (errorResponse.code().equals(NO_SUCH_BUCKET) || errorResponse.code().equals(RETRY_HEAD)) {
-      regionCache.remove(bucketName);
-    }
-
-    throw new ErrorResponseException(errorResponse, response, traceBuilder.toString());
-  }
-
   /** Returns region of given bucket either from region cache or set in constructor. */
-  protected String getRegion(String bucketName, String region)
-      throws ErrorResponseException, InsufficientDataException, InternalException,
-          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
-          ServerException, XmlParserException {
+  protected CompletableFuture<String> getRegionAsync(String bucketName, String region)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
     if (region != null) {
       // Error out if region does not match with region passed via constructor.
       if (this.region != null && !this.region.equals(region)) {
         throw new IllegalArgumentException(
             "region must be " + this.region + ", but passed " + region);
       }
-      return region;
+      return CompletableFuture.completedFuture(region);
     }
 
-    if (this.region != null && !this.region.equals("")) return this.region;
-    if (bucketName == null || this.provider == null) return US_EAST_1;
+    if (this.region != null && !this.region.equals("")) {
+      return CompletableFuture.completedFuture(this.region);
+    }
+    if (bucketName == null || this.provider == null) {
+      return CompletableFuture.completedFuture(US_EAST_1);
+    }
     region = regionCache.get(bucketName);
-    if (region != null) return region;
+    if (region != null) return CompletableFuture.completedFuture(region);
 
     // Execute GetBucketLocation REST API to get region of the bucket.
-    Response response =
-        execute(
+    CompletableFuture<Response> future =
+        executeAsync(
             Method.GET, bucketName, null, US_EAST_1, null, newMultimap("location", null), null, 0);
+    return future.thenApply(
+        response -> {
+          String location;
+          try (ResponseBody body = response.body()) {
+            LocationConstraint lc = Xml.unmarshal(LocationConstraint.class, body.charStream());
+            if (lc.location() == null || lc.location().equals("")) {
+              location = US_EAST_1;
+            } else if (lc.location().equals("EU")) {
+              location = "eu-west-1"; // eu-west-1 is also referred as 'EU'.
+            } else {
+              location = lc.location();
+            }
+          } catch (XmlParserException e) {
+            throw new CompletionException(e);
+          }
 
-    try (ResponseBody body = response.body()) {
-      LocationConstraint lc = Xml.unmarshal(LocationConstraint.class, body.charStream());
-      if (lc.location() == null || lc.location().equals("")) {
-        region = US_EAST_1;
-      } else if (lc.location().equals("EU")) {
-        region = "eu-west-1"; // eu-west-1 is also referred as 'EU'.
-      } else {
-        region = lc.location();
-      }
-    }
-
-    regionCache.put(bucketName, region);
-    return region;
+          regionCache.put(bucketName, location);
+          return location;
+        });
   }
 
-  /** Execute GET HTTP request for given parameters. */
+  /**
+   * Returns region of given bucket either from region cache or set in constructor.
+   *
+   * @deprecated This method is no longer supported. Use {@link #getRegionAsync}.
+   */
+  @Deprecated
+  protected String getRegion(String bucketName, String region)
+      throws ErrorResponseException, InsufficientDataException, InternalException,
+          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
+          ServerException, XmlParserException {
+    try {
+      return getRegionAsync(bucketName, region).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
+
+  /** Execute asynchronously GET HTTP request for given parameters. */
+  protected CompletableFuture<Response> executeGetAsync(
+      BaseArgs args, Multimap<String, String> headers, Multimap<String, String> queryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeAsync(Method.GET, args, headers, queryParams, null, 0);
+  }
+
+  /**
+   * Execute GET HTTP request for given parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executeGetAsync}.
+   */
+  @Deprecated
   protected Response executeGet(
       BaseArgs args, Multimap<String, String> headers, Multimap<String, String> queryParams)
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
           ServerException, XmlParserException {
-    return execute(Method.GET, args, headers, queryParams, null, 0);
+    try {
+      return executeGetAsync(args, headers, queryParams).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
   }
 
-  /** Execute HEAD HTTP request for given parameters. */
+  /** Execute asynchronously HEAD HTTP request for given parameters. */
+  protected CompletableFuture<Response> executeHeadAsync(
+      BaseArgs args, Multimap<String, String> headers, Multimap<String, String> queryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeAsync(Method.HEAD, args, headers, queryParams, null, 0)
+        .exceptionally(
+            e -> {
+              if (e instanceof ErrorResponseException) {
+                ErrorResponseException ex = (ErrorResponseException) e;
+                if (ex.errorResponse().code().equals(RETRY_HEAD)) {
+                  return null;
+                }
+              }
+              throw new CompletionException(e);
+            })
+        .thenCompose(
+            response -> {
+              if (response != null) {
+                return CompletableFuture.completedFuture(response);
+              }
+
+              try {
+                return executeAsync(Method.HEAD, args, headers, queryParams, null, 0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            });
+  }
+
+  /**
+   * Execute HEAD HTTP request for given parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executeHeadAsync}.
+   */
+  @Deprecated
   protected Response executeHead(
       BaseArgs args, Multimap<String, String> headers, Multimap<String, String> queryParams)
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
           ServerException, XmlParserException {
     try {
-      Response response = execute(Method.HEAD, args, headers, queryParams, null, 0);
-      response.body().close();
-      return response;
-    } catch (ErrorResponseException e) {
-      if (!e.errorResponse().code().equals(RETRY_HEAD)) {
-        throw e;
-      }
-    }
-
-    try {
-      // Retry once for RETRY_HEAD error.
-      Response response = execute(Method.HEAD, args, headers, queryParams, null, 0);
-      response.body().close();
-      return response;
-    } catch (ErrorResponseException e) {
-      ErrorResponse errorResponse = e.errorResponse();
-      if (!errorResponse.code().equals(RETRY_HEAD)) {
-        throw e;
-      }
-
-      String[] result =
-          handleRedirectResponse(Method.HEAD, errorResponse.bucketName(), e.response(), false);
-      throw new ErrorResponseException(
-          new ErrorResponse(
-              result[0],
-              result[1],
-              errorResponse.bucketName(),
-              errorResponse.objectName(),
-              errorResponse.resource(),
-              errorResponse.requestId(),
-              errorResponse.hostId()),
-          e.response(),
-          e.httpTrace());
+      return executeHeadAsync(args, headers, queryParams).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
   }
 
-  /** Execute DELETE HTTP request for given parameters. */
+  /** Execute asynchronously DELETE HTTP request for given parameters. */
+  protected CompletableFuture<Response> executeDeleteAsync(
+      BaseArgs args, Multimap<String, String> headers, Multimap<String, String> queryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeAsync(Method.DELETE, args, headers, queryParams, null, 0)
+        .thenApply(
+            response -> {
+              if (response != null) response.body().close();
+              return response;
+            });
+  }
+
+  /**
+   * Execute DELETE HTTP request for given parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executeDeleteAsync}.
+   */
+  @Deprecated
   protected Response executeDelete(
       BaseArgs args, Multimap<String, String> headers, Multimap<String, String> queryParams)
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
           ServerException, XmlParserException {
-    Response response = execute(Method.DELETE, args, headers, queryParams, null, 0);
-    response.body().close();
-    return response;
+    try {
+      return executeDeleteAsync(args, headers, queryParams).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
   }
 
-  /** Execute POST HTTP request for given parameters. */
+  /** Execute asynchronously POST HTTP request for given parameters. */
+  protected CompletableFuture<Response> executePostAsync(
+      BaseArgs args,
+      Multimap<String, String> headers,
+      Multimap<String, String> queryParams,
+      Object data)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeAsync(Method.POST, args, headers, queryParams, data, 0);
+  }
+
+  /**
+   * Execute POST HTTP request for given parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executePostAsync}.
+   */
+  @Deprecated
   protected Response executePost(
       BaseArgs args,
       Multimap<String, String> headers,
@@ -748,10 +1036,34 @@ public abstract class S3Base {
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
           ServerException, XmlParserException {
-    return execute(Method.POST, args, headers, queryParams, data, 0);
+    try {
+      return executePostAsync(args, headers, queryParams, data).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
   }
 
-  /** Execute PUT HTTP request for given parameters. */
+  /** Execute asynchronously PUT HTTP request for given parameters. */
+  protected CompletableFuture<Response> executePutAsync(
+      BaseArgs args,
+      Multimap<String, String> headers,
+      Multimap<String, String> queryParams,
+      Object data,
+      int length)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return executeAsync(Method.PUT, args, headers, queryParams, data, length);
+  }
+
+  /**
+   * Execute PUT HTTP request for given parameters.
+   *
+   * @deprecated This method is no longer supported. Use {@link #executePutAsync}.
+   */
+  @Deprecated
   protected Response executePut(
       BaseArgs args,
       Multimap<String, String> headers,
@@ -761,10 +1073,102 @@ public abstract class S3Base {
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
           ServerException, XmlParserException {
-    return execute(Method.PUT, args, headers, queryParams, data, length);
+    try {
+      return executePutAsync(args, headers, queryParams, data, length).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
+
+  protected CompletableFuture<Integer> calculatePartCountAsync(List<ComposeSource> sources)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    long[] objectSize = {0};
+    int index = 0;
+
+    CompletableFuture<Integer> completableFuture = CompletableFuture.supplyAsync(() -> 0);
+    for (ComposeSource src : sources) {
+      index++;
+      final int i = index;
+      completableFuture =
+          completableFuture.thenCombine(
+              statObjectAsync(new StatObjectArgs((ObjectReadArgs) src)),
+              (partCount, statObjectResponse) -> {
+                src.buildHeaders(statObjectResponse.size(), statObjectResponse.etag());
+
+                long size = statObjectResponse.size();
+                if (src.length() != null) {
+                  size = src.length();
+                } else if (src.offset() != null) {
+                  size -= src.offset();
+                }
+
+                if (size < ObjectWriteArgs.MIN_MULTIPART_SIZE
+                    && sources.size() != 1
+                    && i != sources.size()) {
+                  throw new IllegalArgumentException(
+                      "source "
+                          + src.bucket()
+                          + "/"
+                          + src.object()
+                          + ": size "
+                          + size
+                          + " must be greater than "
+                          + ObjectWriteArgs.MIN_MULTIPART_SIZE);
+                }
+
+                objectSize[0] += size;
+                if (objectSize[0] > ObjectWriteArgs.MAX_OBJECT_SIZE) {
+                  throw new IllegalArgumentException(
+                      "destination object size must be less than "
+                          + ObjectWriteArgs.MAX_OBJECT_SIZE);
+                }
+
+                if (size > ObjectWriteArgs.MAX_PART_SIZE) {
+                  long count = size / ObjectWriteArgs.MAX_PART_SIZE;
+                  long lastPartSize = size - (count * ObjectWriteArgs.MAX_PART_SIZE);
+                  if (lastPartSize > 0) {
+                    count++;
+                  } else {
+                    lastPartSize = ObjectWriteArgs.MAX_PART_SIZE;
+                  }
+
+                  if (lastPartSize < ObjectWriteArgs.MIN_MULTIPART_SIZE
+                      && sources.size() != 1
+                      && i != sources.size()) {
+                    throw new IllegalArgumentException(
+                        "source "
+                            + src.bucket()
+                            + "/"
+                            + src.object()
+                            + ": "
+                            + "for multipart split upload of "
+                            + size
+                            + ", last part size is less than "
+                            + ObjectWriteArgs.MIN_MULTIPART_SIZE);
+                  }
+                  partCount += (int) count;
+                } else {
+                  partCount++;
+                }
+
+                if (partCount > ObjectWriteArgs.MAX_MULTIPART_COUNT) {
+                  throw new IllegalArgumentException(
+                      "Compose sources create more than allowed multipart count "
+                          + ObjectWriteArgs.MAX_MULTIPART_COUNT);
+                }
+                return partCount;
+              });
+    }
+
+    return completableFuture;
   }
 
   /** Calculate part count of given compose sources. */
+  @Deprecated
   protected int calculatePartCount(List<ComposeSource> sources)
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
@@ -774,7 +1178,14 @@ public abstract class S3Base {
     int i = 0;
     for (ComposeSource src : sources) {
       i++;
-      StatObjectResponse stat = statObject(new StatObjectArgs((ObjectReadArgs) src));
+      StatObjectResponse stat = null;
+      try {
+        stat = statObjectAsync(new StatObjectArgs((ObjectReadArgs) src)).get();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } catch (ExecutionException e) {
+        throwEncapsulatedException(e);
+      }
 
       src.buildHeaders(stat.size(), stat.etag());
 
@@ -1073,7 +1484,7 @@ public abstract class S3Base {
     };
   }
 
-  private PartReader newPartReader(Object data, long objectSize, long partSize, int partCount) {
+  protected PartReader newPartReader(Object data, long objectSize, long partSize, int partCount) {
     if (data instanceof RandomAccessFile) {
       return new PartReader((RandomAccessFile) data, objectSize, partSize, partCount);
     }
@@ -1085,7 +1496,12 @@ public abstract class S3Base {
     return null;
   }
 
-  /** Execute put object. */
+  /**
+   * Execute put object.
+   *
+   * @deprecated This method is no longer supported. Use {@link #putObjectAsync}.
+   */
+  @Deprecated
   protected ObjectWriteResponse putObject(
       PutObjectBaseArgs args,
       Object data,
@@ -1096,74 +1512,13 @@ public abstract class S3Base {
       throws ErrorResponseException, InsufficientDataException, InternalException,
           InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
           ServerException, XmlParserException {
-    Multimap<String, String> headers = newMultimap(args.extraHeaders());
-    headers.putAll(args.genHeaders());
-    if (!headers.containsKey("Content-Type")) headers.put("Content-Type", contentType);
-
-    String uploadId = null;
-    Part[] parts = null;
-
-    PartReader partReader = newPartReader(data, objectSize, partSize, partCount);
-    if (partReader == null) {
-      throw new IllegalArgumentException("data must be RandomAccessFile or InputStream");
-    }
-
     try {
-      while (true) {
-        PartSource partSource = partReader.getPart(!this.baseUrl.isHttps());
-        if (partSource == null) break;
-
-        if (partReader.partCount() == 1) {
-          return putObject(
-              args.bucket(),
-              args.region(),
-              args.object(),
-              partSource,
-              headers,
-              args.extraQueryParams());
-        }
-
-        if (uploadId == null) {
-          CreateMultipartUploadResponse response =
-              createMultipartUpload(
-                  args.bucket(), args.region(), args.object(), headers, args.extraQueryParams());
-          uploadId = response.result().uploadId();
-          parts = new Part[ObjectWriteArgs.MAX_MULTIPART_COUNT];
-        }
-
-        Map<String, String> ssecHeaders = null;
-        // set encryption headers in the case of SSE-C.
-        if (args.sse() != null && args.sse() instanceof ServerSideEncryptionCustomerKey) {
-          ssecHeaders = args.sse().headers();
-        }
-
-        int partNumber = partSource.partNumber();
-        UploadPartResponse response =
-            uploadPart(
-                args.bucket(),
-                args.region(),
-                args.object(),
-                partSource,
-                partNumber,
-                uploadId,
-                (ssecHeaders != null) ? Multimaps.forMap(ssecHeaders) : null,
-                null);
-        String etag = response.etag();
-        parts[partNumber - 1] = new Part(partNumber, etag);
-      }
-
-      return completeMultipartUpload(
-          args.bucket(), args.region(), args.object(), uploadId, parts, null, null);
-    } catch (RuntimeException e) {
-      if (uploadId != null) {
-        abortMultipartUpload(args.bucket(), args.region(), args.object(), uploadId, null, null);
-      }
-      throw e;
-    } catch (Exception e) {
-      if (uploadId != null) {
-        abortMultipartUpload(args.bucket(), args.region(), args.object(), uploadId, null, null);
-      }
-      throw e;
+      return putObjectAsync(args, data, objectSize, partSize, partCount, contentType).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
   }
 
@@ -1364,19 +1719,81 @@ public abstract class S3Base {
     this.useVirtualStyle = false;
   }
 
-  /** Execute stat object. */
-  protected StatObjectResponse statObject(StatObjectArgs args)
-      throws ErrorResponseException, InsufficientDataException, InternalException,
-          InvalidKeyException, InvalidResponseException, IOException, NoSuchAlgorithmException,
-          ServerException, XmlParserException {
+  /** Execute stat object asynchronously. */
+  protected CompletableFuture<StatObjectResponse> statObjectAsync(StatObjectArgs args)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
     checkArgs(args);
     args.validateSsec(baseUrl);
-    Response response =
-        executeHead(
+    return executeHeadAsync(
             args,
             args.getHeaders(),
-            (args.versionId() != null) ? newMultimap("versionId", args.versionId()) : null);
-    return new StatObjectResponse(response.headers(), args.bucket(), args.region(), args.object());
+            (args.versionId() != null) ? newMultimap("versionId", args.versionId()) : null)
+        .thenApply(
+            response ->
+                new StatObjectResponse(
+                    response.headers(), args.bucket(), args.region(), args.object()));
+  }
+
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload
+   * S3 API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket.
+   * @param objectName Object name in the bucket.
+   * @param uploadId Upload ID.
+   * @param extraHeaders Extra headers (Optional).
+   * @param extraQueryParams Extra query parameters (Optional).
+   * @return {@link CompletableFuture}&lt;{@link AbortMultipartUploadResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<AbortMultipartUploadResponse> abortMultipartUploadAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      String uploadId,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.DELETE,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(extraHeaders),
+                    merge(extraQueryParams, newMultimap(UPLOAD_ID, uploadId)),
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                return new AbortMultipartUploadResponse(
+                    response.headers(), bucketName, region, objectName, uploadId);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1400,7 +1817,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #abortMultipartUploadAsync}.
    */
+  @Deprecated
   protected AbortMultipartUploadResponse abortMultipartUpload(
       String bucketName,
       String region,
@@ -1411,19 +1830,121 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    try (Response response =
-        execute(
-            Method.DELETE,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            merge(extraQueryParams, newMultimap(UPLOAD_ID, uploadId)),
-            null,
-            0)) {
-      return new AbortMultipartUploadResponse(
-          response.headers(), bucketName, region, objectName, uploadId);
+    try {
+      return abortMultipartUploadAsync(
+              bucketName, region, objectName, uploadId, extraHeaders, extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
+  }
+
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload
+   * S3 API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket.
+   * @param objectName Object name in the bucket.
+   * @param uploadId Upload ID.
+   * @param parts List of parts.
+   * @param extraHeaders Extra headers (Optional).
+   * @param extraQueryParams Extra query parameters (Optional).
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ObjectWriteResponse> completeMultipartUploadAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      String uploadId,
+      Part[] parts,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    Multimap<String, String> queryParams = newMultimap(extraQueryParams);
+    queryParams.put(UPLOAD_ID, uploadId);
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.POST,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(extraHeaders),
+                    queryParams,
+                    new CompleteMultipartUpload(parts),
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                String bodyContent = response.body().string();
+                bodyContent = bodyContent.trim();
+                if (!bodyContent.isEmpty()) {
+                  try {
+                    if (Xml.validate(ErrorResponse.class, bodyContent)) {
+                      ErrorResponse errorResponse = Xml.unmarshal(ErrorResponse.class, bodyContent);
+                      throw new CompletionException(
+                          new ErrorResponseException(errorResponse, response, null));
+                    }
+                  } catch (XmlParserException e) {
+                    // As it is not <Error> message, fallback to parse CompleteMultipartUploadOutput
+                    // XML.
+                  }
+
+                  try {
+                    CompleteMultipartUploadOutput result =
+                        Xml.unmarshal(CompleteMultipartUploadOutput.class, bodyContent);
+                    return new ObjectWriteResponse(
+                        response.headers(),
+                        result.bucket(),
+                        result.location(),
+                        result.object(),
+                        result.etag(),
+                        response.header("x-amz-version-id"));
+                  } catch (XmlParserException e) {
+                    // As this CompleteMultipartUpload REST call succeeded, just log it.
+                    Logger.getLogger(S3Base.class.getName())
+                        .warning(
+                            "S3 service returned unknown XML for CompleteMultipartUpload REST API. "
+                                + bodyContent);
+                  }
+                }
+
+                return new ObjectWriteResponse(
+                    response.headers(),
+                    bucketName,
+                    region,
+                    objectName,
+                    null,
+                    response.header("x-amz-version-id"));
+              } catch (IOException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1448,7 +1969,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #completeMultipartUploadAsync}.
    */
+  @Deprecated
   protected ObjectWriteResponse completeMultipartUpload(
       String bucketName,
       String region,
@@ -1460,58 +1983,89 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    Multimap<String, String> queryParams = newMultimap(extraQueryParams);
-    queryParams.put(UPLOAD_ID, uploadId);
-
-    try (Response response =
-        execute(
-            Method.POST,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            queryParams,
-            new CompleteMultipartUpload(parts),
-            0)) {
-      String bodyContent = response.body().string();
-      bodyContent = bodyContent.trim();
-      if (!bodyContent.isEmpty()) {
-        try {
-          if (Xml.validate(ErrorResponse.class, bodyContent)) {
-            ErrorResponse errorResponse = Xml.unmarshal(ErrorResponse.class, bodyContent);
-            throw new ErrorResponseException(errorResponse, response, null);
-          }
-        } catch (XmlParserException e) {
-          // As it is not <Error> message, fall-back to parse CompleteMultipartUploadOutput XML.
-        }
-
-        try {
-          CompleteMultipartUploadOutput result =
-              Xml.unmarshal(CompleteMultipartUploadOutput.class, bodyContent);
-          return new ObjectWriteResponse(
-              response.headers(),
-              result.bucket(),
-              result.location(),
-              result.object(),
-              result.etag(),
-              response.header("x-amz-version-id"));
-        } catch (XmlParserException e) {
-          // As this CompleteMultipartUpload REST call succeeded, just log it.
-          Logger.getLogger(MinioClient.class.getName())
-              .warning(
-                  "S3 service returned unknown XML for CompleteMultipartUpload REST API. "
-                      + bodyContent);
-        }
-      }
-
-      return new ObjectWriteResponse(
-          response.headers(),
-          bucketName,
-          region,
-          objectName,
-          null,
-          response.header("x-amz-version-id"));
+    try {
+      return completeMultipartUploadAsync(
+              bucketName, region, objectName, uploadId, parts, extraHeaders, extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
+  }
+
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload
+   * S3 API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region name of buckets in S3 service.
+   * @param objectName Object name in the bucket.
+   * @param headers Request headers.
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link CreateMultipartUploadResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<CreateMultipartUploadResponse> createMultipartUploadAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      Multimap<String, String> headers,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    Multimap<String, String> queryParams = newMultimap(extraQueryParams);
+    queryParams.put("uploads", "");
+
+    Multimap<String, String> headersCopy = newMultimap(headers);
+    // set content type if not set already
+    if (!headersCopy.containsKey("Content-Type")) {
+      headersCopy.put("Content-Type", "application/octet-stream");
+    }
+
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.POST,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(headersCopy),
+                    queryParams,
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                InitiateMultipartUploadResult result =
+                    Xml.unmarshal(
+                        InitiateMultipartUploadResult.class, response.body().charStream());
+                return new CreateMultipartUploadResponse(
+                    response.headers(), bucketName, region, objectName, result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1534,7 +2088,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #createMultipartUploadAsync}.
    */
+  @Deprecated
   protected CreateMultipartUploadResponse createMultipartUpload(
       String bucketName,
       String region,
@@ -1544,30 +2100,105 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    Multimap<String, String> queryParams = newMultimap(extraQueryParams);
-    queryParams.put("uploads", "");
+    try {
+      return createMultipartUploadAsync(bucketName, region, objectName, headers, extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
 
-    Multimap<String, String> headersCopy = newMultimap(headers);
-    // set content type if not set already
-    if (!headersCopy.containsKey("Content-Type")) {
-      headersCopy.put("Content-Type", "application/octet-stream");
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html">DeleteObjects S3
+   * API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param objectList List of object names.
+   * @param quiet Quiet flag.
+   * @param bypassGovernanceMode Bypass Governance retention mode.
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link DeleteObjectsResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<DeleteObjectsResponse> deleteObjectsAsync(
+      String bucketName,
+      String region,
+      List<DeleteObject> objectList,
+      boolean quiet,
+      boolean bypassGovernanceMode,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    if (objectList == null) objectList = new LinkedList<>();
+
+    if (objectList.size() > 1000) {
+      throw new IllegalArgumentException("list of objects must not be more than 1000");
     }
 
-    try (Response response =
-        execute(
-            Method.POST,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(headersCopy),
-            queryParams,
-            null,
-            0)) {
-      InitiateMultipartUploadResult result =
-          Xml.unmarshal(InitiateMultipartUploadResult.class, response.body().charStream());
-      return new CreateMultipartUploadResponse(
-          response.headers(), bucketName, region, objectName, result);
-    }
+    Multimap<String, String> headers =
+        merge(
+            extraHeaders,
+            bypassGovernanceMode ? newMultimap("x-amz-bypass-governance-retention", "true") : null);
+
+    final List<DeleteObject> objects = objectList;
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.POST,
+                    bucketName,
+                    null,
+                    location,
+                    httpHeaders(headers),
+                    merge(extraQueryParams, newMultimap("delete", "")),
+                    new DeleteRequest(objects, quiet),
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                String bodyContent = response.body().string();
+                try {
+                  if (Xml.validate(DeleteError.class, bodyContent)) {
+                    DeleteError error = Xml.unmarshal(DeleteError.class, bodyContent);
+                    DeleteResult result = new DeleteResult(error);
+                    return new DeleteObjectsResponse(
+                        response.headers(), bucketName, region, result);
+                  }
+                } catch (XmlParserException e) {
+                  // Ignore this exception as it is not <Error> message,
+                  // but parse it as <DeleteResult> message below.
+                }
+
+                DeleteResult result = Xml.unmarshal(DeleteResult.class, bodyContent);
+                return new DeleteObjectsResponse(response.headers(), bucketName, region, result);
+              } catch (IOException | XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1592,7 +2223,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #deleteObjectsAsync}.
    */
+  @Deprecated
   protected DeleteObjectsResponse deleteObjects(
       String bucketName,
       String region,
@@ -1604,41 +2237,107 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    if (objectList == null) objectList = new LinkedList<>();
-
-    if (objectList.size() > 1000) {
-      throw new IllegalArgumentException("list of objects must not be more than 1000");
+    try {
+      return deleteObjectsAsync(
+              bucketName,
+              region,
+              objectList,
+              quiet,
+              bypassGovernanceMode,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
+  }
 
-    Multimap<String, String> headers =
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects
+   * version 1 S3 API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param delimiter Delimiter (Optional).
+   * @param encodingType Encoding type (Optional).
+   * @param startAfter Fetch listing after this key (Optional).
+   * @param maxKeys Maximum object information to fetch (Optional).
+   * @param prefix Prefix (Optional).
+   * @param continuationToken Continuation token (Optional).
+   * @param fetchOwner Flag to fetch owner information (Optional).
+   * @param includeUserMetadata MinIO extension flag to include user metadata (Optional).
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link ListObjectsV2Response}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ListObjectsV2Response> listObjectsV2Async(
+      String bucketName,
+      String region,
+      String delimiter,
+      String encodingType,
+      String startAfter,
+      Integer maxKeys,
+      String prefix,
+      String continuationToken,
+      boolean fetchOwner,
+      boolean includeUserMetadata,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    Multimap<String, String> queryParams =
         merge(
-            extraHeaders,
-            bypassGovernanceMode ? newMultimap("x-amz-bypass-governance-retention", "true") : null);
-    try (Response response =
-        execute(
-            Method.POST,
-            bucketName,
-            null,
-            getRegion(bucketName, region),
-            httpHeaders(headers),
-            merge(extraQueryParams, newMultimap("delete", "")),
-            new DeleteRequest(objectList, quiet),
-            0)) {
-      String bodyContent = response.body().string();
-      try {
-        if (Xml.validate(DeleteError.class, bodyContent)) {
-          DeleteError error = Xml.unmarshal(DeleteError.class, bodyContent);
-          DeleteResult result = new DeleteResult(error);
-          return new DeleteObjectsResponse(response.headers(), bucketName, region, result);
-        }
-      } catch (XmlParserException e) {
-        // Ignore this exception as it is not <Error> message,
-        // but parse it as <DeleteResult> message below.
-      }
+            extraQueryParams,
+            getCommonListObjectsQueryParams(delimiter, encodingType, maxKeys, prefix));
+    queryParams.put("list-type", "2");
+    if (continuationToken != null) queryParams.put("continuation-token", continuationToken);
+    if (fetchOwner) queryParams.put("fetch-owner", "true");
+    if (startAfter != null) queryParams.put("start-after", startAfter);
+    if (includeUserMetadata) queryParams.put("metadata", "true");
 
-      DeleteResult result = Xml.unmarshal(DeleteResult.class, bodyContent);
-      return new DeleteObjectsResponse(response.headers(), bucketName, region, result);
-    }
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.GET,
+                    bucketName,
+                    null,
+                    location,
+                    httpHeaders(extraHeaders),
+                    queryParams,
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                ListBucketResultV2 result =
+                    Xml.unmarshal(ListBucketResultV2.class, response.body().charStream());
+                return new ListObjectsV2Response(response.headers(), bucketName, region, result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1667,7 +2366,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #listObjectsV2Async}.
    */
+  @Deprecated
   protected ListObjectsV2Response listObjectsV2(
       String bucketName,
       String region,
@@ -1684,30 +2385,102 @@ public abstract class S3Base {
       throws InvalidKeyException, NoSuchAlgorithmException, InsufficientDataException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException, IOException {
+    try {
+      return listObjectsV2Async(
+              bucketName,
+              region,
+              delimiter,
+              encodingType,
+              startAfter,
+              maxKeys,
+              prefix,
+              continuationToken,
+              fetchOwner,
+              includeUserMetadata,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
+
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects
+   * version 1 S3 API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param delimiter Delimiter (Optional).
+   * @param encodingType Encoding type (Optional).
+   * @param marker Marker (Optional).
+   * @param maxKeys Maximum object information to fetch (Optional).
+   * @param prefix Prefix (Optional).
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link ListObjectsV1Response}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ListObjectsV1Response> listObjectsV1Async(
+      String bucketName,
+      String region,
+      String delimiter,
+      String encodingType,
+      String marker,
+      Integer maxKeys,
+      String prefix,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
     Multimap<String, String> queryParams =
         merge(
             extraQueryParams,
             getCommonListObjectsQueryParams(delimiter, encodingType, maxKeys, prefix));
-    queryParams.put("list-type", "2");
-    if (continuationToken != null) queryParams.put("continuation-token", continuationToken);
-    if (fetchOwner) queryParams.put("fetch-owner", "true");
-    if (startAfter != null) queryParams.put("start-after", startAfter);
-    if (includeUserMetadata) queryParams.put("metadata", "true");
+    if (marker != null) queryParams.put("marker", marker);
 
-    try (Response response =
-        execute(
-            Method.GET,
-            bucketName,
-            null,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            queryParams,
-            null,
-            0)) {
-      ListBucketResultV2 result =
-          Xml.unmarshal(ListBucketResultV2.class, response.body().charStream());
-      return new ListObjectsV2Response(response.headers(), bucketName, region, result);
-    }
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.GET,
+                    bucketName,
+                    null,
+                    location,
+                    httpHeaders(extraHeaders),
+                    queryParams,
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                ListBucketResultV1 result =
+                    Xml.unmarshal(ListBucketResultV1.class, response.body().charStream());
+                return new ListObjectsV1Response(response.headers(), bucketName, region, result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1733,7 +2506,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #listObjectsV1Async}.
    */
+  @Deprecated
   protected ListObjectsV1Response listObjectsV1(
       String bucketName,
       String region,
@@ -1747,26 +2522,105 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
+    try {
+      return listObjectsV1Async(
+              bucketName,
+              region,
+              delimiter,
+              encodingType,
+              marker,
+              maxKeys,
+              prefix,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
+
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html">ListObjectVersions
+   * API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param delimiter Delimiter (Optional).
+   * @param encodingType Encoding type (Optional).
+   * @param keyMarker Key marker (Optional).
+   * @param maxKeys Maximum object information to fetch (Optional).
+   * @param prefix Prefix (Optional).
+   * @param versionIdMarker Version ID marker (Optional).
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link ListObjectVersionsResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ListObjectVersionsResponse> listObjectVersionsAsync(
+      String bucketName,
+      String region,
+      String delimiter,
+      String encodingType,
+      String keyMarker,
+      Integer maxKeys,
+      String prefix,
+      String versionIdMarker,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
     Multimap<String, String> queryParams =
         merge(
             extraQueryParams,
             getCommonListObjectsQueryParams(delimiter, encodingType, maxKeys, prefix));
-    if (marker != null) queryParams.put("marker", marker);
+    if (keyMarker != null) queryParams.put("key-marker", keyMarker);
+    if (versionIdMarker != null) queryParams.put("version-id-marker", versionIdMarker);
+    queryParams.put("versions", "");
 
-    try (Response response =
-        execute(
-            Method.GET,
-            bucketName,
-            null,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            queryParams,
-            null,
-            0)) {
-      ListBucketResultV1 result =
-          Xml.unmarshal(ListBucketResultV1.class, response.body().charStream());
-      return new ListObjectsV1Response(response.headers(), bucketName, region, result);
-    }
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.GET,
+                    bucketName,
+                    null,
+                    location,
+                    httpHeaders(extraHeaders),
+                    queryParams,
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                ListVersionsResult result =
+                    Xml.unmarshal(ListVersionsResult.class, response.body().charStream());
+                return new ListObjectVersionsResponse(
+                    response.headers(), bucketName, region, result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1794,7 +2648,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #listObjectVersionsAsync}.
    */
+  @Deprecated
   protected ListObjectVersionsResponse listObjectVersions(
       String bucketName,
       String region,
@@ -1809,58 +2665,351 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    Multimap<String, String> queryParams =
-        merge(
-            extraQueryParams,
-            getCommonListObjectsQueryParams(delimiter, encodingType, maxKeys, prefix));
-    if (keyMarker != null) queryParams.put("key-marker", keyMarker);
-    if (versionIdMarker != null) queryParams.put("version-id-marker", versionIdMarker);
-    queryParams.put("versions", "");
-
-    try (Response response =
-        execute(
-            Method.GET,
-            bucketName,
-            null,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            queryParams,
-            null,
-            0)) {
-      ListVersionsResult result =
-          Xml.unmarshal(ListVersionsResult.class, response.body().charStream());
-      return new ListObjectVersionsResponse(response.headers(), bucketName, region, result);
+    try {
+      return listObjectVersionsAsync(
+              bucketName,
+              region,
+              delimiter,
+              encodingType,
+              keyMarker,
+              maxKeys,
+              prefix,
+              versionIdMarker,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
   }
 
-  private ObjectWriteResponse putObject(
+  private Part[] uploadParts(
+      PutObjectBaseArgs args, String uploadId, PartReader partReader, PartSource firstPartSource)
+      throws InterruptedException, ExecutionException, InsufficientDataException, InternalException,
+          InvalidKeyException, IOException, NoSuchAlgorithmException, XmlParserException {
+    Part[] parts = new Part[ObjectWriteArgs.MAX_MULTIPART_COUNT];
+    int partNumber = 0;
+    PartSource partSource = firstPartSource;
+    while (true) {
+      partNumber++;
+
+      Multimap<String, String> ssecHeaders = null;
+      // set encryption headers in the case of SSE-C.
+      if (args.sse() != null && args.sse() instanceof ServerSideEncryptionCustomerKey) {
+        ssecHeaders = Multimaps.forMap(args.sse().headers());
+      }
+
+      UploadPartResponse response =
+          uploadPartAsync(
+                  args.bucket(),
+                  args.region(),
+                  args.object(),
+                  partSource,
+                  partNumber,
+                  uploadId,
+                  ssecHeaders,
+                  null)
+              .get();
+      parts[partNumber - 1] = new Part(partNumber, response.etag());
+
+      partSource = partReader.getPart(!this.baseUrl.isHttps());
+      if (partSource == null) break;
+    }
+
+    return parts;
+  }
+
+  private CompletableFuture<ObjectWriteResponse> putMultipartObjectAsync(
+      PutObjectBaseArgs args,
+      Multimap<String, String> headers,
+      PartReader partReader,
+      PartSource firstPartSource)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          String uploadId = null;
+          ObjectWriteResponse response = null;
+          try {
+            CreateMultipartUploadResponse createMultipartUploadResponse =
+                createMultipartUploadAsync(
+                        args.bucket(),
+                        args.region(),
+                        args.object(),
+                        headers,
+                        args.extraQueryParams())
+                    .get();
+            uploadId = createMultipartUploadResponse.result().uploadId();
+            Part[] parts = uploadParts(args, uploadId, partReader, firstPartSource);
+            response =
+                completeMultipartUploadAsync(
+                        args.bucket(), args.region(), args.object(), uploadId, parts, null, null)
+                    .get();
+          } catch (InsufficientDataException
+              | InternalException
+              | InvalidKeyException
+              | IOException
+              | NoSuchAlgorithmException
+              | XmlParserException
+              | InterruptedException
+              | ExecutionException e) {
+            if (uploadId == null) {
+              Throwable throwable = e;
+              if (throwable instanceof ExecutionException) {
+                throwable = ((ExecutionException) throwable).getCause();
+              }
+              if (throwable instanceof CompletionException) {
+                throwable = ((CompletionException) throwable).getCause();
+              }
+              throw new CompletionException(throwable);
+            }
+            try {
+              abortMultipartUploadAsync(
+                      args.bucket(), args.region(), args.object(), uploadId, null, null)
+                  .get();
+            } catch (InsufficientDataException
+                | InternalException
+                | InvalidKeyException
+                | IOException
+                | NoSuchAlgorithmException
+                | XmlParserException
+                | InterruptedException
+                | ExecutionException ex) {
+              Throwable throwable = ex;
+              if (throwable instanceof ExecutionException) {
+                throwable = ((ExecutionException) throwable).getCause();
+              }
+              if (throwable instanceof CompletionException) {
+                throwable = ((CompletionException) throwable).getCause();
+              }
+              throw new CompletionException(throwable);
+            }
+          }
+          return response;
+        });
+  }
+
+  /**
+   * Execute put object asynchronously from object data from {@link RandomAccessFile} or {@link
+   * InputStream}.
+   *
+   * @param args {@link PutObjectBaseArgs}.
+   * @param data {@link RandomAccessFile} or {@link InputStream}.
+   * @param objectSize object size.
+   * @param partSize part size for multipart upload.
+   * @param partCount Number of parts for multipart upload.
+   * @param contentType content-type of object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ObjectWriteResponse> putObjectAsync(
+      PutObjectBaseArgs args,
+      Object data,
+      long objectSize,
+      long partSize,
+      int partCount,
+      String contentType)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    PartReader partReader = newPartReader(data, objectSize, partSize, partCount);
+    if (partReader == null) {
+      throw new IllegalArgumentException("data must be RandomAccessFile or InputStream");
+    }
+
+    Multimap<String, String> headers = newMultimap(args.extraHeaders());
+    headers.putAll(args.genHeaders());
+    if (!headers.containsKey("Content-Type")) headers.put("Content-Type", contentType);
+
+    return CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                return partReader.getPart(!this.baseUrl.isHttps());
+              } catch (NoSuchAlgorithmException | IOException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenCompose(
+            partSource -> {
+              try {
+                if (partReader.partCount() == 1) {
+                  return putObjectAsync(
+                      args.bucket(),
+                      args.region(),
+                      args.object(),
+                      partSource,
+                      headers,
+                      args.extraQueryParams());
+                } else {
+                  return putMultipartObjectAsync(args, headers, partReader, partSource);
+                }
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            });
+  }
+
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject S3
+   * API</a> for {@link PartSource} asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param objectName Object name in the bucket.
+   * @param partSource PartSource object.
+   * @param headers Additional headers.
+   * @param extraQueryParams Additional query parameters if any.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  private CompletableFuture<ObjectWriteResponse> putObjectAsync(
       String bucketName,
       String region,
       String objectName,
       PartSource partSource,
       Multimap<String, String> headers,
       Multimap<String, String> extraQueryParams)
-      throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
-          ServerException, XmlParserException, ErrorResponseException, InternalException,
-          InvalidResponseException {
-    try (Response response =
-        execute(
-            Method.PUT,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(headers),
-            extraQueryParams,
-            partSource,
-            0)) {
-      return new ObjectWriteResponse(
-          response.headers(),
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.PUT,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(headers),
+                    extraQueryParams,
+                    partSource,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                return new ObjectWriteResponse(
+                    response.headers(),
+                    bucketName,
+                    region,
+                    objectName,
+                    response.header("ETag").replaceAll("\"", ""),
+                    response.header("x-amz-version-id"));
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject S3
+   * API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param objectName Object name in the bucket.
+   * @param data Object data must be InputStream, RandomAccessFile, byte[] or String.
+   * @param length Length of object data.
+   * @param headers Additional headers.
+   * @param extraQueryParams Additional query parameters if any.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ObjectWriteResponse> putObjectAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      Object data,
+      long length,
+      Multimap<String, String> headers,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    if (!(data instanceof InputStream
+        || data instanceof RandomAccessFile
+        || data instanceof byte[]
+        || data instanceof CharSequence)) {
+      throw new IllegalArgumentException(
+          "data must be InputStream, RandomAccessFile, byte[] or String");
+    }
+
+    PartReader partReader = newPartReader(data, length, length, 1);
+
+    if (partReader != null) {
+      return putObjectAsync(
           bucketName,
           region,
           objectName,
-          response.header("ETag").replaceAll("\"", ""),
-          response.header("x-amz-version-id"));
+          partReader.getPart(!this.baseUrl.isHttps()),
+          headers,
+          extraQueryParams);
     }
+
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.PUT,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(headers),
+                    extraQueryParams,
+                    data,
+                    (int) length);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                return new ObjectWriteResponse(
+                    response.headers(),
+                    bucketName,
+                    region,
+                    objectName,
+                    response.header("ETag").replaceAll("\"", ""),
+                    response.header("x-amz-version-id"));
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1883,7 +3032,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #putObjectAsync}.
    */
+  @Deprecated
   protected ObjectWriteResponse putObject(
       String bucketName,
       String region,
@@ -1895,44 +3046,104 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    if (!(data instanceof InputStream
-        || data instanceof RandomAccessFile
-        || data instanceof byte[]
-        || data instanceof CharSequence)) {
-      throw new IllegalArgumentException(
-          "data must be InputStream, RandomAccessFile, byte[] or String");
+    try {
+      return putObjectAsync(bucketName, region, objectName, data, length, headers, extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
+  }
 
-    PartReader partReader = newPartReader(data, length, length, 1);
-
-    if (partReader != null) {
-      return putObject(
-          bucketName,
-          region,
-          objectName,
-          partReader.getPart(!this.baseUrl.isHttps()),
-          headers,
-          extraQueryParams);
-    }
-
-    try (Response response =
-        execute(
-            Method.PUT,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(headers),
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads
+   * S3 API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param delimiter Delimiter (Optional).
+   * @param encodingType Encoding type (Optional).
+   * @param keyMarker Key marker (Optional).
+   * @param maxUploads Maximum upload information to fetch (Optional).
+   * @param prefix Prefix (Optional).
+   * @param uploadIdMarker Upload ID marker (Optional).
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link ListMultipartUploadsResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ListMultipartUploadsResponse> listMultipartUploadsAsync(
+      String bucketName,
+      String region,
+      String delimiter,
+      String encodingType,
+      String keyMarker,
+      Integer maxUploads,
+      String prefix,
+      String uploadIdMarker,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    Multimap<String, String> queryParams =
+        merge(
             extraQueryParams,
-            data,
-            (int) length)) {
-      return new ObjectWriteResponse(
-          response.headers(),
-          bucketName,
-          region,
-          objectName,
-          response.header("ETag").replaceAll("\"", ""),
-          response.header("x-amz-version-id"));
-    }
+            newMultimap(
+                "uploads",
+                "",
+                "delimiter",
+                (delimiter != null) ? delimiter : "",
+                "max-uploads",
+                (maxUploads != null) ? maxUploads.toString() : "1000",
+                "prefix",
+                (prefix != null) ? prefix : ""));
+    if (encodingType != null) queryParams.put("encoding-type", encodingType);
+    if (keyMarker != null) queryParams.put("key-marker", keyMarker);
+    if (uploadIdMarker != null) queryParams.put("upload-id-marker", uploadIdMarker);
+
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.GET,
+                    bucketName,
+                    null,
+                    location,
+                    httpHeaders(extraHeaders),
+                    queryParams,
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                ListMultipartUploadsResult result =
+                    Xml.unmarshal(ListMultipartUploadsResult.class, response.body().charStream());
+                return new ListMultipartUploadsResponse(
+                    response.headers(), bucketName, region, result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -1960,7 +3171,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #listMultipartUploadsAsync}.
    */
+  @Deprecated
   protected ListMultipartUploadsResponse listMultipartUploads(
       String bucketName,
       String region,
@@ -1975,36 +3188,105 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
+    try {
+      return listMultipartUploadsAsync(
+              bucketName,
+              region,
+              delimiter,
+              encodingType,
+              keyMarker,
+              maxUploads,
+              prefix,
+              uploadIdMarker,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
+    }
+  }
+
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts S3
+   * API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Name of the bucket (Optional).
+   * @param objectName Object name in the bucket.
+   * @param maxParts Maximum parts information to fetch (Optional).
+   * @param partNumberMarker Part number marker (Optional).
+   * @param uploadId Upload ID.
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link ListPartsResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<ListPartsResponse> listPartsAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      Integer maxParts,
+      Integer partNumberMarker,
+      String uploadId,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
     Multimap<String, String> queryParams =
         merge(
             extraQueryParams,
             newMultimap(
-                "uploads",
-                "",
-                "delimiter",
-                (delimiter != null) ? delimiter : "",
-                "max-uploads",
-                (maxUploads != null) ? maxUploads.toString() : "1000",
-                "prefix",
-                (prefix != null) ? prefix : ""));
-    if (encodingType != null) queryParams.put("encoding-type", encodingType);
-    if (keyMarker != null) queryParams.put("key-marker", keyMarker);
-    if (uploadIdMarker != null) queryParams.put("upload-id-marker", uploadIdMarker);
-
-    try (Response response =
-        execute(
-            Method.GET,
-            bucketName,
-            null,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            queryParams,
-            null,
-            0)) {
-      ListMultipartUploadsResult result =
-          Xml.unmarshal(ListMultipartUploadsResult.class, response.body().charStream());
-      return new ListMultipartUploadsResponse(response.headers(), bucketName, region, result);
+                UPLOAD_ID,
+                uploadId,
+                "max-parts",
+                (maxParts != null) ? maxParts.toString() : "1000"));
+    if (partNumberMarker != null) {
+      queryParams.put("part-number-marker", partNumberMarker.toString());
     }
+
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.GET,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(extraHeaders),
+                    queryParams,
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                ListPartsResult result =
+                    Xml.unmarshal(ListPartsResult.class, response.body().charStream());
+                return new ListPartsResponse(
+                    response.headers(), bucketName, region, objectName, result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -2029,7 +3311,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #listPartsAsync}.
    */
+  @Deprecated
   protected ListPartsResponse listParts(
       String bucketName,
       String region,
@@ -2042,34 +3326,46 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    Multimap<String, String> queryParams =
-        merge(
-            extraQueryParams,
-            newMultimap(
-                UPLOAD_ID,
-                uploadId,
-                "max-parts",
-                (maxParts != null) ? maxParts.toString() : "1000"));
-    if (partNumberMarker != null) {
-      queryParams.put("part-number-marker", partNumberMarker.toString());
-    }
-
-    try (Response response =
-        execute(
-            Method.GET,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            queryParams,
-            null,
-            0)) {
-      ListPartsResult result = Xml.unmarshal(ListPartsResult.class, response.body().charStream());
-      return new ListPartsResponse(response.headers(), bucketName, region, objectName, result);
+    try {
+      return listPartsAsync(
+              bucketName,
+              region,
+              objectName,
+              maxParts,
+              partNumberMarker,
+              uploadId,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
   }
 
-  private UploadPartResponse uploadPart(
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart S3
+   * API</a> for PartSource asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param objectName Object name in the bucket.
+   * @param partSource PartSource Object.
+   * @param partNumber Part number.
+   * @param uploadId Upload ID.
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link UploadPartResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<UploadPartResponse> uploadPartAsync(
       String bucketName,
       String region,
       String objectName,
@@ -2078,30 +3374,145 @@ public abstract class S3Base {
       String uploadId,
       Multimap<String, String> extraHeaders,
       Multimap<String, String> extraQueryParams)
-      throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
-          ServerException, XmlParserException, ErrorResponseException, InternalException,
-          InvalidResponseException {
-    try (Response response =
-        execute(
-            Method.PUT,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            merge(
-                extraQueryParams,
-                newMultimap("partNumber", Integer.toString(partNumber), UPLOAD_ID, uploadId)),
-            partSource,
-            0)) {
-      return new UploadPartResponse(
-          response.headers(),
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.PUT,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(extraHeaders),
+                    merge(
+                        extraQueryParams,
+                        newMultimap(
+                            "partNumber", Integer.toString(partNumber), UPLOAD_ID, uploadId)),
+                    partSource,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                return new UploadPartResponse(
+                    response.headers(),
+                    bucketName,
+                    region,
+                    objectName,
+                    uploadId,
+                    partNumber,
+                    response.header("ETag").replaceAll("\"", ""));
+              } finally {
+                response.close();
+              }
+            });
+  }
+
+  /**
+   * Do <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart S3
+   * API</a> asynchronously.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param objectName Object name in the bucket.
+   * @param data Object data must be InputStream, RandomAccessFile, byte[] or String.
+   * @param length Length of object data.
+   * @param uploadId Upload ID.
+   * @param partNumber Part number.
+   * @param extraHeaders Extra headers for request (Optional).
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link UploadPartResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<UploadPartResponse> uploadPartAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      Object data,
+      long length,
+      String uploadId,
+      int partNumber,
+      Multimap<String, String> extraHeaders,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    if (!(data instanceof InputStream
+        || data instanceof RandomAccessFile
+        || data instanceof byte[]
+        || data instanceof CharSequence)) {
+      throw new IllegalArgumentException(
+          "data must be InputStream, RandomAccessFile, byte[] or String");
+    }
+
+    PartReader partReader = newPartReader(data, length, length, 1);
+
+    if (partReader != null) {
+      return uploadPartAsync(
           bucketName,
           region,
           objectName,
-          uploadId,
+          partReader.getPart(!this.baseUrl.isHttps()),
           partNumber,
-          response.header("ETag").replaceAll("\"", ""));
+          uploadId,
+          extraHeaders,
+          extraQueryParams);
     }
+
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.PUT,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(extraHeaders),
+                    merge(
+                        extraQueryParams,
+                        newMultimap(
+                            "partNumber", Integer.toString(partNumber), UPLOAD_ID, uploadId)),
+                    data,
+                    (int) length);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                return new UploadPartResponse(
+                    response.headers(),
+                    bucketName,
+                    region,
+                    objectName,
+                    uploadId,
+                    partNumber,
+                    response.header("ETag").replaceAll("\"", ""));
+              } finally {
+                response.close();
+              }
+            });
   }
 
   /**
@@ -2117,7 +3528,7 @@ public abstract class S3Base {
    * @param partNumber Part number.
    * @param extraHeaders Extra headers for request (Optional).
    * @param extraQueryParams Extra query parameters for request (Optional).
-   * @return String - Contains ETag.
+   * @return {@link UploadPartResponse} object.
    * @throws ErrorResponseException thrown to indicate S3 service returned an error response.
    * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
    * @throws InternalException thrown to indicate internal library error.
@@ -2127,7 +3538,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #uploadPartAsync}.
    */
+  @Deprecated
   protected UploadPartResponse uploadPart(
       String bucketName,
       String region,
@@ -2141,48 +3554,23 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    if (!(data instanceof InputStream
-        || data instanceof RandomAccessFile
-        || data instanceof byte[]
-        || data instanceof CharSequence)) {
-      throw new IllegalArgumentException(
-          "data must be InputStream, RandomAccessFile, byte[] or String");
-    }
-
-    PartReader partReader = newPartReader(data, length, length, 1);
-
-    if (partReader != null) {
-      return uploadPart(
-          bucketName,
-          region,
-          objectName,
-          partReader.getPart(!this.baseUrl.isHttps()),
-          partNumber,
-          uploadId,
-          extraHeaders,
-          extraQueryParams);
-    }
-
-    try (Response response =
-        execute(
-            Method.PUT,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(extraHeaders),
-            merge(
-                extraQueryParams,
-                newMultimap("partNumber", Integer.toString(partNumber), UPLOAD_ID, uploadId)),
-            data,
-            (int) length)) {
-      return new UploadPartResponse(
-          response.headers(),
-          bucketName,
-          region,
-          objectName,
-          uploadId,
-          partNumber,
-          response.header("ETag").replaceAll("\"", ""));
+    try {
+      return uploadPartAsync(
+              bucketName,
+              region,
+              objectName,
+              data,
+              length,
+              uploadId,
+              partNumber,
+              extraHeaders,
+              extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
   }
 
@@ -2208,7 +3596,9 @@ public abstract class S3Base {
    * @throws IOException thrown to indicate I/O error on S3 operation.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws XmlParserException thrown to indicate XML parsing error.
+   * @deprecated This method is no longer supported. Use {@link #uploadPartCopyAsync}.
    */
+  @Deprecated
   protected UploadPartCopyResponse uploadPartCopy(
       String bucketName,
       String region,
@@ -2220,21 +3610,91 @@ public abstract class S3Base {
       throws NoSuchAlgorithmException, InsufficientDataException, IOException, InvalidKeyException,
           ServerException, XmlParserException, ErrorResponseException, InternalException,
           InvalidResponseException {
-    try (Response response =
-        execute(
-            Method.PUT,
-            bucketName,
-            objectName,
-            getRegion(bucketName, region),
-            httpHeaders(headers),
-            merge(
-                extraQueryParams,
-                newMultimap("partNumber", Integer.toString(partNumber), "uploadId", uploadId)),
-            null,
-            0)) {
-      CopyPartResult result = Xml.unmarshal(CopyPartResult.class, response.body().charStream());
-      return new UploadPartCopyResponse(
-          response.headers(), bucketName, region, objectName, uploadId, partNumber, result);
+    try {
+      return uploadPartCopyAsync(
+              bucketName, region, objectName, uploadId, partNumber, headers, extraQueryParams)
+          .get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throwEncapsulatedException(e);
+      return null;
     }
+  }
+
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy
+   * S3 API</a>.
+   *
+   * @param bucketName Name of the bucket.
+   * @param region Region of the bucket (Optional).
+   * @param objectName Object name in the bucket.
+   * @param uploadId Upload ID.
+   * @param partNumber Part number.
+   * @param headers Request headers with source object definitions.
+   * @param extraQueryParams Extra query parameters for request (Optional).
+   * @return {@link CompletableFuture}&lt;{@link UploadPartCopyResponse}&gt; object.
+   * @throws InsufficientDataException thrown to indicate not enough data available in InputStream.
+   * @throws InternalException thrown to indicate internal library error.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on S3 operation.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws XmlParserException thrown to indicate XML parsing error.
+   */
+  protected CompletableFuture<UploadPartCopyResponse> uploadPartCopyAsync(
+      String bucketName,
+      String region,
+      String objectName,
+      String uploadId,
+      int partNumber,
+      Multimap<String, String> headers,
+      Multimap<String, String> extraQueryParams)
+      throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
+          NoSuchAlgorithmException, XmlParserException {
+    return getRegionAsync(bucketName, region)
+        .thenCompose(
+            location -> {
+              try {
+                return executeAsync(
+                    Method.PUT,
+                    bucketName,
+                    objectName,
+                    location,
+                    httpHeaders(headers),
+                    merge(
+                        extraQueryParams,
+                        newMultimap(
+                            "partNumber", Integer.toString(partNumber), "uploadId", uploadId)),
+                    null,
+                    0);
+              } catch (InsufficientDataException
+                  | InternalException
+                  | InvalidKeyException
+                  | IOException
+                  | NoSuchAlgorithmException
+                  | XmlParserException e) {
+                throw new CompletionException(e);
+              }
+            })
+        .thenApply(
+            response -> {
+              try {
+                CopyPartResult result =
+                    Xml.unmarshal(CopyPartResult.class, response.body().charStream());
+                return new UploadPartCopyResponse(
+                    response.headers(),
+                    bucketName,
+                    region,
+                    objectName,
+                    uploadId,
+                    partNumber,
+                    result);
+              } catch (XmlParserException e) {
+                throw new CompletionException(e);
+              } finally {
+                response.close();
+              }
+            });
   }
 }

--- a/api/src/main/java/io/minio/SelectObjectContentArgs.java
+++ b/api/src/main/java/io/minio/SelectObjectContentArgs.java
@@ -21,7 +21,10 @@ import io.minio.messages.InputSerialization;
 import io.minio.messages.OutputSerialization;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#selectObjectContent}. */
+/**
+ * Argument class of {@link MinioAsyncClient#selectObjectContent} and {@link
+ * MinioClient#selectObjectContent}.
+ */
 public class SelectObjectContentArgs extends ObjectReadArgs {
   private String sqlExpression;
   private InputSerialization inputSerialization;

--- a/api/src/main/java/io/minio/SetBucketEncryptionArgs.java
+++ b/api/src/main/java/io/minio/SetBucketEncryptionArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.SseConfiguration;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketEncryption}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketEncryption} and {@link
+ * MinioClient#setBucketEncryption}.
+ */
 public class SetBucketEncryptionArgs extends BucketArgs {
   private SseConfiguration config;
 

--- a/api/src/main/java/io/minio/SetBucketLifecycleArgs.java
+++ b/api/src/main/java/io/minio/SetBucketLifecycleArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.LifecycleConfiguration;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketLifecycle}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketLifecycle} and {@link
+ * MinioClient#setBucketLifecycle}.
+ */
 public class SetBucketLifecycleArgs extends BucketArgs {
   private LifecycleConfiguration config;
 

--- a/api/src/main/java/io/minio/SetBucketNotificationArgs.java
+++ b/api/src/main/java/io/minio/SetBucketNotificationArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.NotificationConfiguration;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketNotification}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketNotification} and {@link
+ * MinioClient#setBucketNotification}.
+ */
 public class SetBucketNotificationArgs extends BucketArgs {
   private NotificationConfiguration config;
 

--- a/api/src/main/java/io/minio/SetBucketPolicyArgs.java
+++ b/api/src/main/java/io/minio/SetBucketPolicyArgs.java
@@ -18,7 +18,10 @@ package io.minio;
 
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketPolicy}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketPolicy} and {@link
+ * MinioClient#setBucketPolicy}.
+ */
 public class SetBucketPolicyArgs extends BucketArgs {
   private String config;
 

--- a/api/src/main/java/io/minio/SetBucketReplicationArgs.java
+++ b/api/src/main/java/io/minio/SetBucketReplicationArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.ReplicationConfiguration;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketReplication}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketReplication} and {@link
+ * MinioClient#setBucketReplication}.
+ */
 public class SetBucketReplicationArgs extends BucketArgs {
   private ReplicationConfiguration config;
   private String objectLockToken;

--- a/api/src/main/java/io/minio/SetBucketTagsArgs.java
+++ b/api/src/main/java/io/minio/SetBucketTagsArgs.java
@@ -20,7 +20,9 @@ import io.minio.messages.Tags;
 import java.util.Map;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketTags}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketTags} and {@link MinioClient#setBucketTags}.
+ */
 public class SetBucketTagsArgs extends BucketArgs {
   private Tags tags;
 

--- a/api/src/main/java/io/minio/SetBucketVersioningArgs.java
+++ b/api/src/main/java/io/minio/SetBucketVersioningArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.VersioningConfiguration;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setBucketVersioning}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setBucketVersioning} and {@link
+ * MinioClient#setBucketVersioning}.
+ */
 public class SetBucketVersioningArgs extends BucketArgs {
   private VersioningConfiguration config;
 

--- a/api/src/main/java/io/minio/SetObjectLockConfigurationArgs.java
+++ b/api/src/main/java/io/minio/SetObjectLockConfigurationArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.ObjectLockConfiguration;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setObjectLockConfiguration}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setObjectLockConfiguration} and {@link
+ * MinioClient#setObjectLockConfiguration}.
+ */
 public class SetObjectLockConfigurationArgs extends BucketArgs {
   private ObjectLockConfiguration config;
 

--- a/api/src/main/java/io/minio/SetObjectRetentionArgs.java
+++ b/api/src/main/java/io/minio/SetObjectRetentionArgs.java
@@ -19,7 +19,10 @@ package io.minio;
 import io.minio.messages.Retention;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setObjectRetention}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setObjectRetention} and {@link
+ * MinioClient#setObjectRetention}.
+ */
 public class SetObjectRetentionArgs extends ObjectVersionArgs {
   private Retention config;
   private boolean bypassGovernanceMode;

--- a/api/src/main/java/io/minio/SetObjectTagsArgs.java
+++ b/api/src/main/java/io/minio/SetObjectTagsArgs.java
@@ -20,7 +20,9 @@ import io.minio.messages.Tags;
 import java.util.Map;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#setObjectTags}. */
+/**
+ * Argument class of {@link MinioAsyncClient#setObjectTags} and {@link MinioClient#setObjectTags}.
+ */
 public class SetObjectTagsArgs extends ObjectVersionArgs {
   private Tags tags;
 

--- a/api/src/main/java/io/minio/StatObjectArgs.java
+++ b/api/src/main/java/io/minio/StatObjectArgs.java
@@ -16,7 +16,7 @@
 
 package io.minio;
 
-/** Argument class of {@link MinioClient#statObject}. */
+/** Argument class of {@link MinioAsyncClient#statObject} and {@link MinioClient#statObject}. */
 public class StatObjectArgs extends ObjectConditionalReadArgs {
   protected StatObjectArgs() {}
 

--- a/api/src/main/java/io/minio/StatObjectResponse.java
+++ b/api/src/main/java/io/minio/StatObjectResponse.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import okhttp3.Headers;
 
-/** Response of {@link MinioAsyncClient#statObject} and {@link MinioClient#statObject}. */
+/** Response of {@link S3Base#statObjectAsync}. */
 public class StatObjectResponse extends GenericResponse {
   private String etag;
   private long size;

--- a/api/src/main/java/io/minio/StatObjectResponse.java
+++ b/api/src/main/java/io/minio/StatObjectResponse.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import okhttp3.Headers;
 
-/** Response of {@link MinioClient#statObject}. */
+/** Response of {@link MinioAsyncClient#statObject} and {@link MinioClient#statObject}. */
 public class StatObjectResponse extends GenericResponse {
   private String etag;
   private long size;

--- a/api/src/main/java/io/minio/UploadObjectArgs.java
+++ b/api/src/main/java/io/minio/UploadObjectArgs.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Objects;
 
-/** Argument class of {@link MinioClient#uploadObject}. */
+/** Argument class of {@link MinioAsyncClient#uploadObject} and {@link MinioClient#uploadObject}. */
 public class UploadObjectArgs extends PutObjectBaseArgs {
   private String filename;
 

--- a/api/src/main/java/io/minio/UploadPartCopyResponse.java
+++ b/api/src/main/java/io/minio/UploadPartCopyResponse.java
@@ -19,7 +19,7 @@ package io.minio;
 import io.minio.messages.CopyPartResult;
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#uploadPartCopy}. */
+/** Response class of {@link S3Base#uploadPartCopyAsync}. */
 public class UploadPartCopyResponse extends GenericResponse {
   private String uploadId;
   private int partNumber;

--- a/api/src/main/java/io/minio/UploadPartResponse.java
+++ b/api/src/main/java/io/minio/UploadPartResponse.java
@@ -18,7 +18,7 @@ package io.minio;
 
 import okhttp3.Headers;
 
-/** Response class of {@link MinioClient#uploadPart}. */
+/** Response class of {@link S3Base#uploadPartAsync}. */
 public class UploadPartResponse extends GenericResponse {
   private String uploadId;
   private int partNumber;

--- a/api/src/main/java/io/minio/UploadSnowballObjectsArgs.java
+++ b/api/src/main/java/io/minio/UploadSnowballObjectsArgs.java
@@ -20,7 +20,10 @@ import java.security.SecureRandom;
 import java.util.Objects;
 import java.util.Random;
 
-/** Argument class of {@link MinioClient#uploadSnowballObjects}. */
+/**
+ * Argument class of {@link MinioAsyncClient#uploadSnowballObjects} and {@link
+ * MinioClient#uploadSnowballObjects}.
+ */
 public class UploadSnowballObjectsArgs extends ObjectWriteArgs {
   private static final Random random = new Random(new SecureRandom().nextLong());
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
 
     [compileJava, compileTestJava].each() {
         it.options.fork = true
-        it.options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options", "-Werror"]
+        it.options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation", "-Xlint:-options", "-Werror", "-Xdiags:verbose"]
         it.options.encoding = "UTF-8"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: "de.marcphilipp.nexus-publish"
 
 allprojects {
     group = 'io.minio'
-    version = '8.3.10'
+    version = '8.4.0'
     if (!project.hasProperty('release')) {
         version += '-DEV'
     }


### PR DESCRIPTION
This commit comes with
* Adds `MinioAsyncClient` class contains APIs returning `CompletableFuture` to execute them in future.
* All APIs in `MinioClient` underneath uses APIs in `MinioAsyncClient` as base.
* All low level S3 APIs in `S3Base` class return `CompletableFuture` and older APIs are deprecated.

Signed-off-by: Bala.FA <bala@minio.io>
