### PR TITLE
Enhancement of the MinIO admin client functionality with the group function

### DIFF
--- a/adminapi/src/main/java/io/minio/admin/GroupAddUpdateRemoveInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/GroupAddUpdateRemoveInfo.java
@@ -1,6 +1,6 @@
 /*
  * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2021 MinIO, Inc.
+ * (C) 2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/adminapi/src/main/java/io/minio/admin/GroupAddUpdateRemoveInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/GroupAddUpdateRemoveInfo.java
@@ -1,0 +1,70 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.admin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Represents groupAddUpdateRemove information. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GroupAddUpdateRemoveInfo {
+  @JsonProperty("group")
+  private String group;
+
+  @JsonProperty("groupStatus")
+  private Status groupStatus;
+
+  @JsonProperty("members")
+  private List<String> members;
+
+  @JsonProperty("isRemove")
+  private boolean isRemove;
+
+  public GroupAddUpdateRemoveInfo(
+      @Nonnull @JsonProperty("group") String group,
+      @Nullable @JsonProperty("groupStatus") Status groupStatus,
+      @Nullable @JsonProperty("members") List<String> members,
+      @Nullable @JsonProperty("isRemove") boolean isRemove) {
+    this.group = Objects.requireNonNull(group, "Group must be provided");
+    this.groupStatus = groupStatus;
+    this.members = (members != null) ? Collections.unmodifiableList(members) : null;
+    this.isRemove = isRemove;
+  }
+
+  public String group() {
+    return group;
+  }
+
+  public Status groupStatus() {
+    return groupStatus;
+  }
+
+  public List<String> members() {
+    return Collections.unmodifiableList(members == null ? new LinkedList<>() : members);
+  }
+
+  public boolean isRemove() {
+    return isRemove;
+  }
+}

--- a/adminapi/src/main/java/io/minio/admin/GroupInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/GroupInfo.java
@@ -1,0 +1,56 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.minio.admin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/** Represents group information. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GroupInfo {
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("status")
+  private Status status;
+
+  @JsonProperty("members")
+  private List<String> members;
+
+  @JsonProperty("policy")
+  private String policy;
+
+  public String name() {
+    return name;
+  }
+
+  public Status status() {
+    return status;
+  }
+
+  public List<String> members() {
+    return Collections.unmodifiableList(members == null ? new LinkedList<>() : members);
+  }
+
+  public String policy() {
+    return policy;
+  }
+}

--- a/adminapi/src/main/java/io/minio/admin/GroupInfo.java
+++ b/adminapi/src/main/java/io/minio/admin/GroupInfo.java
@@ -1,6 +1,6 @@
 /*
  * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
- * (C) 2021 MinIO, Inc.
+ * (C) 2022 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -299,30 +299,23 @@ public class MinioAdminClient {
   }
 
   /**
-   * Adds, updates or removes a group.
+   * Adds or updates a group.
    *
    * @param group Group name.
    * @param groupStatus Status.
    * @param members Members of group.
-   * @param isRemove Add or remove group.
    * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
    * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
    * @throws IOException thrown to indicate I/O error on MinIO REST operation.
    */
-  public void addUpdateRemoveGroup(
-      @Nonnull String group,
-      @Nullable Status groupStatus,
-      @Nullable List<String> members,
-      @Nonnull Boolean isRemove)
+  public void addUpdateGroup(
+      @Nonnull String group, @Nullable Status groupStatus, @Nullable List<String> members)
       throws NoSuchAlgorithmException, InvalidKeyException, IOException {
     if (group == null || group.isEmpty()) {
       throw new IllegalArgumentException("group must be provided");
     }
-    if (isRemove == null) {
-      throw new IllegalArgumentException("isRemove must be provided");
-    }
     GroupAddUpdateRemoveInfo groupAddUpdateRemoveInfo =
-        new GroupAddUpdateRemoveInfo(group, groupStatus, members, isRemove);
+        new GroupAddUpdateRemoveInfo(group, groupStatus, members, false);
 
     try (Response response =
         execute(
@@ -366,6 +359,30 @@ public class MinioAdminClient {
           OBJECT_MAPPER.getTypeFactory().constructCollectionType(ArrayList.class, String.class);
       return OBJECT_MAPPER.readValue(jsonData, mapType);
     }
+  }
+
+  /**
+   * Removes a group.
+   *
+   * @param group Group name.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on MinIO REST operation.
+   */
+  public void removeGroup(@Nonnull String group)
+      throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+    if (group == null || group.isEmpty()) {
+      throw new IllegalArgumentException("group must be provided");
+    }
+    GroupAddUpdateRemoveInfo groupAddUpdateRemoveInfo =
+        new GroupAddUpdateRemoveInfo(group, null, null, true);
+
+    try (Response response =
+        execute(
+            Method.PUT,
+            Command.ADD_UPDATE_REMOVE_GROUP,
+            null,
+            OBJECT_MAPPER.writeValueAsBytes(groupAddUpdateRemoveInfo))) {}
   }
 
   /**

--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -19,6 +19,7 @@ package io.minio.admin;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -43,6 +44,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -71,7 +73,10 @@ public class MinioAdminClient {
     LIST_CANNED_POLICIES("list-canned-policies"),
     REMOVE_CANNED_POLICY("remove-canned-policy"),
     SET_BUCKET_QUOTA("set-bucket-quota"),
-    GET_BUCKET_QUOTA("get-bucket-quota");
+    GET_BUCKET_QUOTA("get-bucket-quota"),
+    ADD_UPDATE_REMOVE_GROUP("update-group-members"),
+    GROUP_INFO("group"),
+    LIST_GROUPS("groups");
     private final String value;
 
     private Command(String value) {
@@ -291,6 +296,76 @@ public class MinioAdminClient {
             Command.REMOVE_USER,
             ImmutableMultimap.of("accessKey", accessKey),
             null)) {}
+  }
+
+  /**
+   * Adds, updates or removes a group.
+   *
+   * @param group Group name.
+   * @param groupStatus Status.
+   * @param members Members of group.
+   * @param isRemove Add or remove group.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on MinIO REST operation.
+   */
+  public void addUpdateRemoveGroup(
+      @Nonnull String group,
+      @Nullable Status groupStatus,
+      @Nullable List<String> members,
+      @Nonnull Boolean isRemove)
+      throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+    if (group == null || group.isEmpty()) {
+      throw new IllegalArgumentException("group must be provided");
+    }
+    if (isRemove == null) {
+      throw new IllegalArgumentException("isRemove must be provided");
+    }
+    GroupAddUpdateRemoveInfo groupAddUpdateRemoveInfo =
+        new GroupAddUpdateRemoveInfo(group, groupStatus, members, isRemove);
+
+    try (Response response =
+        execute(
+            Method.PUT,
+            Command.ADD_UPDATE_REMOVE_GROUP,
+            null,
+            OBJECT_MAPPER.writeValueAsBytes(groupAddUpdateRemoveInfo))) {}
+  }
+
+  /**
+   * Obtains group info for a specified MinIO group.
+   *
+   * @param group Group name.
+   * @return group info for the specified group.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on MinIO REST operation.
+   */
+  public GroupInfo getGroupInfo(String group)
+      throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+    try (Response response =
+        execute(Method.GET, Command.GROUP_INFO, ImmutableMultimap.of("group", group), null)) {
+      byte[] jsonData = response.body().bytes();
+      return OBJECT_MAPPER.readValue(jsonData, GroupInfo.class);
+    }
+  }
+
+  /**
+   * Obtains a list of all MinIO groups.
+   *
+   * @return List of all groups.
+   * @throws NoSuchAlgorithmException thrown to indicate missing of MD5 or SHA-256 digest library.
+   * @throws InvalidKeyException thrown to indicate missing of HMAC SHA-256 library.
+   * @throws IOException thrown to indicate I/O error on MinIO REST operation.
+   */
+  public List<String> listGroups()
+      throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+    try (Response response = execute(Method.GET, Command.LIST_GROUPS, null, null)) {
+      byte[] jsonData = response.body().bytes();
+      CollectionType mapType =
+          OBJECT_MAPPER.getTypeFactory().constructCollectionType(ArrayList.class, String.class);
+      return OBJECT_MAPPER.readValue(jsonData, mapType);
+    }
   }
 
   /**

--- a/adminapi/src/main/java/io/minio/admin/Status.java
+++ b/adminapi/src/main/java/io/minio/admin/Status.java
@@ -1,0 +1,37 @@
+package io.minio.admin;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Status {
+  ENABLED("enabled"),
+  DISABLED("disabled");
+
+  private final String value;
+
+  Status(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String toString() {
+    return this.value;
+  }
+
+  @JsonCreator
+  public static Status fromString(String statusString) {
+    if ("enabled".equals(statusString)) {
+      return ENABLED;
+    }
+
+    if ("disabled".equals(statusString)) {
+      return DISABLED;
+    }
+
+    if (statusString.isEmpty()) {
+      return null;
+    }
+
+    throw new IllegalArgumentException("Unknown status " + statusString);
+  }
+}

--- a/adminapi/src/main/java/io/minio/admin/Status.java
+++ b/adminapi/src/main/java/io/minio/admin/Status.java
@@ -1,3 +1,20 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage,
+ * (C) 2022 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.minio.admin;
 
 import com.fasterxml.jackson.annotation.JsonCreator;


### PR DESCRIPTION
Three functions have been added to the client.

A function (**addUpdateGroup**) to add a group with optional group membership or to update the membership of a Group. 
A function (**removeGroup**) to delete a group.
**Example**: 
Create an empty group: 
`minioClient.addUpdateGroup(groupName, Status.ENABLED, null);`
Update membership of group :
`minioClient.addUpdateGroup(groupId, Status.ENABLED, groupMembers);`
Delete a group: 
`minioClient.removeGroup(groupName);`

A function (**getGroupInfo**) to get information of a group.
**Example**: 
Get info of a group:
 `GroupInfo groupInfo = minioClient.getGroupInfo(groupName);`

A function (**listGroups**) to list all groups.
**Example**: 
List all groups: 
`List<String> groupsMinio = minioClient.listGroups();`

I have extracted the enum status but left it in the class UserInfo so as not to cause any breaking changes.
However, it is recommended to replace the code occurances "UserInfo.Status" with "Status" and then delete the code duplicate of UserInfo