### PR TITLE
feat: upgrade okhttp 5.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     dependencies {
         api 'com.carrotsearch.thirdparty:simple-xml-safe:2.7.1'
         api 'com.google.guava:guava:33.4.0-jre'
-        api 'com.squareup.okhttp3:okhttp:4.12.0'
+        api 'com.squareup.okhttp3:okhttp:5.1.0'
         api 'com.fasterxml.jackson.core:jackson-annotations:2.18.2'
         api 'com.fasterxml.jackson.core:jackson-core:2.18.2'
         api 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
@@ -58,7 +58,7 @@ subprojects {
         api 'org.xerial.snappy:snappy-java:1.1.10.7'
         compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.6'
 
-        testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+        testImplementation 'com.squareup.okhttp3:mockwebserver:5.1.0'
         testImplementation 'junit:junit:4.13.2'
     }
 
@@ -476,7 +476,7 @@ jreleaser {
         //         }
         //     }
         // }
-	// 
+	//
         // maven {
         //     mavenCentral {
         //         sonatype {


### PR DESCRIPTION
Okhttp has released [5.1.0](https://square.github.io/okhttp/changelogs/changelog/) I think minio should be upgraded to 5.x at the same time