### PR TITLE
Do not set completed if NoSuchVersion in removeObjects

### DIFF
--- a/api/src/main/java/io/minio/MinioAsyncClient.java
+++ b/api/src/main/java/io/minio/MinioAsyncClient.java
@@ -1117,7 +1117,7 @@ public class MinioAsyncClient extends BaseS3Client {
               if (!response.result().errors().isEmpty()) {
                 errorIterator = response.result().errors().iterator();
                 setError();
-                completed = true;
+                completed = error != null;
               }
             } catch (MinioException e) {
               error = new Result<>(e);


### PR DESCRIPTION
Previously if batch object removal gets `NoSuchVersion` error only, the iterator stops processing next batches. This is fixed by continue processing next batches for `NoSuchVersion` but stops for other errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object deletion to continue processing when delete responses only include ignored errors, preventing the operation from stopping too early.
  * Improved handling of partial delete failures so valid deletions can proceed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->