### PR TITLE
Handle multiple directories in SSL_CERT_DIR env variable

### DIFF
--- a/api/src/main/java/io/minio/Http.java
+++ b/api/src/main/java/io/minio/Http.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import io.minio.credentials.Credentials;
 import io.minio.errors.MinioException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
@@ -423,15 +424,15 @@ public class Http {
   }
 
   private static int setCertificateEntry(
-      CertificateFactory cf, KeyStore ks, Path file, String namePrefix)
+      CertificateFactory cf, KeyStore ks, Path certPath, String namePrefix)
       throws CertificateException, IOException, KeyStoreException {
-    try (InputStream in = Files.newInputStream(file)) {
-      int index = 0;
+    try (InputStream in = Files.newInputStream(certPath)) {
+      int certsInFile = 0;
       while (in.available() > 0) {
         X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
-        ks.setCertificateEntry(namePrefix + (index++), cert);
+        ks.setCertificateEntry(namePrefix + (certsInFile++), cert);
       }
-      return index;
+      return certsInFile;
     }
   }
 
@@ -444,28 +445,40 @@ public class Http {
     return buildTrustManagerFromKeyStore(ks);
   }
 
-  private static X509TrustManager getTrustManagerFromDir(String dirPath)
+  private static X509TrustManager getTrustManagerFromDirs(String dirPaths)
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-    CertificateFactory cf = CertificateFactory.getInstance("X.509");
-    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+    final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null);
 
-    int index = 0;
-    try (Stream<Path> paths = Files.walk(Paths.get(dirPath))) {
-      int number = 1;
-      for (Path file : (Iterable<Path>) paths.filter(Files::isRegularFile)::iterator) {
-        try {
-          index += setCertificateEntry(cf, ks, file, "cert-dir-file-" + number + "-");
-          number++;
-        } catch (CertificateException | IOException | KeyStoreException e) {
-          // Ignore these errors.
+    int totalCertificates = 0;
+    int fileNumber = 1;
+    for (Path directory : getDirectories(dirPaths)) {
+      try (Stream<Path> paths = Files.walk(directory)) {
+        for (Path certPath : (Iterable<Path>) paths.filter(Files::isRegularFile)::iterator) {
+          try {
+            totalCertificates +=
+                setCertificateEntry(cf, ks, certPath, "cert-dir-file-" + fileNumber + "-");
+          } catch (CertificateException | IOException | KeyStoreException e) {
+            // Ignore these errors.
+          }
+          fileNumber++;
         }
       }
     }
 
-    if (index == 0) return null;
+    if (totalCertificates == 0) return null;
 
     return buildTrustManagerFromKeyStore(ks);
+  }
+
+  private static List<Path> getDirectories(String dirPaths) {
+    return Stream.of(dirPaths.split(File.pathSeparator))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(Paths::get)
+        .filter(Files::isDirectory)
+        .collect(Collectors.toList());
   }
 
   private static X509TrustManager getDefaultTrustManager()
@@ -479,15 +492,15 @@ public class Http {
     return null;
   }
 
-  private static X509TrustManager getCompositeTrustManager(String filePath, String dirPath)
+  private static X509TrustManager getCompositeTrustManager(String filePath, String dirPaths)
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
     List<X509TrustManager> trustManagers = new ArrayList<>();
 
     X509TrustManager defaultTm = getDefaultTrustManager();
     if (defaultTm != null) trustManagers.add(defaultTm);
 
-    if (dirPath != null && !dirPath.isEmpty()) {
-      X509TrustManager dirTm = getTrustManagerFromDir(dirPath);
+    if (dirPaths != null && !dirPaths.isEmpty()) {
+      X509TrustManager dirTm = getTrustManagerFromDirs(dirPaths);
       if (dirTm != null) trustManagers.add(dirTm);
     }
 
@@ -579,11 +592,11 @@ public class Http {
         httpClient, trustStorePath, trustStorePassword, keyStorePath, keyStorePassword, "PKCS12");
   }
 
-  /** Enable external TLS certificates from given file path and all valid files from dir path. */
+  /** Enable external TLS certificates from given file path and all valid files from dir paths. */
   public static OkHttpClient enableExternalCertificates(
-      OkHttpClient client, String filePath, String dirPath) throws MinioException {
+      OkHttpClient client, String filePath, String dirPaths) throws MinioException {
     try {
-      X509TrustManager tm = getCompositeTrustManager(filePath, dirPath);
+      X509TrustManager tm = getCompositeTrustManager(filePath, dirPaths);
       if (tm == null) return client;
 
       SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/api/src/main/java/io/minio/Http.java
+++ b/api/src/main/java/io/minio/Http.java
@@ -451,9 +451,17 @@ public class Http {
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null);
 
+    List<Path> directories =
+        Stream.of(dirPath.split(File.pathSeparator))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .map(Paths::get)
+            .filter(Files::isDirectory)
+            .collect(Collectors.toList());
+
     int index = 0;
     int number = 1;
-    for (Path directory : getDirectories(dirPath)) {
+    for (Path directory : directories) {
       try (Stream<Path> paths = Files.walk(directory)) {
         for (Path file : (Iterable<Path>) paths.filter(Files::isRegularFile)::iterator) {
           try {
@@ -469,15 +477,6 @@ public class Http {
     if (index == 0) return null;
 
     return buildTrustManagerFromKeyStore(ks);
-  }
-
-  private static List<Path> getDirectories(String dirPath) {
-    return Stream.of(dirPath.split(File.pathSeparator))
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
-        .map(Paths::get)
-        .filter(Files::isDirectory)
-        .collect(Collectors.toList());
   }
 
   private static X509TrustManager getDefaultTrustManager()

--- a/api/src/main/java/io/minio/Http.java
+++ b/api/src/main/java/io/minio/Http.java
@@ -424,15 +424,15 @@ public class Http {
   }
 
   private static int setCertificateEntry(
-      CertificateFactory cf, KeyStore ks, Path certPath, String namePrefix)
+      CertificateFactory cf, KeyStore ks, Path file, String namePrefix)
       throws CertificateException, IOException, KeyStoreException {
-    try (InputStream in = Files.newInputStream(certPath)) {
-      int certsInFile = 0;
+    try (InputStream in = Files.newInputStream(file)) {
+      int index = 0;
       while (in.available() > 0) {
         X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
-        ks.setCertificateEntry(namePrefix + (certsInFile++), cert);
+        ks.setCertificateEntry(namePrefix + (index++), cert);
       }
-      return certsInFile;
+      return index;
     }
   }
 
@@ -445,35 +445,34 @@ public class Http {
     return buildTrustManagerFromKeyStore(ks);
   }
 
-  private static X509TrustManager getTrustManagerFromDirs(String dirPaths)
+  private static X509TrustManager getTrustManagerFromDir(String dirPath)
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-    final CertificateFactory cf = CertificateFactory.getInstance("X.509");
-    final KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null);
 
-    int totalCertificates = 0;
-    int fileNumber = 1;
-    for (Path directory : getDirectories(dirPaths)) {
+    int index = 0;
+    int number = 1;
+    for (Path directory : getDirectories(dirPath)) {
       try (Stream<Path> paths = Files.walk(directory)) {
-        for (Path certPath : (Iterable<Path>) paths.filter(Files::isRegularFile)::iterator) {
+        for (Path file : (Iterable<Path>) paths.filter(Files::isRegularFile)::iterator) {
           try {
-            totalCertificates +=
-                setCertificateEntry(cf, ks, certPath, "cert-dir-file-" + fileNumber + "-");
+            index += setCertificateEntry(cf, ks, file, "cert-dir-file-" + number + "-");
+            number++;
           } catch (CertificateException | IOException | KeyStoreException e) {
             // Ignore these errors.
           }
-          fileNumber++;
         }
       }
     }
 
-    if (totalCertificates == 0) return null;
+    if (index == 0) return null;
 
     return buildTrustManagerFromKeyStore(ks);
   }
 
-  private static List<Path> getDirectories(String dirPaths) {
-    return Stream.of(dirPaths.split(File.pathSeparator))
+  private static List<Path> getDirectories(String dirPath) {
+    return Stream.of(dirPath.split(File.pathSeparator))
         .map(String::trim)
         .filter(s -> !s.isEmpty())
         .map(Paths::get)
@@ -492,15 +491,15 @@ public class Http {
     return null;
   }
 
-  private static X509TrustManager getCompositeTrustManager(String filePath, String dirPaths)
+  private static X509TrustManager getCompositeTrustManager(String filePath, String dirPath)
       throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
     List<X509TrustManager> trustManagers = new ArrayList<>();
 
     X509TrustManager defaultTm = getDefaultTrustManager();
     if (defaultTm != null) trustManagers.add(defaultTm);
 
-    if (dirPaths != null && !dirPaths.isEmpty()) {
-      X509TrustManager dirTm = getTrustManagerFromDirs(dirPaths);
+    if (dirPath != null && !dirPath.isEmpty()) {
+      X509TrustManager dirTm = getTrustManagerFromDir(dirPath);
       if (dirTm != null) trustManagers.add(dirTm);
     }
 
@@ -592,11 +591,11 @@ public class Http {
         httpClient, trustStorePath, trustStorePassword, keyStorePath, keyStorePassword, "PKCS12");
   }
 
-  /** Enable external TLS certificates from given file path and all valid files from dir paths. */
+  /** Enable external TLS certificates from given file path and all valid files from dir path. */
   public static OkHttpClient enableExternalCertificates(
-      OkHttpClient client, String filePath, String dirPaths) throws MinioException {
+      OkHttpClient client, String filePath, String dirPath) throws MinioException {
     try {
-      X509TrustManager tm = getCompositeTrustManager(filePath, dirPaths);
+      X509TrustManager tm = getCompositeTrustManager(filePath, dirPath);
       if (tm == null) return client;
 
       SSLContext sslContext = SSLContext.getInstance("TLS");


### PR DESCRIPTION
### Description

Currently, the `SSL_CERT_DIR` environment variable is treated as a single directory path. However, this variable often contains multiple paths separated by the OS path separator. See the OpenSSL manual:

> If any directories are named on the command line, then those are processed in turn. If not, then the `SSL_CERT_DIR` environment variable is consulted; this should be a colon-separated list of directories, like the Unix` PATH` variable. If that is not set then the default directory (installation-specific but often `/usr/local/ssl/certs`) is processed.
Reference: https://docs.openssl.org/3.1/man1/openssl-rehash/#synopsis

This PR updates the certificate loading logic to support multiple directories, ensuring broader compatibility with enterprise and containerized environments.

### Changes Proposed

- Split paths safely: The `SSL_CERT_DIR` string is now split using the OS-specific path separator (`File.pathSeparator`).
- Process independently: Each directory is processed individually to load the certificates.

### Testing Done
- Verified that the code correctly parses multiple directories using OS-specific delimiters.
- Verified that the code still correctly processes single directory variable values.
- Verified that invalid or empty directory strings are gracefully ignored.
- Ran `./gradlew :api:spotlessApply`, `./gradlew build`, and `./gradlew runFunctionalTest` and confirmed everything still green.