### PR TITLE
Allow null values for UserInfo status.

### DIFF
--- a/adminapi/src/main/java/io/minio/admin/UserInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/UserInfo.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Represents user information. */
@@ -44,11 +42,11 @@ public class UserInfo {
   private Status status;
 
   public UserInfo(
-      @Nonnull @JsonProperty("status") Status status,
+      @Nullable @JsonProperty("status") Status status,
       @Nullable @JsonProperty("secretKey") String secretKey,
       @Nullable @JsonProperty("policyName") String policyName,
       @Nullable @JsonProperty("memberOf") List<String> memberOf) {
-    this.status = Objects.requireNonNull(status, "Status must be provided");
+    this.status = status;
     this.secretKey = secretKey;
     this.policyName = policyName;
     this.memberOf = (memberOf != null) ? Collections.unmodifiableList(memberOf) : null;


### PR DESCRIPTION
LDAP users in Minio do not have a `status` value - it is returned as an empty string. We need to update the UserInfo class to allow for these empty string values. so we can fetch info about Minio Ldap Users.

When a user does not have a status assigned, we will get the following error:

`com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of 'io.minio.admin.UserInfo', problem: Status must be provided`

By allowing null values for the status field in the UserInfo model class, this issue is resolved.