### PR TITLE
Fix mfaDelete XML element in VersionningConfiguration

### DIFF
--- a/api/src/main/java/io/minio/messages/VersioningConfiguration.java
+++ b/api/src/main/java/io/minio/messages/VersioningConfiguration.java
@@ -36,7 +36,7 @@ public class VersioningConfiguration {
   @Element(name = "Status", required = false)
   private String status;
 
-  @Element(name = "MFADelete", required = false)
+  @Element(name = "MfaDelete", required = false)
   private String mfaDelete;
 
   public VersioningConfiguration() {}


### PR DESCRIPTION
Update the VersionningConfiguration to follow the XSD validation http://s3.amazonaws.com/doc/2006-03-01/.

A Belgian S3 provider validate the XML which causes error when changing the bucket configuration

#1490