### PR TITLE
Upgrade okhttp, kotlin-stdlib, junit fixing vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
     dependencies {
         compile "com.carrotsearch.thirdparty:simple-xml-safe:2.7.1"
         compile "com.google.guava:guava:30.1.1-jre"
-        compile "com.squareup.okhttp3:okhttp:4.8.1"
+        compile "com.squareup.okhttp3:okhttp:4.10.0"
         compile "com.fasterxml.jackson.core:jackson-annotations:2.13.2"
         compile "com.fasterxml.jackson.core:jackson-core:2.13.2"
         compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"


### PR DESCRIPTION
Upgrade com.squareup.okhttp3:okhttp from 4.8.1 to 4.10.0
fixing an information exposure vulnerability:
https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044

This indirectly upgrades org.jetbrains.kotlin:kotlin-stdlib from
1.3.72 to 1.6.20 fixing an improper locking vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2022-24329

Upgrade junit from 4.13 to 4.13.2 fixing an Information Exposure
vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-15250