### PR TITLE
Allow creation of synchronous MinioClient using already created MinioAsyncClient

### DIFF
--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -100,7 +100,7 @@ import okhttp3.OkHttpClient;
 public class MinioClient implements AutoCloseable {
   private MinioAsyncClient asyncClient = null;
 
-  private MinioClient(MinioAsyncClient asyncClient) {
+  protected MinioClient(MinioAsyncClient asyncClient) {
     this.asyncClient = asyncClient;
   }
 


### PR DESCRIPTION
Changes introduced in (or around) #1665 make it quite easy and convenient to provide a different Executor for executing asynchronous code in MinioAsyncClient. 
Unfortunatelly it's not possible to do the same trick for MinioClient, as it's not possible to create a MinioClient providing external MinioAsyncClient (or it's subclass, which would provide a different Executor). 

The change in this pull request changes the visibility of the constructor in MinioClient to protected. It should allow creation of MinioClient with external MinioAsyncClient.