### PR TITLE
fix: retry transient per-object delete failures in removeObjects() cleanup

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Test on java-version ${{ matrix.java-version }} and ${{ matrix.os }}
+    name: Test on Java ${{ matrix.java-version }} in ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Test on Java ${{ matrix.java-version }} in ${{ matrix.os }}
+    name: Test on java-version ${{ matrix.java-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -1250,6 +1250,10 @@ public class TestMinioClient extends TestArgs {
         RemoveObjectArgs.builder().bucket(bucketName).object(getRandomName()).build());
   }
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "DE_MIGHT_IGNORE",
+      justification =
+          "Cleanup exception suppressed intentionally so original test failure propagates")
   public void testRemoveObjects(String testTags, List<ObjectWriteResponse> results)
       throws Exception {
     String methodName = "removeObjects()";

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -1040,17 +1040,12 @@ public class TestMinioClient extends TestArgs {
   }
 
   public void removeObjects(String bucketName, List<ObjectWriteResponse> results) throws Exception {
-    // DeleteResult.Error has no versionId; keyed by name to rebuild versioned retry batches.
-    Map<String, List<ObjectWriteResponse>> byName = new HashMap<>();
-    for (ObjectWriteResponse res : results) {
-      byName.computeIfAbsent(res.object(), k -> new ArrayList<>()).add(res);
-    }
-    List<DeleteRequest.Object> toDelete =
+    List<DeleteRequest.Object> objects =
         results.stream()
             .map(r -> new DeleteRequest.Object(r.object(), r.versionId()))
             .collect(Collectors.toList());
-    Set<String> failedNames = Collections.emptySet();
-    for (int attempt = 0; attempt < MAX_DELETE_ATTEMPTS && !toDelete.isEmpty(); attempt++) {
+    boolean anyTransient = false;
+    for (int attempt = 0; attempt < MAX_DELETE_ATTEMPTS; attempt++) {
       if (attempt > 0) {
         try {
           Thread.sleep(500L << attempt); // 1s / 2s / 4s / 8s
@@ -1059,11 +1054,11 @@ public class TestMinioClient extends TestArgs {
           throw ie;
         }
       }
-      Set<String> retryNames = new HashSet<>();
+      anyTransient = false;
       IOException nonTransientErr = null;
-      for (int i = 0; i < toDelete.size(); i += DELETE_BATCH_SIZE) {
+      for (int i = 0; i < objects.size(); i += DELETE_BATCH_SIZE) {
         List<DeleteRequest.Object> chunk =
-            toDelete.subList(i, Math.min(i + DELETE_BATCH_SIZE, toDelete.size()));
+            objects.subList(i, Math.min(i + DELETE_BATCH_SIZE, objects.size()));
         for (Result<DeleteResult.Error> r :
             client.removeObjects(
                 RemoveObjectsArgs.builder().bucket(bucketName).objects(chunk).build())) {
@@ -1084,29 +1079,19 @@ public class TestMinioClient extends TestArgs {
             }
             continue; // drain current chunk's response before throwing
           }
-          retryNames.add(err.objectName());
+          anyTransient = true;
         }
         if (nonTransientErr != null) throw nonTransientErr;
       }
-      // All versions re-queued because DeleteResult.Error lacks versionId;
-      // already-deleted versions return NoSuchVersion, filtered upstream by MinioAsyncClient.
-      failedNames = retryNames;
-      toDelete = new ArrayList<>();
-      for (String name : retryNames) {
-        for (ObjectWriteResponse res : byName.getOrDefault(name, Collections.emptyList())) {
-          toDelete.add(new DeleteRequest.Object(res.object(), res.versionId()));
-        }
-      }
+      if (!anyTransient) break;
     }
-    if (!toDelete.isEmpty()) {
+    if (anyTransient) {
       throw new IOException(
-          toDelete.size()
+          results.size()
               + " object(s) not deleted after "
               + MAX_DELETE_ATTEMPTS
               + " attempts in bucket "
-              + bucketName
-              + "; sample: "
-              + failedNames.stream().limit(5).collect(Collectors.toList()));
+              + bucketName);
     }
   }
 

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -1262,7 +1262,13 @@ public class TestMinioClient extends TestArgs {
     } catch (Exception e) {
       handleException(methodName, testTags, startTime, e);
     } finally {
-      if (!succeeded) removeObjects(bucketName, results);
+      if (!succeeded) {
+        try {
+          removeObjects(bucketName, results);
+        } catch (Exception ignored) {
+          // suppress so the original test exception propagates unmasked
+        }
+      }
     }
   }
 

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -113,7 +113,6 @@ import io.minio.messages.Status;
 import io.minio.messages.Tags;
 import io.minio.messages.VersioningConfiguration;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -1058,7 +1057,7 @@ public class TestMinioClient extends TestArgs {
         DeleteResult.Error err = r.get();
         String code = err.code();
         if (!TRANSIENT_DELETE_CODES.contains(code)) {
-          throw new IOException(
+          throw new Exception(
               "non-transient delete error '"
                   + code
                   + "': "
@@ -1073,7 +1072,7 @@ public class TestMinioClient extends TestArgs {
       if (!anyTransient) break;
     }
     if (anyTransient) {
-      throw new IOException(
+      throw new Exception(
           results.size()
               + " object(s) not deleted after "
               + MAX_DELETE_ATTEMPTS
@@ -1222,29 +1221,15 @@ public class TestMinioClient extends TestArgs {
         RemoveObjectArgs.builder().bucket(bucketName).object(getRandomName()).build());
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "DE_MIGHT_IGNORE",
-      justification =
-          "Cleanup exception suppressed intentionally so original test failure propagates")
   public void testRemoveObjects(String testTags, List<ObjectWriteResponse> results)
       throws Exception {
     String methodName = "removeObjects()";
     long startTime = System.currentTimeMillis();
-    boolean succeeded = false;
     try {
       removeObjects(bucketName, results);
       mintSuccessLog(methodName, testTags, startTime);
-      succeeded = true;
     } catch (Exception e) {
       handleException(methodName, testTags, startTime, e);
-    } finally {
-      if (!succeeded) {
-        try {
-          removeObjects(bucketName, results);
-        } catch (Exception ignored) {
-          // suppress so the original test exception propagates unmasked
-        }
-      }
     }
   }
 

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -1079,12 +1079,12 @@ public class TestMinioClient extends TestArgs {
                           + " in bucket "
                           + bucketName);
             }
-            continue; // drain remaining response before throwing
+            continue; // drain current chunk's response before throwing
           }
           retryNames.add(err.objectName());
         }
+        if (nonTransientErr != null) throw nonTransientErr;
       }
-      if (nonTransientErr != null) throw nonTransientErr;
       // All versions re-queued because DeleteResult.Error lacks versionId;
       // already-deleted versions return NoSuchVersion, filtered upstream by MinioAsyncClient.
       toDelete = new ArrayList<>();

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -141,6 +141,9 @@ import org.junit.jupiter.api.Assertions;
     value = {"THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "REC_CATCH_EXCEPTION"})
 public class TestMinioClient extends TestArgs {
   private static final int MAX_DELETE_RETRIES = 5;
+  // Matches the SDK's internal chunk size: MinioAsyncClient sets completed=true on the
+  // first chunk that returns errors, dropping remaining chunks in the same call.
+  private static final int DELETE_BATCH_SIZE = 1000;
   private static final Set<String> TRANSIENT_DELETE_CODES =
       Collections.unmodifiableSet(
           new HashSet<>(
@@ -1057,25 +1060,29 @@ public class TestMinioClient extends TestArgs {
       }
       Set<String> retryNames = new HashSet<>();
       IOException nonTransientErr = null;
-      for (Result<DeleteResult.Error> r :
-          client.removeObjects(
-              RemoveObjectsArgs.builder().bucket(bucketName).objects(toDelete).build())) {
-        DeleteResult.Error err = r.get();
-        String code = err.code();
-        if (!TRANSIENT_DELETE_CODES.contains(code)) {
-          if (nonTransientErr == null) {
-            nonTransientErr =
-                new IOException(
-                    "non-transient delete error '"
-                        + code
-                        + "' on "
-                        + err.objectName()
-                        + " in bucket "
-                        + bucketName);
+      for (int i = 0; i < toDelete.size(); i += DELETE_BATCH_SIZE) {
+        List<DeleteRequest.Object> chunk =
+            toDelete.subList(i, Math.min(i + DELETE_BATCH_SIZE, toDelete.size()));
+        for (Result<DeleteResult.Error> r :
+            client.removeObjects(
+                RemoveObjectsArgs.builder().bucket(bucketName).objects(chunk).build())) {
+          DeleteResult.Error err = r.get();
+          String code = err.code();
+          if (!TRANSIENT_DELETE_CODES.contains(code)) {
+            if (nonTransientErr == null) {
+              nonTransientErr =
+                  new IOException(
+                      "non-transient delete error '"
+                          + code
+                          + "' on "
+                          + err.objectName()
+                          + " in bucket "
+                          + bucketName);
+            }
+            continue; // drain remaining response before throwing
           }
-          continue; // drain remaining response before throwing
+          retryNames.add(err.objectName());
         }
-        retryNames.add(err.objectName());
       }
       if (nonTransientErr != null) throw nonTransientErr;
       // All versions re-queued because DeleteResult.Error lacks versionId;

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -140,7 +140,7 @@ import org.junit.jupiter.api.Assertions;
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = {"THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "REC_CATCH_EXCEPTION"})
 public class TestMinioClient extends TestArgs {
-  private static final int MAX_DELETE_RETRIES = 5;
+  private static final int MAX_DELETE_ATTEMPTS = 5;
   // Matches the SDK's internal chunk size: MinioAsyncClient sets completed=true on the
   // first chunk that returns errors, dropping remaining chunks in the same call.
   private static final int DELETE_BATCH_SIZE = 1000;
@@ -1049,7 +1049,8 @@ public class TestMinioClient extends TestArgs {
         results.stream()
             .map(r -> new DeleteRequest.Object(r.object(), r.versionId()))
             .collect(Collectors.toList());
-    for (int attempt = 0; attempt < MAX_DELETE_RETRIES && !toDelete.isEmpty(); attempt++) {
+    Set<String> failedNames = Collections.emptySet();
+    for (int attempt = 0; attempt < MAX_DELETE_ATTEMPTS && !toDelete.isEmpty(); attempt++) {
       if (attempt > 0) {
         try {
           Thread.sleep(500L << attempt); // 1s / 2s / 4s / 8s
@@ -1074,7 +1075,9 @@ public class TestMinioClient extends TestArgs {
                   new IOException(
                       "non-transient delete error '"
                           + code
-                          + "' on "
+                          + "': "
+                          + err.message()
+                          + " on "
                           + err.objectName()
                           + " in bucket "
                           + bucketName);
@@ -1087,6 +1090,7 @@ public class TestMinioClient extends TestArgs {
       }
       // All versions re-queued because DeleteResult.Error lacks versionId;
       // already-deleted versions return NoSuchVersion, filtered upstream by MinioAsyncClient.
+      failedNames = retryNames;
       toDelete = new ArrayList<>();
       for (String name : retryNames) {
         for (ObjectWriteResponse res : byName.getOrDefault(name, Collections.emptyList())) {
@@ -1098,9 +1102,11 @@ public class TestMinioClient extends TestArgs {
       throw new IOException(
           toDelete.size()
               + " object(s) not deleted after "
-              + MAX_DELETE_RETRIES
+              + MAX_DELETE_ATTEMPTS
               + " attempts in bucket "
-              + bucketName);
+              + bucketName
+              + "; sample: "
+              + failedNames.stream().limit(5).collect(Collectors.toList()));
     }
   }
 

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -141,9 +141,6 @@ import org.junit.jupiter.api.Assertions;
     value = {"THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "REC_CATCH_EXCEPTION"})
 public class TestMinioClient extends TestArgs {
   private static final int MAX_DELETE_ATTEMPTS = 5;
-  // Matches the SDK's internal chunk size: MinioAsyncClient sets completed=true on the
-  // first chunk that returns errors, dropping remaining chunks in the same call.
-  private static final int DELETE_BATCH_SIZE = 1000;
   private static final Set<String> TRANSIENT_DELETE_CODES =
       Collections.unmodifiableSet(
           new HashSet<>(
@@ -1055,33 +1052,23 @@ public class TestMinioClient extends TestArgs {
         }
       }
       anyTransient = false;
-      IOException nonTransientErr = null;
-      for (int i = 0; i < objects.size(); i += DELETE_BATCH_SIZE) {
-        List<DeleteRequest.Object> chunk =
-            objects.subList(i, Math.min(i + DELETE_BATCH_SIZE, objects.size()));
-        for (Result<DeleteResult.Error> r :
-            client.removeObjects(
-                RemoveObjectsArgs.builder().bucket(bucketName).objects(chunk).build())) {
-          DeleteResult.Error err = r.get();
-          String code = err.code();
-          if (!TRANSIENT_DELETE_CODES.contains(code)) {
-            if (nonTransientErr == null) {
-              nonTransientErr =
-                  new IOException(
-                      "non-transient delete error '"
-                          + code
-                          + "': "
-                          + err.message()
-                          + " on "
-                          + err.objectName()
-                          + " in bucket "
-                          + bucketName);
-            }
-            continue; // drain current chunk's response before throwing
-          }
-          anyTransient = true;
+      for (Result<DeleteResult.Error> r :
+          client.removeObjects(
+              RemoveObjectsArgs.builder().bucket(bucketName).objects(objects).build())) {
+        DeleteResult.Error err = r.get();
+        String code = err.code();
+        if (!TRANSIENT_DELETE_CODES.contains(code)) {
+          throw new IOException(
+              "non-transient delete error '"
+                  + code
+                  + "': "
+                  + err.message()
+                  + " on "
+                  + err.objectName()
+                  + " in bucket "
+                  + bucketName);
         }
-        if (nonTransientErr != null) throw nonTransientErr;
+        anyTransient = true;
       }
       if (!anyTransient) break;
     }

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -113,6 +113,7 @@ import io.minio.messages.Status;
 import io.minio.messages.Tags;
 import io.minio.messages.VersioningConfiguration;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -140,11 +141,10 @@ import org.junit.jupiter.api.Assertions;
     value = {"THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "REC_CATCH_EXCEPTION"})
 public class TestMinioClient extends TestArgs {
   private static final int MAX_DELETE_RETRIES = 5;
-  private static final Set<String> IGNORABLE_DELETE_CODES =
-      new HashSet<>(Arrays.asList("NoSuchKey", "NoSuchVersion"));
   private static final Set<String> TRANSIENT_DELETE_CODES =
-      new HashSet<>(
-          Arrays.asList("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown"));
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown")));
 
   private String bucketName = getRandomName();
   private String bucketNameWithLock = getRandomName();
@@ -1036,44 +1036,64 @@ public class TestMinioClient extends TestArgs {
     return results;
   }
 
-  private void retryRemoveObject(String bucket, String object, String versionId) throws Exception {
-    for (int attempt = 0; attempt < MAX_DELETE_RETRIES; attempt++) {
-      if (attempt > 0) Thread.sleep(500L << attempt);
-      try {
-        RemoveObjectArgs.Builder b = RemoveObjectArgs.builder().bucket(bucket).object(object);
-        if (versionId != null) b.versionId(versionId);
-        client.removeObject(b.build());
-        return;
-      } catch (ErrorResponseException e) {
-        String code = e.errorResponse().code();
-        if (IGNORABLE_DELETE_CODES.contains(code)) return;
-        if (attempt == MAX_DELETE_RETRIES - 1 || !TRANSIENT_DELETE_CODES.contains(code)) throw e;
-      }
-    }
-  }
-
   public void removeObjects(String bucketName, List<ObjectWriteResponse> results) throws Exception {
-    // DeleteResult.Error only exposes objectName(); index all responses for retry lookup.
+    // DeleteResult.Error has no versionId; keyed by name to rebuild versioned retry batches.
     Map<String, List<ObjectWriteResponse>> byName = new HashMap<>();
     for (ObjectWriteResponse res : results) {
       byName.computeIfAbsent(res.object(), k -> new ArrayList<>()).add(res);
     }
-    List<DeleteRequest.Object> objects =
+    List<DeleteRequest.Object> toDelete =
         results.stream()
-            .map(result -> new DeleteRequest.Object(result.object(), result.versionId()))
+            .map(r -> new DeleteRequest.Object(r.object(), r.versionId()))
             .collect(Collectors.toList());
-    // Fully consume the iterator before retrying so all batches are sent first.
-    List<DeleteResult.Error> deleteErrors = new ArrayList<>();
-    for (Result<?> r :
-        client.removeObjects(
-            RemoveObjectsArgs.builder().bucket(bucketName).objects(objects).build())) {
-      DeleteResult.Error err = (DeleteResult.Error) r.get();
-      if (err != null) deleteErrors.add(err);
-    }
-    for (DeleteResult.Error err : deleteErrors) {
-      for (ObjectWriteResponse res : byName.getOrDefault(err.objectName(), new ArrayList<>())) {
-        retryRemoveObject(bucketName, res.object(), res.versionId());
+    for (int attempt = 0; attempt < MAX_DELETE_RETRIES && !toDelete.isEmpty(); attempt++) {
+      if (attempt > 0) {
+        try {
+          Thread.sleep(500L << attempt); // 1s / 2s / 4s / 8s
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw ie;
+        }
       }
+      Set<String> retryNames = new HashSet<>();
+      IOException nonTransientErr = null;
+      for (Result<DeleteResult.Error> r :
+          client.removeObjects(
+              RemoveObjectsArgs.builder().bucket(bucketName).objects(toDelete).build())) {
+        DeleteResult.Error err = r.get();
+        String code = err.code();
+        if (!TRANSIENT_DELETE_CODES.contains(code)) {
+          if (nonTransientErr == null) {
+            nonTransientErr =
+                new IOException(
+                    "non-transient delete error '"
+                        + code
+                        + "' on "
+                        + err.objectName()
+                        + " in bucket "
+                        + bucketName);
+          }
+          continue; // drain remaining response before throwing
+        }
+        retryNames.add(err.objectName());
+      }
+      if (nonTransientErr != null) throw nonTransientErr;
+      // All versions re-queued because DeleteResult.Error lacks versionId;
+      // already-deleted versions return NoSuchVersion, filtered upstream by MinioAsyncClient.
+      toDelete = new ArrayList<>();
+      for (String name : retryNames) {
+        for (ObjectWriteResponse res : byName.getOrDefault(name, Collections.emptyList())) {
+          toDelete.add(new DeleteRequest.Object(res.object(), res.versionId()));
+        }
+      }
+    }
+    if (!toDelete.isEmpty()) {
+      throw new IOException(
+          toDelete.size()
+              + " object(s) not deleted after "
+              + MAX_DELETE_RETRIES
+              + " attempts in bucket "
+              + bucketName);
     }
   }
 
@@ -1221,13 +1241,15 @@ public class TestMinioClient extends TestArgs {
       throws Exception {
     String methodName = "removeObjects()";
     long startTime = System.currentTimeMillis();
+    boolean succeeded = false;
     try {
       removeObjects(bucketName, results);
       mintSuccessLog(methodName, testTags, startTime);
+      succeeded = true;
     } catch (Exception e) {
       handleException(methodName, testTags, startTime, e);
     } finally {
-      removeObjects(bucketName, results);
+      if (!succeeded) removeObjects(bucketName, results);
     }
   }
 

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -143,7 +143,8 @@ public class TestMinioClient extends TestArgs {
   private static final Set<String> IGNORABLE_DELETE_CODES =
       new HashSet<>(Arrays.asList("NoSuchKey", "NoSuchVersion"));
   private static final Set<String> TRANSIENT_DELETE_CODES =
-      new HashSet<>(Arrays.asList("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown"));
+      new HashSet<>(
+          Arrays.asList("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown"));
 
   private String bucketName = getRandomName();
   private String bucketNameWithLock = getRandomName();

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -92,6 +92,7 @@ import io.minio.messages.AccessControlList;
 import io.minio.messages.AccessControlPolicy;
 import io.minio.messages.CORSConfiguration;
 import io.minio.messages.DeleteRequest;
+import io.minio.messages.DeleteResult;
 import io.minio.messages.ErrorResponse;
 import io.minio.messages.EventType;
 import io.minio.messages.Filter;
@@ -121,8 +122,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import okhttp3.Headers;
@@ -136,6 +139,12 @@ import org.junit.jupiter.api.Assertions;
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
     value = {"THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION", "REC_CATCH_EXCEPTION"})
 public class TestMinioClient extends TestArgs {
+  private static final int MAX_DELETE_RETRIES = 5;
+  private static final Set<String> IGNORABLE_DELETE_CODES =
+      new HashSet<>(Arrays.asList("NoSuchKey", "NoSuchVersion"));
+  private static final Set<String> TRANSIENT_DELETE_CODES =
+      new HashSet<>(Arrays.asList("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown"));
+
   private String bucketName = getRandomName();
   private String bucketNameWithLock = getRandomName();
   public boolean isQuickTest;
@@ -1026,18 +1035,44 @@ public class TestMinioClient extends TestArgs {
     return results;
   }
 
+  private void retryRemoveObject(String bucket, String object, String versionId) throws Exception {
+    for (int attempt = 0; attempt < MAX_DELETE_RETRIES; attempt++) {
+      if (attempt > 0) Thread.sleep(500L << attempt);
+      try {
+        RemoveObjectArgs.Builder b = RemoveObjectArgs.builder().bucket(bucket).object(object);
+        if (versionId != null) b.versionId(versionId);
+        client.removeObject(b.build());
+        return;
+      } catch (ErrorResponseException e) {
+        String code = e.errorResponse().code();
+        if (IGNORABLE_DELETE_CODES.contains(code)) return;
+        if (attempt == MAX_DELETE_RETRIES - 1 || !TRANSIENT_DELETE_CODES.contains(code)) throw e;
+      }
+    }
+  }
+
   public void removeObjects(String bucketName, List<ObjectWriteResponse> results) throws Exception {
+    // DeleteResult.Error only exposes objectName(); index all responses for retry lookup.
+    Map<String, List<ObjectWriteResponse>> byName = new HashMap<>();
+    for (ObjectWriteResponse res : results) {
+      byName.computeIfAbsent(res.object(), k -> new ArrayList<>()).add(res);
+    }
     List<DeleteRequest.Object> objects =
         results.stream()
-            .map(
-                result -> {
-                  return new DeleteRequest.Object(result.object(), result.versionId());
-                })
+            .map(result -> new DeleteRequest.Object(result.object(), result.versionId()))
             .collect(Collectors.toList());
+    // Fully consume the iterator before retrying so all batches are sent first.
+    List<DeleteResult.Error> deleteErrors = new ArrayList<>();
     for (Result<?> r :
         client.removeObjects(
             RemoveObjectsArgs.builder().bucket(bucketName).objects(objects).build())) {
-      ignore(r.get());
+      DeleteResult.Error err = (DeleteResult.Error) r.get();
+      if (err != null) deleteErrors.add(err);
+    }
+    for (DeleteResult.Error err : deleteErrors) {
+      for (ObjectWriteResponse res : byName.getOrDefault(err.objectName(), new ArrayList<>())) {
+        retryRemoveObject(bucketName, res.object(), res.versionId());
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
The `removeObjects()` cleanup helper in `TestMinioClient.java` **silently discarded all deletion errors** via `ignore(r.get())`. On transient server-side errors (e.g. `SlowDown`, `InternalError`) during a batch delete of 1050 objects, the failing objects remain in the bucket. The subsequent `removeBucket()` call then returns `409 BucketNotEmpty`, causing the test to log a false FAIL from the cleanup path — even when the test logic itself passed.

This failure was observed in 5 distinct CI runs across the week ending 2026-04-24, always in `testListObjects` with 1050 objects, always as the sole minio-java failure while 13 of 14 other mint suites passed. Tracked in miniohq/eos#4608.

**CI evidence (all show the same `BucketNotEmpty` on `listObjects()` / 1050 objects):**
- https://ns-3.min.dev/self-hosted-github-runner-logs-bucket/miniohq_eos/2026/04/21/24709147300/72269330732.log
- https://ns-3.min.dev/self-hosted-github-runner-logs-bucket/miniohq_eos/2026/04/18/24608558011/71959373972.log
- https://ns-3.min.dev/self-hosted-github-runner-logs-bucket/miniohq_eos/2026/04/20/24664997228/72122064001.log
- https://ns-3.min.dev/self-hosted-github-runner-logs-bucket/miniohq_eos/2026/04/21/24744053117/72392971599.log
- https://ns-3.min.dev/self-hosted-github-runner-logs-bucket/miniohq_eos/2026/04/20/24664870144/72119918649.log

Repeated error fragment across all logs:
```
"name":"minio-java","function":"listObjects()","args":"[bucket, prefix, recursive, 1050 objects]",
"status":"FAIL","error":"S3 operation failed; ErrorResponseException{errorResponse=
ErrorResponse{code='BucketNotEmpty', message='The bucket you tried to delete is not empty',
bucketName='minio-java-test-<random>'}}`
``

## Fix

`removeObjects()` now **detects deletion errors and retries transient ones**:

- **Read errors**: Process each `DeleteResult.Error` instead of ignoring via `ignore(r.get())`
- **Non-transient errors** (`!TRANSIENT_DELETE_CODES`): throw `IOException` immediately (preserves actual failures)
- **Transient errors** (`InternalError`, `RequestTimeout`, `ServiceUnavailable`, `SlowDown`): retry the full set up to `MAX_DELETE_ATTEMPTS` (5) times with exponential backoff (1s / 2s / 4s / 8s)
- **Success**: break early if no errors returned

The `testRemoveObjects` wrapper's `finally` block is guarded by a `succeeded` flag so the cleanup is only re-attempted on test failure, preventing spurious timeouts on success.