### PR TITLE
Add content-type condition to getPresignedPostFormData test

### DIFF
--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -1725,6 +1725,7 @@ public class FunctionalTest {
 
       PostPolicy policy = new PostPolicy(bucketName, ZonedDateTime.now().plusDays(7));
       policy.addEqualsCondition("key", objectName);
+      policy.addEqualsCondition("content-type", "image/png");
       policy.addContentLengthRangeCondition(1 * MB, 4 * MB);
       Map<String, String> formData = client.getPresignedPostFormData(policy);
 


### PR DESCRIPTION
fix: https://github.com/minio/minio/pull/18074
This feature ask `Check all formValues appear in postPolicyForm or return error.`