### PR TITLE
Common overrideable method for creating a CompletableFuture

### DIFF
--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -461,8 +461,7 @@ public class MinioAsyncClient extends S3Base {
     checkArgs(args);
     args.validateSse(this.baseUrl);
 
-    return CompletableFuture.supplyAsync(
-            () -> args.source().offset() != null && args.source().length() != null)
+    return supplyAsync(() -> args.source().offset() != null && args.source().length() != null)
         .thenCompose(
             condition -> {
               if (condition) {
@@ -672,7 +671,7 @@ public class MinioAsyncClient extends S3Base {
               }
 
               CompletableFuture<ObjectWriteResponse> completableFuture =
-                  CompletableFuture.supplyAsync(
+                  supplyAsync(
                           () -> {
                             Multimap<String, String> headers = newMultimap(args.extraHeaders());
                             headers.putAll(args.genHeaders());
@@ -712,7 +711,7 @@ public class MinioAsyncClient extends S3Base {
 
                             int partNumber = 0;
                             CompletableFuture<Part[]> future =
-                                CompletableFuture.supplyAsync(
+                                supplyAsync(
                                     () -> {
                                       return new Part[partCount[0]];
                                     });
@@ -3430,7 +3429,7 @@ public class MinioAsyncClient extends S3Base {
           NoSuchAlgorithmException, XmlParserException {
     checkArgs(args);
 
-    return CompletableFuture.supplyAsync(
+    return supplyAsync(
             () -> {
               FileOutputStream fos = null;
               BufferedOutputStream bos = null;
@@ -3580,7 +3579,7 @@ public class MinioAsyncClient extends S3Base {
     checkArgs(args);
     args.validateSse(this.baseUrl);
 
-    return CompletableFuture.supplyAsync(
+    return supplyAsync(
             () -> {
               // Build POST object data
               String objectName =

--- a/api/src/main/java/io/minio/S3Base.java
+++ b/api/src/main/java/io/minio/S3Base.java
@@ -88,6 +88,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -1204,7 +1205,7 @@ public abstract class S3Base implements AutoCloseable {
     long[] objectSize = {0};
     int index = 0;
 
-    CompletableFuture<Integer> completableFuture = CompletableFuture.supplyAsync(() -> 0);
+    CompletableFuture<Integer> completableFuture = supplyAsync(() -> 0);
     for (ComposeSource src : sources) {
       index++;
       final int i = index;
@@ -1280,6 +1281,10 @@ public abstract class S3Base implements AutoCloseable {
     }
 
     return completableFuture;
+  }
+
+  protected <T> CompletableFuture<T> supplyAsync(Supplier<T> supplier) {
+    return CompletableFuture.supplyAsync(supplier);
   }
 
   /** Calculate part count of given compose sources. */
@@ -2887,7 +2892,7 @@ public abstract class S3Base implements AutoCloseable {
       PartSource firstPartSource)
       throws InsufficientDataException, InternalException, InvalidKeyException, IOException,
           NoSuchAlgorithmException, XmlParserException {
-    return CompletableFuture.supplyAsync(
+    return supplyAsync(
         () -> {
           String uploadId = null;
           ObjectWriteResponse response = null;
@@ -2986,7 +2991,7 @@ public abstract class S3Base implements AutoCloseable {
     headers.putAll(args.genHeaders());
     if (!headers.containsKey("Content-Type")) headers.put("Content-Type", contentType);
 
-    return CompletableFuture.supplyAsync(
+    return supplyAsync(
             () -> {
               try {
                 return partReader.getPart();


### PR DESCRIPTION
Since it looks like #1543 is not going anywhere soon, i suggest a simple refactor, which will allow a reasonable client-side fix for this issue. 

The workaround suggested in https://github.com/minio/minio-java/pull/1543#issuecomment-2213133948 is to override the methods, which use the java.util.concurrent.CompletableFuture#supplyAsync() in a custom subclass of the MinioAsyncClient. As of now it's not possible, since some methods which call the CompletableFuture#supplyAsync() also use package-private classes such as io.minio.PartReader (io.minio.S3Base#putObjectAsync()) or io.minio.HttpRequestBody (io.minio.MinioAsyncClient#putObjectFanOut). 
Apart from this, java.util.concurrent.CompletableFuture#supplyAsync() is used by 7 methods, once of them private. In total they make ~800 lines of code. Frankly, it would be a real pain in the ass to maintain this amount of library code copy-pasted to the application for no good reason.

This PR extracts all of the java.util.concurrent.CompletableFuture#supplyAsync() calls into a separate protected method in io.minio.S3Base. With this change everyone interested in a different way of supplying their async :) will only need to override a single short method dedicated for that sole purpose. 

Please review it and let me know if you're ok with this change or if any additional changes are required