### PR TITLE
Add checksum elements into CompleteMultipartUploadOutput class

### DIFF
--- a/api/src/main/java/io/minio/messages/CompleteMultipartUploadOutput.java
+++ b/api/src/main/java/io/minio/messages/CompleteMultipartUploadOutput.java
@@ -70,19 +70,19 @@ public class CompleteMultipartUploadOutput {
     return etag;
   }
 
-  public String getChecksumCRC32() {
+  public String checksumCRC32() {
     return checksumCRC32;
   }
 
-  public String getChecksumCRC32C() {
+  public String checksumCRC32C() {
     return checksumCRC32C;
   }
 
-  public String getChecksumSHA1() {
+  public String checksumSHA1() {
     return checksumSHA1;
   }
 
-  public String getChecksumSHA256() {
+  public String checksumSHA256() {
     return checksumSHA256;
   }
 }

--- a/api/src/main/java/io/minio/messages/CompleteMultipartUploadOutput.java
+++ b/api/src/main/java/io/minio/messages/CompleteMultipartUploadOutput.java
@@ -40,6 +40,18 @@ public class CompleteMultipartUploadOutput {
   @Element(name = "ETag")
   private String etag;
 
+  @Element(name = "ChecksumCRC32", required = false)
+  private String checksumCRC32;
+
+  @Element(name = "ChecksumCRC32C", required = false)
+  private String checksumCRC32C;
+
+  @Element(name = "ChecksumSHA1", required = false)
+  private String checksumSHA1;
+
+  @Element(name = "ChecksumSHA256", required = false)
+  private String checksumSHA256;
+
   public CompleteMultipartUploadOutput() {}
 
   public String location() {
@@ -56,5 +68,21 @@ public class CompleteMultipartUploadOutput {
 
   public String etag() {
     return etag;
+  }
+
+  public String getChecksumCRC32() {
+    return checksumCRC32;
+  }
+
+  public String getChecksumCRC32C() {
+    return checksumCRC32C;
+  }
+
+  public String getChecksumSHA1() {
+    return checksumSHA1;
+  }
+
+  public String getChecksumSHA256() {
+    return checksumSHA256;
   }
 }


### PR DESCRIPTION
Using minio server with docker image minio/minio:RELEASE.2022-09-01T23-53-36Z when I do a mutipart upload, I receive the following response:
```
<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
	<Location>https://minio.xxx/myBucket/bigFile</Location>
	<Bucket>myBucket</Bucket>
	<Key>bigFile</Key>
	<ETag>&#34;d991cefbc7c54591517a7d17b5188c68-104&#34;</ETag>
	<ChecksumCRC32></ChecksumCRC32>
	<ChecksumCRC32C></ChecksumCRC32C>
	<ChecksumSHA1></ChecksumSHA1>
	<ChecksumSHA256></ChecksumSHA256>
</CompleteMultipartUploadResult>
```
This cause a warn log like
```
 Oct 18, 2022 1:02:21 AM io.minio.S3Base lambda$completeMultipartUploadAsync$12 WARNING: S3 service returned unknown XML for CompleteMultipartUpload REST API. <?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>https://minio.xxx/myBucket/bigFile</Location><Bucket>myBucket</Bucket><Key>bigFile</Key><ETag>&#34;d991cefbc7c54591517a7d17b5188c68-104&#34;</ETag><ChecksumCRC32></ChecksumCRC32><ChecksumCRC32C></ChecksumCRC32C><ChecksumSHA1></ChecksumSHA1<ChecksumSHA256></ChecksumSHA256></CompleteMultipartUploadResult>
```
This pull request add the missing Checksum elements in CompleteMultipartUploadOutput object.

Fixes #1376