### PR TITLE
Add a temporary connection function that can specify the generated ba…

### DIFF
--- a/api/src/main/java/io/minio/GetPresignedObjectUrlArgs.java
+++ b/api/src/main/java/io/minio/GetPresignedObjectUrlArgs.java
@@ -27,9 +27,13 @@ import java.util.concurrent.TimeUnit;
 public class GetPresignedObjectUrlArgs extends ObjectVersionArgs {
   // default expiration for a presigned URL is 7 days in seconds
   public static final int DEFAULT_EXPIRY_TIME = (int) TimeUnit.DAYS.toSeconds(7);
-
+  private String endpoint;
   private Method method;
   private int expiry = DEFAULT_EXPIRY_TIME;
+
+  public String endpoint() {
+    return endpoint;
+  }
 
   public Method method() {
     return method;
@@ -46,6 +50,10 @@ public class GetPresignedObjectUrlArgs extends ObjectVersionArgs {
   /** Argument builder of {@link GetPresignedObjectUrlArgs}. */
   public static final class Builder
       extends ObjectVersionArgs.Builder<Builder, GetPresignedObjectUrlArgs> {
+    private void validateEndpoint(String endpoint) {
+      validateNotNull(endpoint, "endpoint");
+    }
+
     private void validateMethod(Method method) {
       validateNotNull(method, "method");
     }
@@ -57,6 +65,13 @@ public class GetPresignedObjectUrlArgs extends ObjectVersionArgs {
                 + TimeUnit.SECONDS.toDays(DEFAULT_EXPIRY_TIME)
                 + " days");
       }
+    }
+
+    /* proxy address. */
+    public Builder endpoint(String endpoint) {
+      validateEndpoint(endpoint);
+      operations.add(args -> args.endpoint = endpoint);
+      return this;
     }
 
     /* method HTTP {@link Method} to generate presigned URL. */
@@ -90,11 +105,13 @@ public class GetPresignedObjectUrlArgs extends ObjectVersionArgs {
     if (!(o instanceof GetPresignedObjectUrlArgs)) return false;
     if (!super.equals(o)) return false;
     GetPresignedObjectUrlArgs that = (GetPresignedObjectUrlArgs) o;
-    return expiry == that.expiry && method == that.method;
+    return expiry == that.expiry
+        && method == that.method
+        && Objects.equals(endpoint, that.endpoint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), method, expiry);
+    return Objects.hash(super.hashCode(), method, expiry, endpoint);
   }
 }

--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -934,15 +934,16 @@ public class MinioAsyncClient extends S3Base {
     } catch (ExecutionException e) {
       throwEncapsulatedException(e);
     }
+    HttpUrl proxyUrl = args.endpoint() == null ? this.baseUrl : HttpUrl.parse(args.endpoint());
 
     if (provider == null) {
-      HttpUrl url = buildUrl(args.method(), args.bucket(), args.object(), region, queryParams);
+      HttpUrl url = buildUrl(proxyUrl, args.method(), args.bucket(), args.object(), region, queryParams);
       return url.toString();
     }
 
     Credentials creds = provider.fetch();
     if (creds.sessionToken() != null) queryParams.put("X-Amz-Security-Token", creds.sessionToken());
-    HttpUrl url = buildUrl(args.method(), args.bucket(), args.object(), region, queryParams);
+    HttpUrl url = buildUrl(proxyUrl, args.method(), args.bucket(), args.object(), region, queryParams);
     Request request =
         createRequest(
             url,

--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -277,18 +277,20 @@ public abstract class S3Base {
 
   /** Build URL for given parameters. */
   protected HttpUrl buildUrl(
-      Method method,
-      String bucketName,
-      String objectName,
-      String region,
-      Multimap<String, String> queryParamMap)
-      throws NoSuchAlgorithmException {
+          HttpUrl proxyUrl,
+          Method method,
+          String bucketName,
+          String objectName,
+          String region,
+          Multimap<String, String> queryParamMap)
+          throws NoSuchAlgorithmException {
     if (bucketName == null && objectName != null) {
       throw new IllegalArgumentException("null bucket name for object '" + objectName + "'");
     }
 
     HttpUrl.Builder urlBuilder = this.baseUrl.newBuilder();
-    String host = this.baseUrl.host();
+    urlBuilder.port(proxyUrl.port());
+    String host = proxyUrl.host();
     if (bucketName != null) {
       boolean enforcePathStyle = false;
       if (method == Method.PUT && objectName == null && queryParamMap == null) {
@@ -357,6 +359,17 @@ public abstract class S3Base {
     }
 
     return urlBuilder.build();
+  }
+
+  /** Build URL for given parameters. */
+  protected HttpUrl buildUrl(
+      Method method,
+      String bucketName,
+      String objectName,
+      String region,
+      Multimap<String, String> queryParamMap)
+      throws NoSuchAlgorithmException {
+    return buildUrl(baseUrl, method, bucketName, objectName, region, queryParamMap);
   }
 
   /** Convert Multimap to Headers. */

--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1626,6 +1626,17 @@ public class FunctionalTest {
                 .build(),
             expectedChecksum);
 
+        testTags = "[GET, expiry, endpoint]";
+        testGetPresignedUrl(
+                GetPresignedObjectUrlArgs.builder()
+                        .endpoint("http://127.0.0.1:9000")
+                        .method(Method.GET)
+                        .bucket(bucketName)
+                        .object(objectName)
+                        .expiry(1, TimeUnit.DAYS)
+                        .build(),
+                expectedChecksum);
+
         testTags = "[GET, expiry, query params]";
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("response-content-type", "application/json");


### PR DESCRIPTION
Add a temporary connection function that can specify the generated base URL. Because in most cases, Java programs connect to Minio through an internal network IP, but the generated temporary access link needs to be accessed through a public network.