### PR TITLE
test: fix GetObjectAttributes to check multipart upload

### DIFF
--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -3223,8 +3223,8 @@ public class TestMinioClient extends TestArgs {
         long partSize = response.result().objectParts().parts().get(0).partSize();
         long[][] parts =
             (partNumber == 1)
-                ? new long[][] {{1, 6 * MB}, {2, 1 * MB}}
-                : new long[][] {{2, 1 * MB}, {1, 6 * MB}};
+                ? new long[][] {{1, 5 * MB}, {2, 1 * MB}}
+                : new long[][] {{2, 1 * MB}, {1, 5 * MB}};
         Assertions.assertTrue(
             partNumber == parts[0][0],
             "partEntry 0: partNumber: expected: " + parts[0][0] + ", got: " + partNumber);


### PR DESCRIPTION
test: GetObjectAttributes  wouldn't return parts when its putObject
CICD failed in https://github.com/miniohq/eos/pull/3330
That fix will return follow xml which is the same as AWS S3:
**No parts anymore**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<GetObjectAttributesResponse
    xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <ETag>0df68495b5ef53a8ce2a9d4076cc6252</ETag>
    <Checksum>
        <ChecksumCRC64NVME>Mt/sLbVfRxo=</ChecksumCRC64NVME>
        <ChecksumType>FULL_OBJECT</ChecksumType>
    </Checksum>
    <StorageClass>STANDARD</StorageClass>
    <ObjectSize>6291456</ObjectSize>
</GetObjectAttributesResponse>
```
