### PR TITLE
Add retry support for removeObjects()/completeMultipartUpload() APIs

### DIFF
--- a/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
+++ b/adminapi/src/main/java/io/minio/admin/MinioAdminClient.java
@@ -46,19 +46,20 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 /** Client to perform MinIO administration operations. */
 public class MinioAdminClient {
@@ -111,12 +112,12 @@ public class MinioAdminClient {
   }
 
   private String userAgent = Utils.getDefaultUserAgent();
-  private PrintWriter traceStream;
+  private volatile PrintWriter traceStream;
 
   private HttpUrl baseUrl;
   private String region;
   private Provider provider;
-  private OkHttpClient httpClient;
+  private volatile OkHttpClient httpClient;
 
   private MinioAdminClient(
       HttpUrl baseUrl, String region, Provider provider, OkHttpClient httpClient) {
@@ -130,6 +131,39 @@ public class MinioAdminClient {
     Credentials creds = provider.fetch();
     if (creds == null) throw new MinioException("Credential provider returns null credential");
     return creds;
+  }
+
+  private static int getStatusRetryInterceptorIndex(List<Interceptor> interceptors) {
+    return IntStream.range(0, interceptors.size())
+        .filter(i -> interceptors.get(i) instanceof Http.StatusRetryInterceptor)
+        .findFirst()
+        .orElse(-1);
+  }
+
+  private OkHttpClient getHttpClient(PrintWriter traceStream) {
+    if (traceStream == null) return this.httpClient;
+
+    OkHttpClient httpClient = this.httpClient;
+    List<Interceptor> interceptors = httpClient.interceptors();
+    int i = getStatusRetryInterceptorIndex(interceptors);
+    Http.StatusRetryInterceptor interceptor =
+        i < 0 ? null : (Http.StatusRetryInterceptor) interceptors.get(i);
+
+    OkHttpClient.Builder builder = httpClient.newBuilder();
+    if (interceptor == null) {
+      builder.addInterceptor(new Http.StatusRetryInterceptor(interceptor, traceStream, false));
+    } else {
+      builder.interceptors().clear();
+      for (int j = 0; j < interceptors.size(); j++) {
+        if (i == j) {
+          builder.addInterceptor(new Http.StatusRetryInterceptor(interceptor, traceStream, false));
+        } else {
+          builder.addInterceptor(interceptors.get(j));
+        }
+      }
+    }
+
+    return builder.build();
   }
 
   private Response httpExecute(
@@ -179,40 +213,8 @@ public class MinioAdminClient {
             creds.secretKey(),
             request.header("x-amz-content-sha256"));
 
-    PrintWriter traceStream = this.traceStream;
-    if (traceStream != null) {
-      StringBuilder traceBuilder = new StringBuilder();
-      traceBuilder.append("---------START-HTTP---------\n");
-      String encodedPath = request.url().encodedPath();
-      String encodedQuery = request.url().encodedQuery();
-      if (encodedQuery != null) encodedPath += "?" + encodedQuery;
-      traceBuilder.append(request.method()).append(" ").append(encodedPath).append(" HTTP/1.1\n");
-      traceBuilder.append(
-          request
-              .headers()
-              .toString()
-              .replaceAll("Signature=([0-9a-f]+)", "Signature=*REDACTED*")
-              .replaceAll("Credential=([^/]+)", "Credential=*REDACTED*"));
-      if (body != null) traceBuilder.append("\n").append(new String(body, StandardCharsets.UTF_8));
-      traceStream.println(traceBuilder.toString());
-    }
-
-    OkHttpClient httpClient = this.httpClient;
+    OkHttpClient httpClient = getHttpClient(this.traceStream);
     Response response = httpClient.newCall(request).execute();
-
-    if (traceStream != null) {
-      String trace =
-          response.protocol().toString().toUpperCase(Locale.US)
-              + " "
-              + response.code()
-              + "\n"
-              + response.headers();
-      traceStream.println(trace);
-      ResponseBody responseBody = response.peekBody(1024 * 1024);
-      traceStream.println(responseBody.string());
-      traceStream.println("----------END-HTTP----------");
-    }
-
     if (response.isSuccessful()) return response;
 
     throw new MinioException("Request failed with response: " + response.body().string());
@@ -924,6 +926,38 @@ public class MinioAdminClient {
    */
   public void traceOff() {
     this.traceStream = null;
+  }
+
+  /**
+   * Sets request retry parameters. Any null/invalid values disable retry.
+   *
+   * <pre>Example:{@code
+   * minioClient.setRetry(ImmutableSet.of(408, 504), 250, 3);
+   * }</pre>
+   *
+   * @param retryStatusCodes HTTP status codes to be retried.
+   * @param delayMs Delay between retries.
+   * @param maxRetries Maximum number of retry attempts.
+   */
+  public synchronized void setRetry(
+      Set<Integer> retryStatusCodes, Long delayMs, Integer maxRetries) {
+    Interceptor interceptor =
+        new Http.StatusRetryInterceptor(
+            retryStatusCodes, delayMs == null ? 0 : delayMs, maxRetries == null ? 0 : maxRetries);
+
+    List<Interceptor> interceptors = this.httpClient.interceptors();
+    int i = getStatusRetryInterceptorIndex(interceptors);
+    OkHttpClient.Builder builder = this.httpClient.newBuilder();
+    if (i >= 0) {
+      builder.interceptors().clear();
+      for (int j = 0; j < interceptors.size(); j++) {
+        builder.addInterceptor(i == j ? interceptor : interceptors.get(j));
+      }
+    } else {
+      builder.addInterceptor(interceptor);
+    }
+
+    this.httpClient = builder.build();
   }
 
   public static Builder builder() {

--- a/api/src/main/java/io/minio/BaseS3Client.java
+++ b/api/src/main/java/io/minio/BaseS3Client.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.collect.ImmutableSet;
 import io.minio.credentials.Credentials;
 import io.minio.credentials.Provider;
 import io.minio.errors.ErrorResponseException;
@@ -60,6 +61,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
@@ -84,6 +86,8 @@ public abstract class BaseS3Client implements AutoCloseable {
     }
   }
 
+  protected static final Set<String> RETRYABLE_ERRORS =
+      ImmutableSet.of("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown");
   protected static final String NO_SUCH_BUCKET_MESSAGE = "Bucket does not exist";
   protected static final String NO_SUCH_BUCKET = "NoSuchBucket";
   protected static final String NO_SUCH_BUCKET_POLICY = "NoSuchBucketPolicy";
@@ -675,24 +679,8 @@ public abstract class BaseS3Client implements AutoCloseable {
             });
   }
 
-  /**
-   * Do <a
-   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload
-   * S3 API</a> asynchronously.
-   *
-   * @param args {@link CompleteMultipartUploadArgs} object.
-   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
-   */
-  public CompletableFuture<ObjectWriteResponse> completeMultipartUpload(
-      CompleteMultipartUploadArgs args) {
-    checkArgs(args);
-    args.validateSsec(baseUrl.isHttps());
-    Http.Body body = null;
-    try {
-      body = new Http.Body(new CompleteMultipartUpload(args.parts()), null, null, null);
-    } catch (MinioException e) {
-      return Utils.failedFuture(e);
-    }
+  private CompletableFuture<ObjectWriteResponse> completeMultipartUpload(
+      CompleteMultipartUploadArgs args, Http.Body body) {
     return executePostAsync(
             args,
             args.ssec() == null ? null : args.ssec().headers(),
@@ -748,6 +736,59 @@ public abstract class BaseS3Client implements AutoCloseable {
                 response.close();
               }
             });
+  }
+
+  private CompletableFuture<ObjectWriteResponse> completeMultipartUpload(
+      CompleteMultipartUploadArgs args, Http.Body body, int attempt) {
+    return completeMultipartUpload(args, body)
+        .handle(
+            (response, ex) -> {
+              if (ex == null) return CompletableFuture.completedFuture(response);
+
+              ex = ex.getCause();
+              if (attempt == Math.max(1, args.maxRetries()) - 1
+                  || !(ex instanceof ErrorResponseException)
+                  || !RETRYABLE_ERRORS.contains(
+                      ((ErrorResponseException) ex).errorResponse().code())) {
+                return Utils.<ObjectWriteResponse>failedFuture(ex);
+              }
+
+              if (args.delayMs() > 0) {
+                long maxBackoffLimit = args.delayMs() * (1L << (attempt + 1));
+                long jitteredDelay = ThreadLocalRandom.current().nextLong(0, maxBackoffLimit);
+                try {
+                  Thread.sleep(jitteredDelay);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return Utils.<ObjectWriteResponse>failedFuture(
+                      new IllegalStateException("Retry timeout interrupted", e));
+                }
+              }
+
+              return completeMultipartUpload(args, body, attempt + 1);
+            })
+        .thenCompose(future -> future);
+  }
+
+  /**
+   * Do <a
+   * href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload
+   * S3 API</a> asynchronously.
+   *
+   * @param args {@link CompleteMultipartUploadArgs} object.
+   * @return {@link CompletableFuture}&lt;{@link ObjectWriteResponse}&gt; object.
+   */
+  public CompletableFuture<ObjectWriteResponse> completeMultipartUpload(
+      CompleteMultipartUploadArgs args) {
+    checkArgs(args);
+    args.validateSsec(baseUrl.isHttps());
+    Http.Body body = null;
+    try {
+      body = new Http.Body(new CompleteMultipartUpload(args.parts()), null, null, null);
+    } catch (MinioException e) {
+      return Utils.failedFuture(e);
+    }
+    return completeMultipartUpload(args, body, 0);
   }
 
   /**

--- a/api/src/main/java/io/minio/CompleteMultipartUploadArgs.java
+++ b/api/src/main/java/io/minio/CompleteMultipartUploadArgs.java
@@ -25,6 +25,8 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
   private String uploadId;
   private Part[] parts;
   private ServerSideEncryption.CustomerKey ssec;
+  private long delayMs = 100L;
+  private int maxRetries = 5;
 
   protected CompleteMultipartUploadArgs() {}
 
@@ -32,6 +34,8 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
     super(args);
     this.uploadId = uploadId;
     this.parts = parts;
+    this.delayMs = args.delayMs();
+    this.maxRetries = args.maxRetries();
   }
 
   public CompleteMultipartUploadArgs(PutObjectBaseArgs args, String uploadId, Part[] parts) {
@@ -41,6 +45,8 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
     if (args.sse() != null && args.sse() instanceof ServerSideEncryption.CustomerKey) {
       this.ssec = (ServerSideEncryption.CustomerKey) args.sse();
     }
+    this.delayMs = args.delayMs();
+    this.maxRetries = args.maxRetries();
   }
 
   public String uploadId() {
@@ -53,6 +59,14 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
 
   public ServerSideEncryption.CustomerKey ssec() {
     return ssec;
+  }
+
+  public long delayMs() {
+    return delayMs;
+  }
+
+  public int maxRetries() {
+    return maxRetries;
   }
 
   public void validateSsec(boolean isHttps) {
@@ -89,6 +103,18 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
       operations.add(args -> args.ssec = ssec);
       return this;
     }
+
+    /** Set delay between retries. Value &lt;= 0 makes no delay (default 100ms). */
+    public Builder delayMs(long delayMs) {
+      operations.add(args -> args.delayMs = delayMs);
+      return this;
+    }
+
+    /** Set maximum retry between failure. Value &lt;= 0 disables retry (default 5). */
+    public Builder maxRetries(int maxRetries) {
+      operations.add(args -> args.maxRetries = maxRetries);
+      return this;
+    }
   }
 
   @Override
@@ -99,11 +125,13 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
     CompleteMultipartUploadArgs that = (CompleteMultipartUploadArgs) o;
     return Objects.equals(uploadId, that.uploadId)
         && Arrays.equals(parts, that.parts)
-        && Objects.equals(ssec, that.ssec);
+        && Objects.equals(ssec, that.ssec)
+        && delayMs == that.delayMs
+        && maxRetries == that.maxRetries;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), uploadId, parts, ssec);
+    return Objects.hash(super.hashCode(), uploadId, parts, ssec, delayMs, maxRetries);
   }
 }

--- a/api/src/main/java/io/minio/ComposeObjectArgs.java
+++ b/api/src/main/java/io/minio/ComposeObjectArgs.java
@@ -26,11 +26,15 @@ import java.util.Objects;
  */
 public class ComposeObjectArgs extends ObjectWriteArgs {
   List<SourceObject> sources;
+  private long delayMs = 100L;
+  private int maxRetries = 5;
 
   protected ComposeObjectArgs() {}
 
   public ComposeObjectArgs(ComposeObjectArgs args, List<SourceObject> sources) {
     super(args);
+    this.delayMs = args.delayMs;
+    this.maxRetries = args.maxRetries;
     this.sources = sources;
   }
 
@@ -41,6 +45,14 @@ public class ComposeObjectArgs extends ObjectWriteArgs {
 
   public List<SourceObject> sources() {
     return sources;
+  }
+
+  public long delayMs() {
+    return delayMs;
+  }
+
+  public int maxRetries() {
+    return maxRetries;
   }
 
   public static Builder builder() {
@@ -74,6 +86,18 @@ public class ComposeObjectArgs extends ObjectWriteArgs {
       operations.add(args -> args.sources = sources);
       return this;
     }
+
+    /** Set delay between retries. Value &lt;= 0 makes no delay (default 100ms). */
+    public Builder delayMs(long delayMs) {
+      operations.add(args -> args.delayMs = delayMs);
+      return this;
+    }
+
+    /** Set maximum retry between failure. Value &lt;= 0 disables retry (default 5). */
+    public Builder maxRetries(int maxRetries) {
+      operations.add(args -> args.maxRetries = maxRetries);
+      return this;
+    }
   }
 
   @Override
@@ -82,11 +106,13 @@ public class ComposeObjectArgs extends ObjectWriteArgs {
     if (!(o instanceof ComposeObjectArgs)) return false;
     if (!super.equals(o)) return false;
     ComposeObjectArgs that = (ComposeObjectArgs) o;
-    return Objects.equals(sources, that.sources);
+    return Objects.equals(sources, that.sources)
+        && delayMs == that.delayMs
+        && maxRetries == that.maxRetries;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), sources);
+    return Objects.hash(super.hashCode(), sources, delayMs, maxRetries);
   }
 }

--- a/api/src/main/java/io/minio/Http.java
+++ b/api/src/main/java/io/minio/Http.java
@@ -774,6 +774,10 @@ public class Http {
       if (request.body() instanceof RequestBody) {
         RequestBody body = (RequestBody) request.body();
         bodyString = body.bodyString();
+      } else if ((method == Method.PUT || method == Method.POST)
+          && request.body() != null
+          && request.body().contentLength() != 0) {
+        bodyString = "<<<BYTES>>>";
       }
 
       for (int i = 0; i < maxRetries; i++) {

--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -93,6 +93,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -1050,6 +1051,8 @@ public class MinioAsyncClient extends BaseS3Client {
           private Iterator<DeleteResult.Error> errorIterator = null;
           private boolean completed = false;
           private Iterator<DeleteRequest.Object> objectIter = args.objects().iterator();
+          private long delayMs = args.delayMs();
+          private int maxRetries = Math.max(1, args.maxRetries());
 
           private void setError() {
             error = null;
@@ -1060,6 +1063,41 @@ public class MinioAsyncClient extends BaseS3Client {
                 break;
               }
             }
+          }
+
+          private DeleteObjectsResponse doDeleteObjects(List<DeleteRequest.Object> objectList)
+              throws MinioException {
+            for (int i = 0; i < maxRetries; i++) {
+              try {
+                DeleteObjectsResponse response =
+                    deleteObjects(
+                            DeleteObjectsArgs.builder()
+                                .extraHeaders(args.extraHeaders())
+                                .extraQueryParams(args.extraQueryParams())
+                                .bucket(args.bucket())
+                                .region(args.region())
+                                .objects(objectList)
+                                .quiet(true)
+                                .bypassGovernanceMode(args.bypassGovernanceMode())
+                                .build())
+                        .join();
+                boolean retryableError =
+                    response.result().errors().stream()
+                        .anyMatch(err -> RETRYABLE_ERRORS.contains(err.code()));
+                if (!retryableError || i == maxRetries - 1) return response;
+                if (delayMs <= 0) continue;
+                long maxBackoffLimit = delayMs * (1L << (i + 1));
+                long jitteredDelay = ThreadLocalRandom.current().nextLong(0, maxBackoffLimit);
+                Thread.sleep(jitteredDelay);
+              } catch (CompletionException e) {
+                throwMinioException(e);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Retry backoff interrupted", e);
+              }
+            }
+
+            return null; // This never happens.
           }
 
           private synchronized void populate() {
@@ -1075,23 +1113,7 @@ public class MinioAsyncClient extends BaseS3Client {
 
               completed = objectList.isEmpty();
               if (completed) return;
-              DeleteObjectsResponse response = null;
-              try {
-                response =
-                    deleteObjects(
-                            DeleteObjectsArgs.builder()
-                                .extraHeaders(args.extraHeaders())
-                                .extraQueryParams(args.extraQueryParams())
-                                .bucket(args.bucket())
-                                .region(args.region())
-                                .objects(objectList)
-                                .quiet(true)
-                                .bypassGovernanceMode(args.bypassGovernanceMode())
-                                .build())
-                        .join();
-              } catch (CompletionException e) {
-                throwMinioException(e);
-              }
+              DeleteObjectsResponse response = doDeleteObjects(objectList);
               if (!response.result().errors().isEmpty()) {
                 errorIterator = response.result().errors().iterator();
                 setError();

--- a/api/src/main/java/io/minio/PutObjectBaseArgs.java
+++ b/api/src/main/java/io/minio/PutObjectBaseArgs.java
@@ -28,6 +28,8 @@ public abstract class PutObjectBaseArgs extends ObjectWriteArgs {
   protected MediaType contentType;
   protected Checksum.Algorithm checksum;
   protected int parallelUploads;
+  protected long delayMs = 100L;
+  protected int maxRetries = 5;
 
   public Long objectSize() {
     return objectSize;
@@ -51,6 +53,14 @@ public abstract class PutObjectBaseArgs extends ObjectWriteArgs {
 
   public int parallelUploads() {
     return parallelUploads;
+  }
+
+  public long delayMs() {
+    return delayMs;
+  }
+
+  public int maxRetries() {
+    return maxRetries;
   }
 
   /** Builder of {@link PutObjectBaseArgs}. */
@@ -138,6 +148,18 @@ public abstract class PutObjectBaseArgs extends ObjectWriteArgs {
       operations.add(args -> args.parallelUploads = parallelUploads);
       return (B) this;
     }
+
+    /** Set delay between retries. Value &lt;= 0 disables retry (default 100ms). */
+    public B delayMs(long delayMs) {
+      operations.add(args -> args.delayMs = delayMs);
+      return (B) this;
+    }
+
+    /** Set maximum retry between failure. Value &lt;= 0 disables retry (default 5). */
+    public B maxRetries(int maxRetries) {
+      operations.add(args -> args.maxRetries = maxRetries);
+      return (B) this;
+    }
   }
 
   @Override
@@ -151,12 +173,22 @@ public abstract class PutObjectBaseArgs extends ObjectWriteArgs {
         && partCount == that.partCount
         && Objects.equals(contentType, that.contentType)
         && Objects.equals(checksum, that.checksum)
-        && parallelUploads == that.parallelUploads;
+        && parallelUploads == that.parallelUploads
+        && delayMs == that.delayMs
+        && maxRetries == that.maxRetries;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        super.hashCode(), objectSize, partSize, partCount, contentType, checksum, parallelUploads);
+        super.hashCode(),
+        objectSize,
+        partSize,
+        partCount,
+        contentType,
+        checksum,
+        parallelUploads,
+        delayMs,
+        maxRetries);
   }
 }

--- a/api/src/main/java/io/minio/RemoveObjectsArgs.java
+++ b/api/src/main/java/io/minio/RemoveObjectsArgs.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 public class RemoveObjectsArgs extends BucketArgs {
   private boolean bypassGovernanceMode;
   private Iterable<DeleteRequest.Object> objects = new ArrayList<>();
+  private long delayMs = 100L;
+  private int maxRetries = 5;
 
   public boolean bypassGovernanceMode() {
     return bypassGovernanceMode;
@@ -31,6 +33,14 @@ public class RemoveObjectsArgs extends BucketArgs {
 
   public Iterable<DeleteRequest.Object> objects() {
     return objects;
+  }
+
+  public long delayMs() {
+    return delayMs;
+  }
+
+  public int maxRetries() {
+    return maxRetries;
   }
 
   public static Builder builder() {
@@ -49,6 +59,18 @@ public class RemoveObjectsArgs extends BucketArgs {
       operations.add(args -> args.objects = objects);
       return this;
     }
+
+    /** Set delay between retries. Value &lt;= 0 makes no delay (default 100ms). */
+    public Builder delayMs(long delayMs) {
+      operations.add(args -> args.delayMs = delayMs);
+      return this;
+    }
+
+    /** Set maximum retry between failure. Value &lt;= 0 disables retry (default 5). */
+    public Builder maxRetries(int maxRetries) {
+      operations.add(args -> args.maxRetries = maxRetries);
+      return this;
+    }
   }
 
   @Override
@@ -58,11 +80,13 @@ public class RemoveObjectsArgs extends BucketArgs {
     if (!super.equals(o)) return false;
     RemoveObjectsArgs that = (RemoveObjectsArgs) o;
     return bypassGovernanceMode == that.bypassGovernanceMode
-        && Objects.equals(objects, that.objects);
+        && Objects.equals(objects, that.objects)
+        && delayMs == that.delayMs
+        && maxRetries == that.maxRetries;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), bypassGovernanceMode, objects);
+    return Objects.hash(super.hashCode(), bypassGovernanceMode, objects, delayMs, maxRetries);
   }
 }

--- a/functional/TestMinioClient.java
+++ b/functional/TestMinioClient.java
@@ -88,6 +88,7 @@ import io.minio.UploadObjectArgs;
 import io.minio.UploadSnowballObjectsArgs;
 import io.minio.Xml;
 import io.minio.errors.ErrorResponseException;
+import io.minio.errors.MinioException;
 import io.minio.messages.AccessControlList;
 import io.minio.messages.AccessControlPolicy;
 import io.minio.messages.CORSConfiguration;
@@ -1034,11 +1035,21 @@ public class TestMinioClient extends TestArgs {
                   return new DeleteRequest.Object(result.object(), result.versionId());
                 })
             .collect(Collectors.toList());
+    Exception ex = null;
     for (Result<?> r :
         client.removeObjects(
             RemoveObjectsArgs.builder().bucket(bucketName).objects(objects).build())) {
-      ignore(r.get());
+      try {
+        r.get();
+      } catch (MinioException e) {
+        if (ex == null) {
+          ex = e;
+        } else {
+          ex.addSuppressed(e);
+        }
+      }
     }
+    if (ex != null) throw ex;
   }
 
   public void testListObjects(String testTags, ListObjectsArgs args, int objCount, int versions)


### PR DESCRIPTION
As S3 error response of DeleteObjects and CompleteMultipartUpload S3 APIs is returned with HTTP status code 2xx, MinIO Client retries at high level by S3 error codes `InternalError`, `RequestTimeout`, `ServiceUnavailable` and `SlowDown`.