### PR TITLE
Add skip bucket/region/object name validation as special usecase

### DIFF
--- a/api/src/main/java/io/minio/BucketArgs.java
+++ b/api/src/main/java/io/minio/BucketArgs.java
@@ -39,9 +39,13 @@ public abstract class BucketArgs extends BaseArgs {
       extends BaseArgs.Builder<B, A> {
     private static final Pattern BUCKET_NAME_REGEX =
         Pattern.compile("^[a-z0-9][a-z0-9\\.\\-]{1,61}[a-z0-9]$");
+    private boolean validateBucket = true;
 
     protected void validateBucketName(String name) {
       validateNotNull(name, "bucket name");
+      if (!validateBucket) {
+        return;
+      }
 
       if (!BUCKET_NAME_REGEX.matcher(name).find()) {
         throw new IllegalArgumentException(
@@ -77,6 +81,12 @@ public abstract class BucketArgs extends BaseArgs {
     public B bucket(String name) {
       validateBucketName(name);
       operations.add(args -> args.bucketName = name);
+      return (B) this;
+    }
+
+    @SuppressWarnings("unchecked") // Its safe to type cast to B as B extends this class.
+    public B bucketValidation(boolean validateBucket) {
+      this.validateBucket = validateBucket;
       return (B) this;
     }
 

--- a/api/src/main/java/io/minio/BucketArgs.java
+++ b/api/src/main/java/io/minio/BucketArgs.java
@@ -39,11 +39,11 @@ public abstract class BucketArgs extends BaseArgs {
       extends BaseArgs.Builder<B, A> {
     private static final Pattern BUCKET_NAME_REGEX =
         Pattern.compile("^[a-z0-9][a-z0-9\\.\\-]{1,61}[a-z0-9]$");
-    private boolean validateBucket = true;
+    protected boolean skipValidation = false;
 
     protected void validateBucketName(String name) {
       validateNotNull(name, "bucket name");
-      if (!validateBucket) {
+      if (skipValidation) {
         return;
       }
 
@@ -67,7 +67,7 @@ public abstract class BucketArgs extends BaseArgs {
     }
 
     private void validateRegion(String region) {
-      if (region != null && !HttpUtils.REGION_REGEX.matcher(region).find()) {
+      if (!skipValidation && region != null && !HttpUtils.REGION_REGEX.matcher(region).find()) {
         throw new IllegalArgumentException("invalid region " + region);
       }
     }
@@ -85,8 +85,8 @@ public abstract class BucketArgs extends BaseArgs {
     }
 
     @SuppressWarnings("unchecked") // Its safe to type cast to B as B extends this class.
-    public B bucketValidation(boolean validateBucket) {
-      this.validateBucket = validateBucket;
+    public B skipValidation(boolean skipValidation) {
+      this.skipValidation = skipValidation;
       return (B) this;
     }
 

--- a/api/src/main/java/io/minio/ObjectArgs.java
+++ b/api/src/main/java/io/minio/ObjectArgs.java
@@ -43,6 +43,9 @@ public abstract class ObjectArgs extends BucketArgs {
       extends BucketArgs.Builder<B, A> {
     protected void validateObjectName(String name) {
       validateNotEmptyString(name, "object name");
+      if (skipValidation) {
+        return;
+      }
       for (String token : name.split("/")) {
         if (token.equals(".") || token.equals("..")) {
           throw new IllegalArgumentException(

--- a/api/src/test/java/io/minio/MakeBucketArgsTest.java
+++ b/api/src/test/java/io/minio/MakeBucketArgsTest.java
@@ -51,11 +51,6 @@ public class MakeBucketArgsTest {
     Assert.fail("exception should be thrown");
   }
 
-  @Test()
-  public void testInvalidBucketNameWithoutValidation() {
-    MakeBucketArgs.builder().bucketValidation(false).bucket("invalid_bucketname").build();
-  }
-
   @Test
   public void testBuild() {
     MakeBucketArgs args =

--- a/api/src/test/java/io/minio/MakeBucketArgsTest.java
+++ b/api/src/test/java/io/minio/MakeBucketArgsTest.java
@@ -51,6 +51,11 @@ public class MakeBucketArgsTest {
     Assert.fail("exception should be thrown");
   }
 
+  @Test()
+  public void testInvalidBucketNameWithoutValidation() {
+    MakeBucketArgs.builder().bucketValidation(false).bucket("invalid_bucketname").build();
+  }
+
   @Test
   public void testBuild() {
     MakeBucketArgs args =


### PR DESCRIPTION
Hello,

the minio-java client is my preferred way to access S3 buckets within java projects.

Unfortunately in my current project I need to access an on-premises S3 bucket. 
For some historic reasons the bucketname contains underscores and as such does not adhere to the official [naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html). 
Sadly I have no means to correct this bucketname easily without causing severe efforts throughout the organization.

For this reason I would appreciate to have a possibility to disable the validation in such cases.
With this PR I'd like to propose a feasible solution.

I researched passt issues/change-requests, this might also be related to #1564 .

 