### PR TITLE
Update retryable errors and delay

### DIFF
--- a/api/src/main/java/io/minio/BaseS3Client.java
+++ b/api/src/main/java/io/minio/BaseS3Client.java
@@ -86,8 +86,21 @@ public abstract class BaseS3Client implements AutoCloseable {
     }
   }
 
+  // Update the list from https://github.com/minio/minio-go/blob/master/retry.go#L98
   protected static final Set<String> RETRYABLE_ERRORS =
-      ImmutableSet.of("InternalError", "RequestTimeout", "ServiceUnavailable", "SlowDown");
+      ImmutableSet.of(
+          "RequestError",
+          "RequestTimeout",
+          "Throttling",
+          "ThrottlingException",
+          "RequestLimitExceeded",
+          "RequestThrottled",
+          "InternalError",
+          "ExpiredToken",
+          "ExpiredTokenException",
+          "SlowDown",
+          "SlowDownWrite",
+          "SlowDownRead");
   protected static final String NO_SUCH_BUCKET_MESSAGE = "Bucket does not exist";
   protected static final String NO_SUCH_BUCKET = "NoSuchBucket";
   protected static final String NO_SUCH_BUCKET_POLICY = "NoSuchBucketPolicy";

--- a/api/src/main/java/io/minio/CompleteMultipartUploadArgs.java
+++ b/api/src/main/java/io/minio/CompleteMultipartUploadArgs.java
@@ -25,7 +25,7 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
   private String uploadId;
   private Part[] parts;
   private ServerSideEncryption.CustomerKey ssec;
-  private long delayMs = 100L;
+  private long delayMs = 200L;
   private int maxRetries = 5;
 
   protected CompleteMultipartUploadArgs() {}
@@ -104,7 +104,7 @@ public class CompleteMultipartUploadArgs extends ObjectArgs {
       return this;
     }
 
-    /** Set delay between retries. Value &lt;= 0 makes no delay (default 100ms). */
+    /** Set delay between retries. Value &lt;= 0 makes no delay (default 200ms). */
     public Builder delayMs(long delayMs) {
       operations.add(args -> args.delayMs = delayMs);
       return this;

--- a/api/src/main/java/io/minio/ComposeObjectArgs.java
+++ b/api/src/main/java/io/minio/ComposeObjectArgs.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public class ComposeObjectArgs extends ObjectWriteArgs {
   List<SourceObject> sources;
-  private long delayMs = 100L;
+  private long delayMs = 200L;
   private int maxRetries = 5;
 
   protected ComposeObjectArgs() {}
@@ -87,7 +87,7 @@ public class ComposeObjectArgs extends ObjectWriteArgs {
       return this;
     }
 
-    /** Set delay between retries. Value &lt;= 0 makes no delay (default 100ms). */
+    /** Set delay between retries. Value &lt;= 0 makes no delay (default 200ms). */
     public Builder delayMs(long delayMs) {
       operations.add(args -> args.delayMs = delayMs);
       return this;

--- a/api/src/main/java/io/minio/Http.java
+++ b/api/src/main/java/io/minio/Http.java
@@ -753,7 +753,7 @@ public class Http {
         StatusRetryInterceptor interceptor, PrintWriter traceWriter, boolean isBucketRequest) {
       this(
           interceptor != null ? interceptor.retryStatusCodes : RETRIABLE_STATUS_CODES,
-          interceptor != null ? interceptor.delayMs : 100,
+          interceptor != null ? interceptor.delayMs : 200,
           interceptor != null ? interceptor.maxRetries : 5,
           traceWriter,
           isBucketRequest);

--- a/api/src/main/java/io/minio/PutObjectBaseArgs.java
+++ b/api/src/main/java/io/minio/PutObjectBaseArgs.java
@@ -28,7 +28,7 @@ public abstract class PutObjectBaseArgs extends ObjectWriteArgs {
   protected MediaType contentType;
   protected Checksum.Algorithm checksum;
   protected int parallelUploads;
-  protected long delayMs = 100L;
+  protected long delayMs = 200L;
   protected int maxRetries = 5;
 
   public Long objectSize() {
@@ -149,7 +149,7 @@ public abstract class PutObjectBaseArgs extends ObjectWriteArgs {
       return (B) this;
     }
 
-    /** Set delay between retries. Value &lt;= 0 disables retry (default 100ms). */
+    /** Set delay between retries. Value &lt;= 0 disables retry (default 200ms). */
     public B delayMs(long delayMs) {
       operations.add(args -> args.delayMs = delayMs);
       return (B) this;

--- a/api/src/main/java/io/minio/RemoveObjectsArgs.java
+++ b/api/src/main/java/io/minio/RemoveObjectsArgs.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 public class RemoveObjectsArgs extends BucketArgs {
   private boolean bypassGovernanceMode;
   private Iterable<DeleteRequest.Object> objects = new ArrayList<>();
-  private long delayMs = 100L;
+  private long delayMs = 200L;
   private int maxRetries = 5;
 
   public boolean bypassGovernanceMode() {
@@ -60,7 +60,7 @@ public class RemoveObjectsArgs extends BucketArgs {
       return this;
     }
 
-    /** Set delay between retries. Value &lt;= 0 makes no delay (default 100ms). */
+    /** Set delay between retries. Value &lt;= 0 makes no delay (default 200ms). */
     public Builder delayMs(long delayMs) {
       operations.add(args -> args.delayMs = delayMs);
       return this;


### PR DESCRIPTION
The values are synced with `minio-go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded retryable S3 error conditions to include throttling and request-related errors, improving resilience during transient service disruptions.
  * Increased default retry delay from 100ms to 200ms across multipart operations for better handling of rate-limited requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->