### PR TITLE
fix: skip functional tests on HTTP 405/501 responses

### DIFF
--- a/functional/TestArgs.java
+++ b/functional/TestArgs.java
@@ -323,7 +323,8 @@ public class TestArgs {
   public static void handleException(String methodName, String args, long startTime, Exception e)
       throws Exception {
     if (e instanceof ErrorResponseException) {
-      if (((ErrorResponseException) e).errorResponse().code().equals("NotImplemented")) {
+      int code = ((ErrorResponseException) e).response().code();
+      if (code == 405 || code == 501) {
         mintIgnoredLog(methodName, args, startTime);
         return;
       }

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -394,7 +394,8 @@ public class TestMinioClient extends TestArgs {
           MakeBucketArgs.builder().bucket(bucketNameWithLock).objectLock(true).build());
     } catch (Exception e) {
       if (e instanceof ErrorResponseException) {
-        if (((ErrorResponseException) e).errorResponse().code().equals("NotImplemented")) {
+        int code = ((ErrorResponseException) e).response().code();
+        if (code == 405 || code == 501) {
           bucketNameWithLock = null;
           return;
         }


### PR DESCRIPTION
Use HTTP status codes directly instead of checking error
code strings, so tests are properly skipped when APIs
return 405 (Method Not Allowed) or 501 (Not Implemented).