### PR TITLE
tests: remove deprecated --config-dir MinIO server argument

### DIFF
--- a/functional/FunctionalTest.java
+++ b/functional/FunctionalTest.java
@@ -3839,8 +3839,8 @@ public class FunctionalTest {
               "server",
               "--address",
               ":9001",
-              "--config-dir",
-              ".cfg",
+              "--certs-dir",
+              ".cfg/certs",
               ".d{1...4}");
     } else {
       pb = new ProcessBuilder(binaryPath.getPath(), "server", ".d{1...4}");


### PR DESCRIPTION
Sort-of-a follow-up to #1523 and #1522 

As stated in https://min.io/docs/minio/linux/reference/minio-server/minio-server.html:
![obraz](https://github.com/minio/minio-java/assets/7287392/d124c535-34ce-437b-855c-50786bfbb001)

The functional tests on master branch still use the removed --config-dir property. Due to this, the test instance of Min.io, which was intended to run with TLS, runs without TLS. Therefore the tests which were intended to call the TLS instance fail with an SSL handshake error. 

I aligned the parameter in line with the docs. The TLS instance should start with TLS enabled and the functional tests should be back in order.