### PR TITLE
Update okhttp to fix vuln: 	 CVE-2023-3635

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
     dependencies {
         api "com.carrotsearch.thirdparty:simple-xml-safe:2.7.1"
         api "com.google.guava:guava:32.0.1-jre"
-        api "com.squareup.okhttp3:okhttp:4.11.0"
+        api "com.squareup.okhttp3:okhttp:4.12.0"
         api "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
         api "com.fasterxml.jackson.core:jackson-core:2.15.2"
         api "com.fasterxml.jackson.core:jackson-databind:2.15.2"
@@ -62,7 +62,7 @@ subprojects {
         api "org.xerial.snappy:snappy-java:1.1.10.1"
         compileOnly "com.github.spotbugs:spotbugs-annotations:4.7.3"
 
-        testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
+        testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
         testImplementation "junit:junit:4.13.2"
     }
 


### PR DESCRIPTION
This version, updates okio-jvm dependency, that is affected by the vulnerability above. 


