### PR TITLE
Upgrade guava to fix CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
 
     dependencies {
         api "com.carrotsearch.thirdparty:simple-xml-safe:2.7.1"
-        api "com.google.guava:guava:32.0.0-jre"
+        api "com.google.guava:guava:32.0.1-jre"
         api "com.squareup.okhttp3:okhttp:4.11.0"
         api "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
         api "com.fasterxml.jackson.core:jackson-core:2.15.2"


### PR DESCRIPTION
The currently used guava version is affected by vulnerability CVE-2023-2976 reported here: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976

Version 32.0.1 of guava is not affected by this vulnerability.

