### PR TITLE
Handle null value in io.minio.messages.Item.lastModified() method

### DIFF
--- a/api/src/main/java/io/minio/messages/Item.java
+++ b/api/src/main/java/io/minio/messages/Item.java
@@ -21,6 +21,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Optional;
 import org.simpleframework.xml.Element;
 
 /**
@@ -86,7 +87,9 @@ public abstract class Item {
 
   /** Returns last modified time of the object. */
   public ZonedDateTime lastModified() {
-    return lastModified.zonedDateTime();
+    return Optional.ofNullable(lastModified)
+      .map(ResponseDate::zonedDateTime)
+      .orElse(null);
   }
 
   /** Returns ETag of the object. */
@@ -111,7 +114,9 @@ public abstract class Item {
 
   /** Returns user metadata. This is MinIO specific extension to ListObjectsV2. */
   public Map<String, String> userMetadata() {
-    return (userMetadata == null) ? null : userMetadata.get();
+    return Optional.ofNullable(userMetadata)
+      .map(Metadata::get)
+      .orElse(null);
   }
 
   public String userTags() {

--- a/api/src/main/java/io/minio/messages/Item.java
+++ b/api/src/main/java/io/minio/messages/Item.java
@@ -21,7 +21,6 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.Optional;
 import org.simpleframework.xml.Element;
 
 /**
@@ -87,9 +86,7 @@ public abstract class Item {
 
   /** Returns last modified time of the object. */
   public ZonedDateTime lastModified() {
-    return Optional.ofNullable(lastModified)
-      .map(ResponseDate::zonedDateTime)
-      .orElse(null);
+    return (lastModified == null) ? null : lastModified.zonedDateTime();
   }
 
   /** Returns ETag of the object. */
@@ -114,9 +111,7 @@ public abstract class Item {
 
   /** Returns user metadata. This is MinIO specific extension to ListObjectsV2. */
   public Map<String, String> userMetadata() {
-    return Optional.ofNullable(userMetadata)
-      .map(Metadata::get)
-      .orElse(null);
+    return (userMetadata == null) ? null : userMetadata.get();
   }
 
   public String userTags() {


### PR DESCRIPTION
Avert exception:

`java.lang.NullPointerException: Cannot invoke "io.minio.messages.ResponseDate.zonedDateTime()" because "this.lastModified" is null`.

Null values occur when doing a non-recursive, prefixed 'listObjects' call.