### PR TITLE
Add getUserInfo to admin client

### DIFF
--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -63,6 +63,7 @@ import org.bouncycastle.crypto.InvalidCipherTextException;
 public class MinioAdminClient {
   private enum Command {
     ADD_USER("add-user"),
+    USER_INFO("user-info"),
     LIST_USERS("list-users"),
     REMOVE_USER("remove-user"),
     ADD_CANNED_POLICY("add-canned-policy"),
@@ -224,6 +225,25 @@ public class MinioAdminClient {
             Command.ADD_USER,
             ImmutableMultimap.of("accessKey", accessKey),
             Crypto.encrypt(creds.secretKey(), OBJECT_MAPPER.writeValueAsBytes(userInfo)))) {}
+  }
+
+  /**
+   * Obtains user info for a specified MinIO user.
+   *
+   * @param accessKey Access Key.
+   * @return user info for the specified accessKey.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on MinIO REST operation.
+   */
+  public UserInfo getUserInfo(String accessKey)
+      throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+    try (Response response =
+        execute(
+            Method.GET, Command.USER_INFO, ImmutableMultimap.of("accessKey", accessKey), null)) {
+      byte[] jsonData = response.body().bytes();
+      return OBJECT_MAPPER.readValue(jsonData, UserInfo.class);
+    }
   }
 
   /**

--- a/adminapi/src/main/java/io/minio/admin/UserInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/UserInfo.java
@@ -70,8 +70,7 @@ public class UserInfo {
 
   public static enum Status {
     ENABLED("enabled"),
-    DISABLED("disabled"),
-    UNKNOWN("unknown");
+    DISABLED("disabled");
 
     private final String value;
 
@@ -94,7 +93,11 @@ public class UserInfo {
         return DISABLED;
       }
 
-      return UNKNOWN;
+      if (statusString.isEmpty()) {
+        return null;
+      }
+
+      throw new IllegalArgumentException("Unknown status " + statusString);
     }
   }
 }

--- a/adminapi/src/main/java/io/minio/admin/UserInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/UserInfo.java
@@ -70,7 +70,8 @@ public class UserInfo {
 
   public static enum Status {
     ENABLED("enabled"),
-    DISABLED("disabled");
+    DISABLED("disabled"),
+    UNKNOWN("unknown");
 
     private final String value;
 
@@ -93,7 +94,7 @@ public class UserInfo {
         return DISABLED;
       }
 
-      throw new IllegalArgumentException("Unknown status " + statusString);
+      return UNKNOWN;
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: "de.marcphilipp.nexus-publish"
 
 allprojects {
     group = 'io.minio'
-    version = '8.3.8'
+    version = '8.3.9'
     if (!project.hasProperty('release')) {
         version += '-DEV'
     }

--- a/functional/TestMinioAdminClient.java
+++ b/functional/TestMinioAdminClient.java
@@ -109,6 +109,22 @@ public class TestMinioAdminClient {
     }
   }
 
+  public void getUserInfo() throws Exception {
+    String methodName = "getUserInfo()";
+    if (!mintEnv) {
+      System.out.println(methodName);
+    }
+
+    long startTime = System.currentTimeMillis();
+    try {
+      UserInfo userInfo = adminClient.getUserInfo(userAccessKey);
+      Assert.assertEquals(userInfo.status(), UserInfo.Status.ENABLED);
+      Assert.assertEquals(userInfo.policyName(), policyName);
+    } catch (Exception e) {
+      FunctionalTest.handleException(methodName, null, startTime, e);
+    }
+  }
+
   public void listUsers() throws Exception {
     String methodName = "listUsers()";
     if (!mintEnv) {
@@ -144,6 +160,7 @@ public class TestMinioAdminClient {
     addUser();
     addCannedPolicy();
     setPolicy();
+    getUserInfo();
     listUsers();
     listCannedPolicies();
     deleteUser();


### PR DESCRIPTION
This PR adds the `getUserInfo` function to the Admin Client allowing users to get the UserInfo for a single specified MinIO user (AccessToken). This allows fetching of UserInfo for not only MinIO local users but also for MinIO LDAP Users, which are not returned by the `listUsers` function.

e.g. `mcAdmin.getUserInfo("cn=Ldap User,cn=Users,dc=company,dc=io");` will return a UserInfo object for the MinIO LDAP account `cn=Ldap User,cn=Users,dc=company,dc=io` if the user exists. This UserInfo is not returned by the `mcAdmin.listUsers()` function. 

As MinIO LDAP Users do not get a `Status` by default, a new Status enum value of `unknown` is also needed in the UserInfo class. This will be assigned to any User who does not return a status of `enable` or `disabled`.