### PR TITLE
Update snappy-java to address CVE-2023-43642

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects {
         api "com.fasterxml.jackson.core:jackson-databind:2.15.2"
         api 'org.bouncycastle:bcprov-jdk18on:1.74'
         api 'org.apache.commons:commons-compress:1.24.0'
-        api "org.xerial.snappy:snappy-java:1.1.10.1"
+        api "org.xerial.snappy:snappy-java:1.1.10.4"
         compileOnly "com.github.spotbugs:spotbugs-annotations:4.7.3"
 
         testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"


### PR DESCRIPTION
Project is currently using `snappy-java:1.1.10.1` which has a known vulnerability, reported here: https://nvd.nist.gov/vuln/detail/CVE-2023-43642

This PR addresses that vulnerability by upgrading to `snappy-java:1.1.10.4` which is reported to not be affected.