### PR TITLE
Add overwrite flag to downloadObject() API.

### DIFF
--- a/api/src/main/java/io/minio/DownloadObjectArgs.java
+++ b/api/src/main/java/io/minio/DownloadObjectArgs.java
@@ -16,16 +16,19 @@
 
 package io.minio;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 /** Argument class of {@link MinioClient#downloadObject}. */
 public class DownloadObjectArgs extends ObjectReadArgs {
   private String filename;
+  private boolean overwrite;
 
   public String filename() {
     return filename;
+  }
+
+  public boolean overwrite() {
+    return overwrite;
   }
 
   public static Builder builder() {
@@ -34,18 +37,19 @@ public class DownloadObjectArgs extends ObjectReadArgs {
 
   /** Argument class of {@link DownloadObjectArgs}. */
   public static final class Builder extends ObjectReadArgs.Builder<Builder, DownloadObjectArgs> {
+    private void validateFilename(String filename) {
+      validateNotEmptyString(filename, "filename");
+    }
+
     public Builder filename(String filename) {
       validateFilename(filename);
       operations.add(args -> args.filename = filename);
       return this;
     }
 
-    private void validateFilename(String filename) {
-      validateNotEmptyString(filename, "filename");
-
-      if (Files.exists(Paths.get(filename))) {
-        throw new IllegalArgumentException("Destination file " + filename + " already exists");
-      }
+    public Builder overwrite(boolean flag) {
+      operations.add(args -> args.overwrite = flag);
+      return this;
     }
   }
 
@@ -55,11 +59,12 @@ public class DownloadObjectArgs extends ObjectReadArgs {
     if (!(o instanceof DownloadObjectArgs)) return false;
     if (!super.equals(o)) return false;
     DownloadObjectArgs that = (DownloadObjectArgs) o;
-    return Objects.equals(filename, that.filename);
+    if (!Objects.equals(filename, that.filename)) return false;
+    return overwrite == that.overwrite;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), filename);
+    return Objects.hash(super.hashCode(), filename, overwrite);
   }
 }

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -287,7 +287,7 @@ public class MinioClient extends S3Base {
           ServerException, XmlParserException {
     String filename = args.filename();
     Path filePath = Paths.get(filename);
-    if (Files.exists(filePath)) {
+    if (!args.overwrite() && Files.exists(filePath)) {
       throw new IllegalArgumentException("Destination file " + filename + " already exists");
     }
 
@@ -314,7 +314,12 @@ public class MinioClient extends S3Base {
                 + ", written = "
                 + bytesWritten);
       }
-      Files.move(tempFilePath, filePath, StandardCopyOption.REPLACE_EXISTING);
+
+      if (!args.overwrite()) {
+        Files.move(tempFilePath, filePath);
+      } else {
+        Files.move(tempFilePath, filePath, StandardCopyOption.REPLACE_EXISTING);
+      }
     } finally {
       if (is != null) {
         is.close();


### PR DESCRIPTION
When setting overwrite flag to true for `DownloadObjectArgs` makes overwriting destination file if it exists.

Signed-off-by: Bala.FA <bala@minio.io>