### PR TITLE
Upgrade to junit 4.13.2 fixing Information Exposure (CVE-2020-15250)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ subprojects {
         compileOnly "com.github.spotbugs:spotbugs-annotations:4.1.2"
 
         testImplementation "com.squareup.okhttp3:mockwebserver:4.8.1"
-        testImplementation "junit:junit:4.13"
+        testImplementation "junit:junit:4.13.2"
     }
 
     [compileJava, compileTestJava].each() {
@@ -362,7 +362,7 @@ import org.gradle.internal.os.OperatingSystem;
 
 project(':functional') {
     dependencies {
-        compile "junit:junit:4.13"
+        compile "junit:junit:4.13.2"
         compile project(':api')
         compile project(':adminapi')
     }


### PR DESCRIPTION
Upgrade junit from 4.13 to 4.13.2 fixing an Information Exposure
vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-15250