### PR TITLE
ObjectWriteResponse: return checksums if any

### DIFF
--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -533,10 +533,7 @@ public class MinioAsyncClient extends S3Base {
                                 args.object(),
                                 result.etag(),
                                 response.header("x-amz-version-id"),
-                                result.checksumCRC32(),
-                                result.checksumCRC32C(),
-                                result.checksumSHA1(),
-                                result.checksumSHA256());
+                                result);
                           } catch (XmlParserException e) {
                             throw new CompletionException(e);
                           } finally {

--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -532,7 +532,11 @@ public class MinioAsyncClient extends S3Base {
                                 args.region(),
                                 args.object(),
                                 result.etag(),
-                                response.header("x-amz-version-id"));
+                                response.header("x-amz-version-id"),
+                                result.checksumCRC32(),
+                                result.checksumCRC32C(),
+                                result.checksumSHA1(),
+                                result.checksumSHA256());
                           } catch (XmlParserException e) {
                             throw new CompletionException(e);
                           } finally {

--- a/api/src/main/java/io/minio/ObjectWriteResponse.java
+++ b/api/src/main/java/io/minio/ObjectWriteResponse.java
@@ -16,9 +16,9 @@
 
 package io.minio;
 
-import okhttp3.Headers;
-import io.minio.messages.CopyObjectResult;
 import io.minio.messages.CompleteMultipartUploadOutput;
+import io.minio.messages.CopyObjectResult;
+import okhttp3.Headers;
 
 /** Response class of any APIs doing object creation. */
 public class ObjectWriteResponse extends GenericResponse {
@@ -43,9 +43,13 @@ public class ObjectWriteResponse extends GenericResponse {
   }
 
   public ObjectWriteResponse(
-          Headers headers, String bucket, String region, String object, String etag, String versionId,
-          CopyObjectResult result
-    ) {
+      Headers headers,
+      String bucket,
+      String region,
+      String object,
+      String etag,
+      String versionId,
+      CopyObjectResult result) {
     super(headers, bucket, region, object);
     this.etag = etag;
     this.versionId = versionId;
@@ -58,9 +62,13 @@ public class ObjectWriteResponse extends GenericResponse {
   }
 
   public ObjectWriteResponse(
-          Headers headers, String bucket, String region, String object, String etag, String versionId,
-          CompleteMultipartUploadOutput result
-  ) {
+      Headers headers,
+      String bucket,
+      String region,
+      String object,
+      String etag,
+      String versionId,
+      CompleteMultipartUploadOutput result) {
     super(headers, bucket, region, object);
     this.etag = etag;
     this.versionId = versionId;

--- a/api/src/main/java/io/minio/ObjectWriteResponse.java
+++ b/api/src/main/java/io/minio/ObjectWriteResponse.java
@@ -59,7 +59,7 @@ public class ObjectWriteResponse extends GenericResponse {
 
   public ObjectWriteResponse(
           Headers headers, String bucket, String region, String object, String etag, String versionId,
-          CompleteMultipartUploadResult result
+          CompleteMultipartUploadOutput result
   ) {
     super(headers, bucket, region, object);
     this.etag = etag;

--- a/api/src/main/java/io/minio/ObjectWriteResponse.java
+++ b/api/src/main/java/io/minio/ObjectWriteResponse.java
@@ -17,6 +17,8 @@
 package io.minio;
 
 import okhttp3.Headers;
+import io.minio.messages.CopyObjectResult;
+import io.minio.messages.CompleteMultipartUploadOutput;
 
 /** Response class of any APIs doing object creation. */
 public class ObjectWriteResponse extends GenericResponse {
@@ -32,19 +34,42 @@ public class ObjectWriteResponse extends GenericResponse {
     super(headers, bucket, region, object);
     this.etag = etag;
     this.versionId = versionId;
+    if (headers != null) {
+      this.checksumCRC32 = headers.get("x-amz-checksum-crc32");
+      this.checksumCRC32C = headers.get("x-amz-checksum-crc32c");
+      this.checksumSHA1 = headers.get("x-amz-checksum-sha1");
+      this.checksumSHA256 = headers.get("x-amz-checksum-sha256");
+    }
   }
 
   public ObjectWriteResponse(
           Headers headers, String bucket, String region, String object, String etag, String versionId,
-          String checksumCRC32, String checksumCRC32C, String checksumSHA1, String checksumSHA256
+          CopyObjectResult result
+    ) {
+    super(headers, bucket, region, object);
+    this.etag = etag;
+    this.versionId = versionId;
+    if (result != null) {
+      this.checksumCRC32 = result.checksumCRC32(),
+      this.checksumCRC32C = result.checksumCRC32C(),
+      this.checksumSHA1 = result.checksumSHA1(),
+      this.checksumSHA256 = result.checksumSHA256()
+    }
+  }
+
+  public ObjectWriteResponse(
+          Headers headers, String bucket, String region, String object, String etag, String versionId,
+          CompleteMultipartUploadResult result
   ) {
     super(headers, bucket, region, object);
     this.etag = etag;
     this.versionId = versionId;
-    this.checksumCRC32 = checksumCRC32;
-    this.checksumCRC32C = checksumCRC32C;
-    this.checksumSHA1 = checksumSHA1;
-    this.checksumSHA256 = checksumSHA256;
+    if (result != null) {
+      this.checksumCRC32 = result.checksumCRC32(),
+      this.checksumCRC32C = result.checksumCRC32C(),
+      this.checksumSHA1 = result.checksumSHA1(),
+      this.checksumSHA256 = result.checksumSHA256()
+    }
   }
 
   public String etag() {

--- a/api/src/main/java/io/minio/ObjectWriteResponse.java
+++ b/api/src/main/java/io/minio/ObjectWriteResponse.java
@@ -22,6 +22,10 @@ import okhttp3.Headers;
 public class ObjectWriteResponse extends GenericResponse {
   private String etag;
   private String versionId;
+  private String checksumCRC32;
+  private String checksumCRC32C;
+  private String checksumSHA1;
+  private String checksumSHA256;
 
   public ObjectWriteResponse(
       Headers headers, String bucket, String region, String object, String etag, String versionId) {
@@ -30,11 +34,40 @@ public class ObjectWriteResponse extends GenericResponse {
     this.versionId = versionId;
   }
 
+  public ObjectWriteResponse(
+          Headers headers, String bucket, String region, String object, String etag, String versionId,
+          String checksumCRC32, String checksumCRC32C, String checksumSHA1, String checksumSHA256
+  ) {
+    super(headers, bucket, region, object);
+    this.etag = etag;
+    this.versionId = versionId;
+    this.checksumCRC32 = checksumCRC32;
+    this.checksumCRC32C = checksumCRC32C;
+    this.checksumSHA1 = checksumSHA1;
+    this.checksumSHA256 = checksumSHA256;
+  }
+
   public String etag() {
     return etag;
   }
 
   public String versionId() {
     return versionId;
+  }
+
+  public String checksumCRC32() {
+    return checksumCRC32;
+  }
+
+  public String checksumCRC32C() {
+    return checksumCRC32C;
+  }
+
+  public String checksumSHA1() {
+    return checksumSHA1;
+  }
+
+  public String checksumSHA256() {
+    return checksumSHA256;
   }
 }

--- a/api/src/main/java/io/minio/ObjectWriteResponse.java
+++ b/api/src/main/java/io/minio/ObjectWriteResponse.java
@@ -50,10 +50,10 @@ public class ObjectWriteResponse extends GenericResponse {
     this.etag = etag;
     this.versionId = versionId;
     if (result != null) {
-      this.checksumCRC32 = result.checksumCRC32(),
-      this.checksumCRC32C = result.checksumCRC32C(),
-      this.checksumSHA1 = result.checksumSHA1(),
-      this.checksumSHA256 = result.checksumSHA256()
+      this.checksumCRC32 = result.checksumCRC32();
+      this.checksumCRC32C = result.checksumCRC32C();
+      this.checksumSHA1 = result.checksumSHA1();
+      this.checksumSHA256 = result.checksumSHA256();
     }
   }
 
@@ -65,10 +65,10 @@ public class ObjectWriteResponse extends GenericResponse {
     this.etag = etag;
     this.versionId = versionId;
     if (result != null) {
-      this.checksumCRC32 = result.checksumCRC32(),
-      this.checksumCRC32C = result.checksumCRC32C(),
-      this.checksumSHA1 = result.checksumSHA1(),
-      this.checksumSHA256 = result.checksumSHA256()
+      this.checksumCRC32 = result.checksumCRC32();
+      this.checksumCRC32C = result.checksumCRC32C();
+      this.checksumSHA1 = result.checksumSHA1();
+      this.checksumSHA256 = result.checksumSHA256();
     }
   }
 

--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -2016,10 +2016,7 @@ public abstract class S3Base implements AutoCloseable {
                         result.object(),
                         result.etag(),
                         response.header("x-amz-version-id"),
-                        result.checksumCRC32(),
-                        result.checksumCRC32C(),
-                        result.checksumSHA1(),
-                        result.checksumSHA256());
+                        result);
                   } catch (XmlParserException e) {
                     // As this CompleteMultipartUpload REST call succeeded, just log it.
                     Logger.getLogger(S3Base.class.getName())
@@ -3016,11 +3013,7 @@ public abstract class S3Base implements AutoCloseable {
                     region,
                     objectName,
                     response.header("ETag").replaceAll("\"", ""),
-                    response.header("x-amz-version-id"),
-                    response.header("x-amz-checksum-crc32"),
-                    response.header("x-amz-checksum-crc32c"),
-                    response.header("x-amz-checksum-sha1"),
-                    response.header("x-amz-checksum-sha256"));
+                    response.header("x-amz-version-id"));
               } finally {
                 response.close();
               }
@@ -3101,11 +3094,7 @@ public abstract class S3Base implements AutoCloseable {
                     region,
                     objectName,
                     response.header("ETag").replaceAll("\"", ""),
-                    response.header("x-amz-version-id"),
-                    response.header("x-amz-checksum-crc32"),
-                    response.header("x-amz-checksum-crc32c"),
-                    response.header("x-amz-checksum-sha1"),
-                    response.header("x-amz-checksum-sha256"));
+                    response.header("x-amz-version-id"));
               } finally {
                 response.close();
               }

--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -2015,7 +2015,11 @@ public abstract class S3Base implements AutoCloseable {
                         result.location(),
                         result.object(),
                         result.etag(),
-                        response.header("x-amz-version-id"));
+                        response.header("x-amz-version-id"),
+                        result.checksumCRC32(),
+                        result.checksumCRC32C(),
+                        result.checksumSHA1(),
+                        result.checksumSHA256());
                   } catch (XmlParserException e) {
                     // As this CompleteMultipartUpload REST call succeeded, just log it.
                     Logger.getLogger(S3Base.class.getName())
@@ -3012,7 +3016,11 @@ public abstract class S3Base implements AutoCloseable {
                     region,
                     objectName,
                     response.header("ETag").replaceAll("\"", ""),
-                    response.header("x-amz-version-id"));
+                    response.header("x-amz-version-id"),
+                    response.header("x-amz-checksum-crc32"),
+                    response.header("x-amz-checksum-crc32c"),
+                    response.header("x-amz-checksum-sha1"),
+                    response.header("x-amz-checksum-sha256"));
               } finally {
                 response.close();
               }
@@ -3093,7 +3101,11 @@ public abstract class S3Base implements AutoCloseable {
                     region,
                     objectName,
                     response.header("ETag").replaceAll("\"", ""),
-                    response.header("x-amz-version-id"));
+                    response.header("x-amz-version-id"),
+                    response.header("x-amz-checksum-crc32"),
+                    response.header("x-amz-checksum-crc32c"),
+                    response.header("x-amz-checksum-sha1"),
+                    response.header("x-amz-checksum-sha256"));
               } finally {
                 response.close();
               }

--- a/api/src/main/java/io/minio/messages/CopyObjectResult.java
+++ b/api/src/main/java/io/minio/messages/CopyObjectResult.java
@@ -35,6 +35,18 @@ public class CopyObjectResult {
   @Element(name = "LastModified")
   private ResponseDate lastModified;
 
+  @Element(name = "ChecksumCRC32", required = false)
+  private String checksumCRC32;
+
+  @Element(name = "ChecksumCRC32C", required = false)
+  private String checksumCRC32C;
+
+  @Element(name = "ChecksumSHA1", required = false)
+  private String checksumSHA1;
+
+  @Element(name = "ChecksumSHA256", required = false)
+  private String checksumSHA256;
+
   public CopyObjectResult() {}
 
   /** Returns ETag of the object. */
@@ -45,5 +57,21 @@ public class CopyObjectResult {
   /** Returns last modified time. */
   public ZonedDateTime lastModified() {
     return lastModified.zonedDateTime();
+  }
+
+  public String checksumCRC32() {
+    return checksumCRC32;
+  }
+
+  public String checksumCRC32C() {
+    return checksumCRC32C;
+  }
+
+  public String checksumSHA1() {
+    return checksumSHA1;
+  }
+
+  public String checksumSHA256() {
+    return checksumSHA256;
   }
 }


### PR DESCRIPTION
Currently `PutObject`, `CopyObject`, `CompleteMultipartUpload` could return checksums, but client api for `CopyObjectResult` and `ObjectWriteResponse` does not return it. This commit adds checksums to `CopyObjectResult` and `ObjectWriteResponse` to allow users to get checksums if any.
Close https://github.com/minio/minio-java/issues/1608

References:
<https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_ResponseSyntax>
<https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_ResponseSyntax>
<https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax>