### PR TITLE
Update to Java 11 & support JPMS

### DIFF
--- a/adminapi/src/main/java/module-info.java
+++ b/adminapi/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.minio.api.admin {
+	requires org.bouncycastle.provider;
+	requires com.google.common;
+	requires com.fasterxml.jackson.annotation;
+	requires jsr305;
+	requires okhttp3;
+	requires com.fasterxml.jackson.databind;
+	requires com.fasterxml.jackson.datatype.jsr310;
+	requires com.github.spotbugs.annotations;
+	
+	requires io.minio.api;
+	
+	exports io.minio.admin;
+	exports io.minio.admin.messages;
+}

--- a/adminapi/src/main/java/module-info.java
+++ b/adminapi/src/main/java/module-info.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module io.minio.api.admin {
+open module io.minio.api.admin {
 	requires org.bouncycastle.provider;
 	requires com.google.common;
 	requires com.fasterxml.jackson.annotation;

--- a/adminapi/src/main/java/module-info.java
+++ b/adminapi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2023 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,32 @@
+/*
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+open module io.minio.api {
+	requires okhttp3;
+	requires com.google.common;
+	requires simple.xml.safe;
+	requires jsr305;
+	requires com.fasterxml.jackson.databind;
+	requires com.github.spotbugs.annotations;
+	
+	exports io.minio;
+	exports io.minio.credentials;
+	exports io.minio.errors;
+	exports io.minio.http;
+	exports io.minio.messages;
+
+	// TODO - Should this be exported (is this a public facing API)?
+	// exports io.minio.org.apache.commons.validator.routines;
+}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ * MinIO Java SDK for Amazon S3 Compatible Cloud Storage, (C) 2023 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,8 @@ subprojects {
 
     check.dependsOn localeTest
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 
     spotless {
         java {


### PR DESCRIPTION
# Motivation
JPMS is used by the vast majority of publically released libraries. The performance benefits it provides over the generic classpath, and better compile-time verification is very important. Without native support for JPMS, nobody can release a public library using JPMS and Minio safely.

# Downsides
This will break support for Java 1.8, and Java 9 or over will be needed to use Minio. In the PR that I have created, Java 11 is the base version as it is the next LTS release after 1.8. Most people consider Java 1.8 as "ancient" by modern standards, but it is still used today in a lot of commercial software. The best way to maintain support will be to simply refer people to the older versions of the client, or the official S3 clients.

A hacky way people tend to retain support for Java 1.8 is to compile the module-info with Java 9/11, and the rest of the project with Java 1,8. This is not the most elegant build toolchain but is a valid solution nevertheless.

# Issues
This PR should not build correctly, as I have not thoroughly checked if all `requires` statements are defined, and there are likely several other issues.
This PR also uses `open module` for all of the declarations, as I was conducting some quick tests with Spring - this can be changed, and probably should be changed as the client does not seem to require any kind of reflection.