### PR TITLE
Close HTTP client owned by MinioClient

### DIFF
--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -139,7 +139,8 @@ public class MinioAsyncClient extends S3Base {
       boolean useVirtualStyle,
       String region,
       Provider provider,
-      OkHttpClient httpClient) {
+      OkHttpClient httpClient,
+      boolean closeHttpClient) {
     super(
         baseUrl,
         awsS3Prefix,
@@ -148,7 +149,8 @@ public class MinioAsyncClient extends S3Base {
         useVirtualStyle,
         region,
         provider,
-        httpClient);
+        httpClient,
+        closeHttpClient);
   }
 
   protected MinioAsyncClient(MinioAsyncClient client) {
@@ -3338,10 +3340,12 @@ public class MinioAsyncClient extends S3Base {
             "Region missing in Amazon S3 China endpoint " + this.baseUrl);
       }
 
+      boolean closeHttpClient = false;
       if (this.httpClient == null) {
         this.httpClient =
             HttpUtils.newDefaultHttpClient(
                 DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
+        closeHttpClient = true;
       }
 
       return new MinioAsyncClient(
@@ -3352,7 +3356,8 @@ public class MinioAsyncClient extends S3Base {
           useVirtualStyle,
           region,
           provider,
-          httpClient);
+          httpClient,
+          closeHttpClient);
     }
   }
 }

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -95,7 +95,7 @@ import okhttp3.OkHttpClient;
  *         .build();
  * }</pre>
  */
-public class MinioClient {
+public class MinioClient implements AutoCloseable {
   private MinioAsyncClient asyncClient = null;
 
   private MinioClient(MinioAsyncClient asyncClient) {
@@ -2448,6 +2448,13 @@ public class MinioClient {
   /** Sets AWS S3 domain prefix. */
   public void setAwsS3Prefix(String awsS3Prefix) {
     asyncClient.setAwsS3Prefix(awsS3Prefix);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (asyncClient != null) {
+      asyncClient.close();
+    }
   }
 
   public static Builder builder() {

--- a/functional/TestUserAgent.java
+++ b/functional/TestUserAgent.java
@@ -23,7 +23,7 @@ import java.util.Scanner;
 
 public class TestUserAgent {
   public static void main(String[] args) throws Exception {
-    MinioClient client = MinioClient.builder().endpoint("http://example.org").build();
+    MinioClient client = MinioClient.builder().endpoint("http://httpbin.org").build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     client.traceOn(baos);
     client.bucketExists(BucketExistsArgs.builder().bucket("any-bucket-name-works").build());


### PR DESCRIPTION
MinioClient builder and MinioAsyncClient builder allocate a new OkHttpClient instance. OkHttpClient manages internal resources such as dispatcher thread pool for executing HTTP requests and should be closed to dispose of these resources.