### PR TITLE
Improve ResponseDate parsing

### DIFF
--- a/api/src/main/java/io/minio/messages/ResponseDate.java
+++ b/api/src/main/java/io/minio/messages/ResponseDate.java
@@ -19,9 +19,6 @@ package io.minio.messages;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.minio.Time;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Locale;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.convert.Convert;
 import org.simpleframework.xml.convert.Converter;
@@ -32,9 +29,6 @@ import org.simpleframework.xml.stream.OutputNode;
 @Root
 @Convert(ResponseDate.ResponseDateConverter.class)
 public class ResponseDate {
-  public static final DateTimeFormatter MINIO_RESPONSE_DATE_FORMAT =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH':'mm':'ss'Z'", Locale.US).withZone(Time.UTC);
-
   private ZonedDateTime zonedDateTime;
 
   public ResponseDate() {}
@@ -53,11 +47,7 @@ public class ResponseDate {
 
   @JsonCreator
   public static ResponseDate fromString(String responseDateString) {
-    try {
-      return new ResponseDate(ZonedDateTime.parse(responseDateString, Time.RESPONSE_DATE_FORMAT));
-    } catch (DateTimeParseException e) {
-      return new ResponseDate(ZonedDateTime.parse(responseDateString, MINIO_RESPONSE_DATE_FORMAT));
-    }
+    return new ResponseDate(ZonedDateTime.parse(responseDateString));
   }
 
   /** XML converter class. */


### PR DESCRIPTION
### Summary
Enable parsing of additional date formats (including nanosecond precision) in CopyObjectResult.
This makes the **minio-java** client compatible with **SeaweedFS** responses.

### Problem
Currently, [ResponseDate](https://github.com/minio/minio-java/blob/master/api/src/main/java/io/minio/messages/ResponseDate.java) parses only two formats:

```
"yyyy-MM-dd'T'HH':'mm':'ss'.'SSS'Z'" 
"yyyy-MM-dd'T'HH':'mm':'ss'Z'"
```

If the date contains nanoseconds, parsing fails with a DateTimeParseException:

```
io.minio.errors.XmlParserException: java.time.format.DateTimeParseException: Text '2025-08-23T12:22:54.239913137Z' could not be parsed at index 19
	at io.minio.Xml.unmarshal(Xml.java:55)
```

### Example
#### SeaweedFS response (nanoseconds):

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<CopyObjectResult>
    <LastModified>2025-08-23T11:26:27.109253154Z</LastModified>
    <ETag>03da054f179eed855c27d7d6b2041e2a</ETag>
</CopyObjectResult>
```

#### MinIO response (milliseconds):

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <LastModified>2025-08-23T11:27:44.684Z</LastModified>
    <ETag>"03da054f179eed855c27d7d6b2041e2a"</ETag>
</CopyObjectResult>
```

Both are valid according to the [S3 API spec](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#shape-copyobjectresult) (LastModified is any string DateTime parsable by strtotime).

### Solution
Use ZonedDateTime.parse without a custom formatter.
It falls back to ISO_ZONED_DATE_TIME and supports all previously accepted formats as well as those with nanoseconds.
Additionally, it simplifies the code.

### Compatibility
No breaking changes - existing formats continue to be parsed correctly.